### PR TITLE
fix: mock requests for bad url test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ autopep8 = "^2.0.1"
 flake8 = "^6.0.0"
 pytest = "^7.3.1"
 coverage = "^7.2.2"
+pytest-mock = "^3.11.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,12 +1,10 @@
 # here we are going to create all needed tests for the parser.py parse function
 import os
-from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 import requests
-import yaml
 
 from keep.alertmanager.alertstore import AlertStore
 from keep.parser.parser import Parser
@@ -21,7 +19,12 @@ def test_parse_with_nonexistent_file():
         alert = alert_store.get_alerts("non-existing-file")
 
 
-def test_parse_with_nonexistent_url():
+def test_parse_with_nonexistent_url(monkeypatch):
+    # Mocking requests.get to always raise a ConnectionError
+    def mock_get(*args, **kwargs):
+        raise requests.exceptions.ConnectionError
+
+    monkeypatch.setattr(requests, "get", mock_get)
     alert_store = AlertStore()
     # Expected error when a given input does not describe an existing URL
     with pytest.raises(requests.exceptions.ConnectionError):


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #231  <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
This addresses the issue I raised in https://github.com/keephq/keep/issues/231.  I ran the tests and noticed the took a long time to run. I was able to isolate the long test run to a single test: test_parse_with_nonexistent_url @ 130s (ouch!)

The root cause of this test is due to `requests` attempting to make a request over the Internet to a url that doesn't exist. We don't need to test that `requests` tries to make the request and then throws the long awaited error. Or that the Internet isn't going to resolve a bad url. Let's focus on testing how this function handles `requests`'s thrown error.

I solved this by mocking the requests.get() call with an immediate raise of the error.  As the below shows, this drastically speeds up this test. You can now run all the unit tests in a little over half a second (from 2+ minutes). Even in CI!

*also: I did a bit of cleanup with some unused imports

```
    ~/repos/keep    isaac-fast-unit-nonexist-url *1 ?1  pytest --durations=0 tests/                                                                                 4 ✘  3.11.1  
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.11.1, pytest-7.4.0, pluggy-1.2.0
rootdir: /home/isaac/repos/keep
plugins: anyio-3.7.1, mock-3.11.1
collected 57 items                                                                                                                                                                         

tests/test_conditions.py ...........                                                                                                                                                 [ 19%]
tests/test_contextmanager.py .............                                                                                                                                           [ 42%]
tests/test_functions.py ........................                                                                                                                                     [ 84%]
tests/test_iohandler.py ....                                                                                                                                                         [ 91%]
tests/test_parser.py ....x                                                                                                                                                           [100%]

==================================================================================== slowest durations =====================================================================================
0.02s call     tests/test_parser.py::test_parse_all_alerts
0.01s call     tests/test_parser.py::test_parse_sanity_check

(169 durations < 0.005s hidden.  Use -vv to show these durations.)
============================================================================== 56 passed, 1 xfailed in 0.65s ===============================================================================```

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
