### PR TITLE
test: parse providers from env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
+coverage.lcov
 coverage.xml
 *.cover
 *.py,cover

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,5 @@
 # here we are going to create all needed tests for the parser.py parse function
+import json
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -87,3 +88,93 @@ def test_parse_with_alert_source_with_no_providers_file():
     parser = Parser()
     with pytest.raises(TypeError):
         parser.parse(str(alert_path))
+
+
+def parse_env_setup():
+        parser = Parser()
+        parser._parse_providers_from_env()
+        return parser
+
+class TestParseProvidersFromEnv:
+    
+    def test_parse_providers_from_env_empty(self, monkeypatch):
+        #ARRANGE
+        monkeypatch.setenv("KEEP_PROVIDERS", "")
+
+        # ACT
+        parser = parse_env_setup()
+
+        #ASSERT
+        assert parser.context_manager.providers_context == {}
+
+    def test_parse_providers_from_env_providers(self, monkeypatch):
+        #ARRANGE
+        providers_dict = {"slack-demo": {"authentication": {"webhook_url": "https://not.a.real.url"}}}
+        monkeypatch.setenv("KEEP_PROVIDERS", json.dumps(providers_dict))
+
+        # ACT
+        parser = parse_env_setup()
+
+        #ASSERT
+        assert parser.context_manager.providers_context == providers_dict
+
+    def test_parse_providers_from_env_providers_bad_json(self, monkeypatch):
+        #ARRANGE
+        providers_str = '{"slack-demo": {"authentication": {"webhook_url": '
+        monkeypatch.setenv("KEEP_PROVIDERS", providers_str)
+
+        # ACT
+        parser = parse_env_setup()
+
+        # ASSERT
+        assert parser.context_manager.providers_context == {}
+
+
+class TestProviderFromEnv:
+    def test_parse_provider_from_env_empty(self, monkeypatch):
+        #ARRANGE
+        provider_name = "TEST_NAME_STUB"
+        provider_dict = {"hi": 0}
+        monkeypatch.setenv(f"KEEP_PROVIDER_{provider_name}", json.dumps(provider_dict))
+
+        # ACT
+        parser = parse_env_setup()
+
+        #ASSERT
+        expected = {provider_name.replace("_", "-").lower(): provider_dict}
+        assert parser.context_manager.providers_context == expected
+    
+    def test_parse_providers_from_env_provider_bad_json(self, monkeypatch):
+        #ARRANGE
+        provider_name = "BAD"
+        providers_str = '{"authentication": {"webhook_url": '
+        monkeypatch.setenv(f"KEEP_PROVIDER_{provider_name}", providers_str)
+
+        # ACT
+        parser = parse_env_setup()
+
+        # ASSERT
+        assert parser.context_manager.providers_context == {}
+
+    def test_parse_providers_from_env_provider_var_missing_name(self, monkeypatch):
+        #ARRANGE
+        provider_name = ""
+        provider_dict = {"hi": 1}
+        monkeypatch.setenv(f"KEEP_PROVIDER_{provider_name}", json.dumps(provider_dict))
+
+        # ACT
+        parser = parse_env_setup()
+
+        #ASSERT
+        expected = {provider_name.replace("_", "-").lower(): provider_dict}
+        
+        # This might be a bug?
+        # It will create a provider context with an empty string as a provider name: {'': {'hi': 1}}
+        assert parser.context_manager.providers_context == expected
+
+        # I would expect it to not create the provider
+        #assert parser.context_manager.providers_context == {}
+
+
+
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -91,35 +91,37 @@ def test_parse_with_alert_source_with_no_providers_file():
 
 
 def parse_env_setup():
-        parser = Parser()
-        parser._parse_providers_from_env()
-        return parser
+    parser = Parser()
+    parser._parse_providers_from_env()
+    return parser
+
 
 class TestParseProvidersFromEnv:
-    
     def test_parse_providers_from_env_empty(self, monkeypatch):
-        #ARRANGE
+        # ARRANGE
         monkeypatch.setenv("KEEP_PROVIDERS", "")
 
         # ACT
         parser = parse_env_setup()
 
-        #ASSERT
+        # ASSERT
         assert parser.context_manager.providers_context == {}
 
     def test_parse_providers_from_env_providers(self, monkeypatch):
-        #ARRANGE
-        providers_dict = {"slack-demo": {"authentication": {"webhook_url": "https://not.a.real.url"}}}
+        # ARRANGE
+        providers_dict = {
+            "slack-demo": {"authentication": {"webhook_url": "https://not.a.real.url"}}
+        }
         monkeypatch.setenv("KEEP_PROVIDERS", json.dumps(providers_dict))
 
         # ACT
         parser = parse_env_setup()
 
-        #ASSERT
+        # ASSERT
         assert parser.context_manager.providers_context == providers_dict
 
     def test_parse_providers_from_env_providers_bad_json(self, monkeypatch):
-        #ARRANGE
+        # ARRANGE
         providers_str = '{"slack-demo": {"authentication": {"webhook_url": '
         monkeypatch.setenv("KEEP_PROVIDERS", providers_str)
 
@@ -132,7 +134,7 @@ class TestParseProvidersFromEnv:
 
 class TestProviderFromEnv:
     def test_parse_provider_from_env_empty(self, monkeypatch):
-        #ARRANGE
+        # ARRANGE
         provider_name = "TEST_NAME_STUB"
         provider_dict = {"hi": 0}
         monkeypatch.setenv(f"KEEP_PROVIDER_{provider_name}", json.dumps(provider_dict))
@@ -140,12 +142,12 @@ class TestProviderFromEnv:
         # ACT
         parser = parse_env_setup()
 
-        #ASSERT
+        # ASSERT
         expected = {provider_name.replace("_", "-").lower(): provider_dict}
         assert parser.context_manager.providers_context == expected
-    
+
     def test_parse_providers_from_env_provider_bad_json(self, monkeypatch):
-        #ARRANGE
+        # ARRANGE
         provider_name = "BAD"
         providers_str = '{"authentication": {"webhook_url": '
         monkeypatch.setenv(f"KEEP_PROVIDER_{provider_name}", providers_str)
@@ -157,7 +159,7 @@ class TestProviderFromEnv:
         assert parser.context_manager.providers_context == {}
 
     def test_parse_providers_from_env_provider_var_missing_name(self, monkeypatch):
-        #ARRANGE
+        # ARRANGE
         provider_name = ""
         provider_dict = {"hi": 1}
         monkeypatch.setenv(f"KEEP_PROVIDER_{provider_name}", json.dumps(provider_dict))
@@ -165,16 +167,12 @@ class TestProviderFromEnv:
         # ACT
         parser = parse_env_setup()
 
-        #ASSERT
+        # ASSERT
         expected = {provider_name.replace("_", "-").lower(): provider_dict}
-        
+
         # This might be a bug?
         # It will create a provider context with an empty string as a provider name: {'': {'hi': 1}}
         assert parser.context_manager.providers_context == expected
 
         # I would expect it to not create the provider
-        #assert parser.context_manager.providers_context == {}
-
-
-
-
+        # assert parser.context_manager.providers_context == {}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Added some tests around parsing providers from env vars.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

There might be some behavior when parsing a malformed env var that is unintentional. See comments...