### PR TITLE
db pvc fixes and k8s min version removed

### DIFF
--- a/chart/keep/Chart.yaml
+++ b/chart/keep/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 name: keep
 version: 0.0.1
-kubeVersion: ">=1.25.9"
 description: Keep Helm Chart
 type: application
 icon: https://platform.keephq.dev/_next/image?url=%2Fkeep.png&w=48&q=75

--- a/chart/keep/templates/keep-db-pv.yaml
+++ b/chart/keep/templates/keep-db-pv.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ $fullName }}-pv
+  name: {{ include "keep.fullname" . }}-pv
 spec:
   capacity:
     storage: {{ .Values.database.size }}
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: manual
+  storageClassName: {{ .Values.database.storageClasss }}
   hostPath:
     path: "/var/lib/mysql"

--- a/chart/keep/templates/keep-db-pvc.yaml
+++ b/chart/keep/templates/keep-db-pvc.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ $fullName }}-pv
+  name: {{ include "keep.fullname" . }}-pvc
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: default
+  storageClassName: {{ .Values.database.storageClasss }}
   resources:
     requests:
       storage: 5Gi

--- a/chart/keep/templates/keep-db.yaml
+++ b/chart/keep/templates/keep-db.yaml
@@ -46,7 +46,7 @@ spec:
             {{- end }}
           volumeMounts:
           - mountPath: /var/lib/mysql
-            name: {{ $fullName }}-pv
+            name: {{ include "keep.fullname" . }}-pv
             readOnly: false
           resources:
             {{- toYaml .Values.database.resources | nindent 12 }}
@@ -63,6 +63,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        - name: {{ $fullName }}-p
+        - name: {{ include "keep.fullname" . }}-pv
           persistentVolumeClaim:
-            claimName: {{ $fullName }}-pvc
+            claimName: {{ include "keep.fullname" . }}-pvc

--- a/chart/keep/values.yaml
+++ b/chart/keep/values.yaml
@@ -102,6 +102,7 @@ database:
   enabled: true
   replicaCount: 1
   size: 5Gi
+  storageClasss: deafult
   image:
     repository: mysql
     pullPolicy: IfNotPresent


### PR DESCRIPTION
1. fixed keep-db naming in yamls
2. keep-db get pv and pvc based on storageClassName from values.yaml
3. removed min k8s version for more "old" k8s clusters