### PR TITLE
chore: docker-compose templatization

### DIFF
--- a/docker-compose-with-auth.yml
+++ b/docker-compose-with-auth.yml
@@ -1,47 +1,28 @@
 services:
   keep-frontend:
+    extends:
+      file: docker-compose.common.yml
+      service: keep-frontend-common
     image: us-central1-docker.pkg.dev/keephq/keep/keep-ui
-    ports:
-      - "3000:3000"
     environment:
       - AUTH_TYPE=SINGLE_TENANT
-      - NEXTAUTH_SECRET=secret
-      - NEXTAUTH_URL=http://localhost:3000
       - API_URL=http://keep-backend:8080
-      - NEXT_PUBLIC_API_URL=http://localhost:8080
-      - NEXT_PUBLIC_POSTHOG_KEY=phc_muk9qE3TfZsX3SZ9XxX52kCGJBclrjhkP9JxAQcm1PZ
-      - NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
-      - NEXT_PUBLIC_PUSHER_HOST=localhost
-      - NEXT_PUBLIC_PUSHER_PORT=6001
-      - NEXT_PUBLIC_PUSHER_APP_KEY=keepappkey
-      - NEXT_PUBLIC_KEEP_VERSION=0.2.9
     volumes:
       - ./state:/state
     depends_on:
       - keep-backend
+  
   keep-backend:
+    extends:
+      file: docker-compose.common.yml
+      service: keep-backend-common
     image: us-central1-docker.pkg.dev/keephq/keep/keep-api
-    ports:
-      - "8080:8080"
     environment:
       - AUTH_TYPE=SINGLE_TENANT
-      - PORT=8080
-      - SECRET_MANAGER_TYPE=FILE
-      - SECRET_MANAGER_DIRECTORY=/state
-      - DATABASE_CONNECTION_STRING=sqlite:////state/db.sqlite3?check_same_thread=False
-      - OPENAI_API_KEY=$OPENAI_API_KEY
-      - KEEP_JWT_SECRET=keepjwtsecret
-      - KEEP_DEFAULT_USERNAME=admin
-      - KEEP_DEFAULT_PASSWORD=keep
-      - PUSHER_APP_ID=1
-      - PUSHER_APP_KEY=keepappkey
-      - PUSHER_APP_SECRET=keepappsecret
-      - PUSHER_HOST=keep-websocket-server
-      - PUSHER_PORT=6001
     volumes:
       - ./state:/state
   
   keep-websocket-server:
     extends:
-      file: common.yml
-      service: keep-websocket-server
+      file: docker-compose.common.yml
+      service: keep-websocket-server-common

--- a/docker-compose-with-otel.yaml
+++ b/docker-compose-with-otel.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   loki:
     image: grafana/loki:latest
@@ -85,58 +84,38 @@ services:
       - ./otel-shared/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
 
   keep-frontend-dev:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.dev.ui
-    ports:
-      - "3000:3000"
+    extends:
+      file: docker-compose.common.yml
+      service: keep-frontend-common
     environment:
-      - NEXTAUTH_SECRET=secret
-      - NEXTAUTH_URL=http://localhost:3001
-      - NEXT_PUBLIC_API_URL=http://localhost:8080
       - API_URL=http://keep-backend-dev:8080
-      - NEXT_PUBLIC_POSTHOG_KEY=phc_muk9qE3TfZsX3SZ9XxX52kCGJBclrjhkP9JxAQcm1PZ
-      - NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
-      - NEXT_PUBLIC_PUSHER_HOST=keep-websocket-server
-      - NEXT_PUBLIC_PUSHER_PORT=6001
-      - NEXT_PUBLIC_PUSHER_APP_KEY=keepappkey
-      - NEXT_PUBLIC_KEEP_VERSION=0.2.9
+    build:
+      dockerfile: docker/Dockerfile.dev.ui
     volumes:
-      - ./keep/keep-ui:/app
+      - ./keep-ui:/app
       - /app/node_modules
       - /app/.next
     depends_on:
       - keep-backend-dev
+  
   keep-backend-dev:
+    extends:
+      file: docker-compose.common.yml
+      service: keep-backend-common
     build:
-      context: .
       dockerfile: docker/Dockerfile.dev.api
-    labels:
-      - vector_scrape=true
-      - service=keep-api
-    ports:
-      - "8080:8080"
     environment:
       - OTEL_SERVICE_NAME=keephq
       - OTLP_ENDPOINT=http://otel-collector:4317
       - METRIC_OTEL_ENABLED=true
-      - PORT=8080
-      - SECRET_MANAGER_TYPE=FILE
-      - SECRET_MANAGER_DIRECTORY=/state
-      - DATABASE_CONNECTION_STRING=sqlite:////state/db.sqlite3?check_same_thread=False
-      - PUSHER_APP_ID=1
-      - PUSHER_APP_KEY=keepappkey
-      - PUSHER_APP_SECRET=keepappsecret
-      - PUSHER_HOST=localhost
-      - PUSHER_PORT=6001
     volumes:
-      - ./keep/keep:/code/keep
+      - .:/app
       - ./state:/state
   
   keep-websocket-server:
     extends:
-      file: common.yml
-      service: keep-websocket-server
+      file: docker-compose.common.yml
+      service: keep-websocket-server-common
 
   log_collector:
     image: timberio/vector:0.32.2-debian

--- a/docker-compose-with-otel.yaml
+++ b/docker-compose-with-otel.yaml
@@ -132,16 +132,11 @@ services:
     volumes:
       - ./keep/keep:/code/keep
       - ./state:/state
+  
   keep-websocket-server:
-    image: quay.io/soketi/soketi:1.4-16-debian
-    ports:
-      - "6001:6001"
-      - "9601:9601"
-    environment:
-      - SOKETI_USER_AUTHENTICATION_TIMEOUT=3000
-      - SOKETI_DEFAULT_APP_ID=1
-      - SOKETI_DEFAULT_APP_KEY=keepappkey
-      - SOKETI_DEFAULT_APP_SECRET=keepappsecret
+    extends:
+      file: common.yml
+      service: keep-websocket-server
 
   log_collector:
     image: timberio/vector:0.32.2-debian

--- a/docker-compose.common.yml
+++ b/docker-compose.common.yml
@@ -7,7 +7,6 @@ services:
       - NEXTAUTH_SECRET=secret
       - NEXTAUTH_URL=http://localhost:3000
       - NEXT_PUBLIC_API_URL=http://localhost:8080
-      - API_URL=http://keep-backend-dev:8080
       - NEXT_PUBLIC_POSTHOG_KEY=phc_muk9qE3TfZsX3SZ9XxX52kCGJBclrjhkP9JxAQcm1PZ
       - NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
       - NEXT_PUBLIC_PUSHER_HOST=localhost
@@ -22,7 +21,7 @@ services:
       - PORT=8080
       - SECRET_MANAGER_TYPE=FILE
       - SECRET_MANAGER_DIRECTORY=/state
-      - DATABASE_CONNECTION_STRING=sqlite:////db.sqlite3?check_same_thread=False
+      - DATABASE_CONNECTION_STRING=sqlite:///./db.sqlite3?check_same_thread=False
       - OPENAI_API_KEY=$OPENAI_API_KEY
       - PUSHER_APP_ID=1
       - PUSHER_APP_KEY=keepappkey

--- a/docker-compose.common.yml
+++ b/docker-compose.common.yml
@@ -1,47 +1,43 @@
 services:
-  keep-frontend:
-    image: us-central1-docker.pkg.dev/keephq/keep/keep-ui
+
+  keep-frontend-common:
     ports:
-      - "3000:3000"
+      - '3000:3000'
     environment:
-      - AUTH_TYPE=SINGLE_TENANT
       - NEXTAUTH_SECRET=secret
       - NEXTAUTH_URL=http://localhost:3000
-      - API_URL=http://keep-backend:8080
       - NEXT_PUBLIC_API_URL=http://localhost:8080
+      - API_URL=http://keep-backend-dev:8080
       - NEXT_PUBLIC_POSTHOG_KEY=phc_muk9qE3TfZsX3SZ9XxX52kCGJBclrjhkP9JxAQcm1PZ
       - NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
       - NEXT_PUBLIC_PUSHER_HOST=localhost
       - NEXT_PUBLIC_PUSHER_PORT=6001
       - NEXT_PUBLIC_PUSHER_APP_KEY=keepappkey
       - NEXT_PUBLIC_KEEP_VERSION=0.2.9
-    volumes:
-      - ./state:/state
-    depends_on:
-      - keep-backend
-  keep-backend:
-    image: us-central1-docker.pkg.dev/keephq/keep/keep-api
+
+  keep-backend-common:
     ports:
-      - "8080:8080"
+      - '8080:8080'
     environment:
-      - AUTH_TYPE=SINGLE_TENANT
       - PORT=8080
       - SECRET_MANAGER_TYPE=FILE
       - SECRET_MANAGER_DIRECTORY=/state
-      - DATABASE_CONNECTION_STRING=sqlite:////state/db.sqlite3?check_same_thread=False
+      - DATABASE_CONNECTION_STRING=sqlite:////db.sqlite3?check_same_thread=False
       - OPENAI_API_KEY=$OPENAI_API_KEY
-      - KEEP_JWT_SECRET=keepjwtsecret
-      - KEEP_DEFAULT_USERNAME=admin
-      - KEEP_DEFAULT_PASSWORD=keep
       - PUSHER_APP_ID=1
       - PUSHER_APP_KEY=keepappkey
       - PUSHER_APP_SECRET=keepappsecret
       - PUSHER_HOST=keep-websocket-server
       - PUSHER_PORT=6001
-    volumes:
-      - ./state:/state
-  
-  keep-websocket-server:
-    extends:
-      file: common.yml
-      service: keep-websocket-server
+
+  keep-websocket-server-common:
+    image: quay.io/soketi/soketi:1.4-16-debian
+    ports:
+      - "6001:6001"
+      - "9601:9601"
+    environment:
+      - SOKETI_USER_AUTHENTICATION_TIMEOUT=3000
+      - SOKETI_DEBUG=1
+      - SOKETI_DEFAULT_APP_ID=1
+      - SOKETI_DEFAULT_APP_KEY=keepappkey
+      - SOKETI_DEFAULT_APP_SECRET=keepappsecret

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,54 +1,31 @@
 services:
   keep-frontend-dev:
+    
+    extends:
+      file: docker-compose.common.yml
+      service: keep-frontend-common
     build:
       dockerfile: docker/Dockerfile.dev.ui
-    ports:
-      - '3000:3000'
-    environment:
-      - NEXTAUTH_SECRET=secret
-      - NEXTAUTH_URL=http://localhost:3000
-      - NEXT_PUBLIC_API_URL=http://localhost:8080
-      - API_URL=http://keep-backend-dev:8080
-      - NEXT_PUBLIC_POSTHOG_KEY=phc_muk9qE3TfZsX3SZ9XxX52kCGJBclrjhkP9JxAQcm1PZ
-      - NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
-      - NEXT_PUBLIC_PUSHER_HOST=localhost
-      - NEXT_PUBLIC_PUSHER_PORT=6001
-      - NEXT_PUBLIC_PUSHER_APP_KEY=keepappkey
-      - NEXT_PUBLIC_KEEP_VERSION=0.2.9
     volumes:
       - ./keep-ui:/app
       - /app/node_modules
       - /app/.next
     depends_on:
       - keep-backend-dev
+  
   keep-backend-dev:
+    extends:
+      file: docker-compose.common.yml
+      service: keep-backend-common
     build:
       dockerfile: docker/Dockerfile.dev.api
-    ports:
-      - '8080:8080'
     environment:
-      - PORT=8080
-      - SECRET_MANAGER_TYPE=FILE
-      - SECRET_MANAGER_DIRECTORY=/state
-      - DATABASE_CONNECTION_STRING=sqlite:////db.sqlite3?check_same_thread=False
       - USE_NGROK=true
-      - OPENAI_API_KEY=$OPENAI_API_KEY
-      - PUSHER_APP_ID=1
-      - PUSHER_APP_KEY=keepappkey
-      - PUSHER_APP_SECRET=keepappsecret
-      - PUSHER_HOST=keep-websocket-server
-      - PUSHER_PORT=6001
     volumes:
       - .:/app
       - ./state:/state
+      
   keep-websocket-server:
-    image: quay.io/soketi/soketi:1.4-16-debian
-    ports:
-      - "6001:6001"
-      - "9601:9601"
-    environment:
-      - SOKETI_USER_AUTHENTICATION_TIMEOUT=3000
-      - SOKETI_DEBUG=1
-      - SOKETI_DEFAULT_APP_ID=1
-      - SOKETI_DEFAULT_APP_KEY=keepappkey
-      - SOKETI_DEFAULT_APP_SECRET=keepappsecret
+    extends:
+      file: docker-compose.common.yml
+      service: keep-websocket-server-common

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,9 +1,10 @@
 services:
   keep-frontend-dev:
-    
     extends:
       file: docker-compose.common.yml
       service: keep-frontend-common
+    environment:
+      - API_URL=http://keep-backend-dev:8080
     build:
       dockerfile: docker/Dockerfile.dev.ui
     volumes:
@@ -20,7 +21,7 @@ services:
     build:
       dockerfile: docker/Dockerfile.dev.api
     environment:
-      - USE_NGROK=true
+      - USE_NGROK=true 
     volumes:
       - .:/app
       - ./state:/state

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,28 @@
 services:
   keep-frontend:
     extends:
-      file: docker-compose.yml
+      file: docker-compose.common.yml
       service: keep-frontend-common
     image: us-central1-docker.pkg.dev/keephq/keep/keep-ui
-    ports:
-      - "3000:3000"
     environment:
       - AUTH_TYPE=NO_AUTH
+      - API_URL=http://keep-backend:8080
     volumes:
       - ./state:/state
     depends_on:
       - keep-backend
 
   keep-backend:
+    extends:
+      file: docker-compose.common.yml
+      service: keep-backend-common
     image: us-central1-docker.pkg.dev/keephq/keep/keep-api
-    ports:
-      - "8080:8080"
     environment:
       - AUTH_TYPE=NO_AUTH
-      - PORT=8080
-      - SECRET_MANAGER_TYPE=FILE
-      - SECRET_MANAGER_DIRECTORY=/state
-      - DATABASE_CONNECTION_STRING=sqlite:////state/db.sqlite3?check_same_thread=False
-      - OPENAI_API_KEY=$OPENAI_API_KEY
-      - PUSHER_APP_ID=1
-      - PUSHER_APP_KEY=keepappkey
-      - PUSHER_APP_SECRET=keepappsecret
-      - PUSHER_HOST=keep-websocket-server
-      - PUSHER_PORT=6001
     volumes:
       - ./state:/state
   
   keep-websocket-server:
     extends:
-      file: common.yml
-      service: keep-websocket-server
+      file: docker-compose.common.yml
+      service: keep-websocket-server-common

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,25 @@
 services:
   keep-frontend:
+    extends:
+      file: docker-compose.yml
+      service: keep-frontend-common
     image: us-central1-docker.pkg.dev/keephq/keep/keep-ui
     ports:
       - "3000:3000"
     environment:
       - AUTH_TYPE=NO_AUTH
-      - NEXTAUTH_SECRET=secret
-      - NEXTAUTH_URL=http://localhost:3000
-      - API_URL=http://keep-backend:8080
-      - NEXT_PUBLIC_API_URL=http://localhost:8080
-      - NEXT_PUBLIC_POSTHOG_KEY=phc_muk9qE3TfZsX3SZ9XxX52kCGJBclrjhkP9JxAQcm1PZ
-      - NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
-      - NEXT_PUBLIC_PUSHER_HOST=localhost
-      - NEXT_PUBLIC_PUSHER_PORT=6001
-      - NEXT_PUBLIC_PUSHER_APP_KEY=keepappkey
-      - NEXT_PUBLIC_KEEP_VERSION=0.2.9
     volumes:
       - ./state:/state
     depends_on:
       - keep-backend
+
   keep-backend:
     image: us-central1-docker.pkg.dev/keephq/keep/keep-api
     ports:
       - "8080:8080"
     environment:
-      - PORT=8080
       - AUTH_TYPE=NO_AUTH
+      - PORT=8080
       - SECRET_MANAGER_TYPE=FILE
       - SECRET_MANAGER_DIRECTORY=/state
       - DATABASE_CONNECTION_STRING=sqlite:////state/db.sqlite3?check_same_thread=False
@@ -37,13 +31,8 @@ services:
       - PUSHER_PORT=6001
     volumes:
       - ./state:/state
+  
   keep-websocket-server:
-    image: quay.io/soketi/soketi:1.4-16-debian
-    ports:
-      - "6001:6001"
-      - "9601:9601"
-    environment:
-      - SOKETI_USER_AUTHENTICATION_TIMEOUT=3000
-      - SOKETI_DEFAULT_APP_ID=1
-      - SOKETI_DEFAULT_APP_KEY=keepappkey
-      - SOKETI_DEFAULT_APP_SECRET=keepappsecret
+    extends:
+      file: common.yml
+      service: keep-websocket-server

--- a/docker/Dockerfile.dev.api
+++ b/docker/Dockerfile.dev.api
@@ -21,4 +21,4 @@ RUN . /venv/bin/activate && poetry install --no-root
 ENV PATH="/venv/bin:${PATH}"
 ENV VIRTUAL_ENV="/venv"
 
-CMD ["uvicorn", "keep.api.api:get_app", "--host", "0.0.0.0", "--port", "8080", "--reload"]
+ENTRYPOINT ["gunicorn", "keep.api.api:get_app", "--bind" , "0.0.0.0:8080" , "--workers", "1" , "-k" , "uvicorn.workers.UvicornWorker", "-c", "./keep/api/config.py"]

--- a/docker/Dockerfile.dev.api
+++ b/docker/Dockerfile.dev.api
@@ -24,4 +24,4 @@ RUN . /venv/bin/activate && poetry install --no-root
 ENV PATH="/venv/bin:${PATH}"
 ENV VIRTUAL_ENV="/venv"
 
-ENTRYPOINT ["gunicorn", "keep.api.api:get_app", "--bind" , "0.0.0.0:8080" , "--workers", "1" , "-k" , "uvicorn.workers.UvicornWorker", "-c", "./keep/api/config.py"]
+ENTRYPOINT ["gunicorn", "keep.api.api:get_app", "--bind" , "0.0.0.0:8080" , "--workers", "1" , "-k" , "uvicorn.workers.UvicornWorker", "-c", "./keep/api/config.py", "--reload"]

--- a/docker/Dockerfile.dev.api
+++ b/docker/Dockerfile.dev.api
@@ -14,8 +14,8 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
 
 RUN pip install "poetry==$POETRY_VERSION"
 RUN python -m venv /venv
-COPY poetry.lock pyproject.toml ./
-RUN . /venv/bin/activate && poetry install
+COPY pyproject.toml ./
+RUN . /venv/bin/activate && poetry install --no-root
 
 # Setting the virtual environment path
 ENV PATH="/venv/bin:${PATH}"


### PR DESCRIPTION
/close #531

- Templatization docker compose file
- Fixes Dockerfile.dev.api entry point
so that also calls config.py at the start of gunicorn server.
- Updates volume binding for backend in otel compose file