### PR TITLE
fix(ui): Column Width & History Modal

### DIFF
--- a/keep-ui/app/alerts/alert-history.tsx
+++ b/keep-ui/app/alerts/alert-history.tsx
@@ -9,6 +9,7 @@ import { useAlerts } from "utils/hooks/useAlerts";
 import { PaginationState } from "@tanstack/react-table";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toDateObjectWithFallback } from "utils/helpers";
+import Image from "next/image";
 
 interface AlertHistoryPanelProps {
   alertsHistoryWithDate: (Omit<AlertDto, "lastReceived"> & {
@@ -39,7 +40,16 @@ const AlertHistoryPanel = ({
   const minLastReceived = new Date(Math.min(...sortedHistoryAlert));
 
   if (alertsHistoryWithDate.length === 0) {
-    return null;
+    return (
+      <div className="flex justify-center">
+        <Image
+          src="/keep_loading_new.gif"
+          alt="loading"
+          width={200}
+          height={200}
+        />
+      </div>
+    );
   }
 
   return (

--- a/keep-ui/app/alerts/alert-history.tsx
+++ b/keep-ui/app/alerts/alert-history.tsx
@@ -6,48 +6,30 @@ import { useAlertTableCols } from "./alert-table-utils";
 import { Button, Flex, Subtitle, Title, Divider } from "@tremor/react";
 import AlertHistoryCharts from "./alert-history-charts";
 import { useAlerts } from "utils/hooks/useAlerts";
-import Loading from "app/loading";
 import { PaginationState } from "@tanstack/react-table";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toDateObjectWithFallback } from "utils/helpers";
-import { usePresets } from "utils/hooks/usePresets";
 
-interface Props {
-  alerts: AlertDto[];
+interface AlertHistoryPanelProps {
+  alertsHistoryWithDate: (Omit<AlertDto, "lastReceived"> & {
+    lastReceived: Date;
+  })[];
 }
 
-export function AlertHistory({ alerts }: Props) {
+const AlertHistoryPanel = ({
+  alertsHistoryWithDate,
+}: AlertHistoryPanelProps) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentPreset = searchParams
+    ? searchParams.get("selectedPreset")
+    : "Feed";
+
   const [rowPagination, setRowPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: 10,
   });
-
-  const router = useRouter();
-
-  const searchParams = useSearchParams();
-  const selectedAlert = alerts.find((alert) =>
-    searchParams ? searchParams.get("id") === alert.id : undefined
-  );
-  const { getCurrentPreset } = usePresets();
-
-  const { useAlertHistory } = useAlerts();
-  const { data: alertHistory = [], isLoading } = useAlertHistory(
-    selectedAlert,
-    {
-      revalidateOnFocus: false,
-    }
-  );
-
   const alertTableColumns = useAlertTableCols();
-
-  if (isLoading) {
-    return <Loading />;
-  }
-
-  const alertsHistoryWithDate = alertHistory.map((alert) => ({
-    ...alert,
-    lastReceived: toDateObjectWithFallback(alert.lastReceived),
-  }));
 
   const sortedHistoryAlert = alertsHistoryWithDate.map((alert) =>
     alert.lastReceived.getTime()
@@ -56,13 +38,88 @@ export function AlertHistory({ alerts }: Props) {
   const maxLastReceived = new Date(Math.max(...sortedHistoryAlert));
   const minLastReceived = new Date(Math.min(...sortedHistoryAlert));
 
+  if (alertsHistoryWithDate.length === 0) {
+    return null;
+  }
+
+  return (
+    <Fragment>
+      <Flex alignItems="center" justifyContent="between">
+        <div>
+          <Title>History of: {alertsHistoryWithDate.at(0)?.name}</Title>
+          <Subtitle>Total alerts: {alertsHistoryWithDate.length}</Subtitle>
+          <Subtitle>First Occurence: {minLastReceived.toString()}</Subtitle>
+          <Subtitle>Last Occurence: {maxLastReceived.toString()}</Subtitle>
+        </div>
+        <Button
+          className="mt-2 bg-white border-gray-200 text-gray-500 hover:bg-gray-50 hover:border-gray-300"
+          onClick={() =>
+            router.replace(`/alerts?selectedPreset=${currentPreset}`, {
+              scroll: false,
+            })
+          }
+        >
+          Close
+        </Button>
+      </Flex>
+      <Divider />
+      {alertsHistoryWithDate.length && (
+        <AlertHistoryCharts
+          maxLastReceived={maxLastReceived}
+          minLastReceived={minLastReceived}
+          alerts={alertsHistoryWithDate}
+        />
+      )}
+      <Divider />
+      <AlertTable
+        alerts={alertsHistoryWithDate}
+        columns={alertTableColumns}
+        isMenuColDisplayed={false}
+        isRefreshAllowed={false}
+        rowPagination={{
+          state: rowPagination,
+          onChange: setRowPagination,
+        }}
+        presetName="alert-history"
+      />
+    </Fragment>
+  );
+};
+
+interface Props {
+  alerts: AlertDto[];
+}
+
+export function AlertHistory({ alerts }: Props) {
+  const router = useRouter();
+
+  const searchParams = useSearchParams();
+  const selectedAlert = alerts.find((alert) =>
+    searchParams
+      ? searchParams.get("fingerprint") === alert.fingerprint
+      : undefined
+  );
+  const currentPreset = searchParams
+    ? searchParams.get("selectedPreset")
+    : "Feed";
+
+  const { useAlertHistory } = useAlerts();
+  const { data: alertHistory = [] } = useAlertHistory(selectedAlert, {
+    revalidateOnFocus: false,
+  });
+
+  const alertsHistoryWithDate = alertHistory.map((alert) => ({
+    ...alert,
+    lastReceived: toDateObjectWithFallback(alert.lastReceived),
+  }));
+
   return (
     <Transition appear show={selectedAlert !== undefined} as={Fragment}>
       <Dialog
         as="div"
         className="relative z-50"
         onClose={() =>
-          router.replace(`/alerts?selectedPreset=${getCurrentPreset()}`, {
+          router.replace(`/alerts?selectedPreset=${currentPreset}`, {
             scroll: false,
           })
         }
@@ -91,52 +148,10 @@ export function AlertHistory({ alerts }: Props) {
             >
               <Dialog.Panel
                 className="w-full max-w-screen-2xl max-h-[710px] transform overflow-scroll ring-tremor bg-white
-                                    p-6 text-left align-middle shadow-tremor transition-all rounded-xl"
+                    p-6 text-left align-middle shadow-tremor transition-all rounded-xl"
               >
-                <Flex alignItems="center" justifyContent="between">
-                  <div>
-                    <Title>History of: {alertsHistoryWithDate[0]?.name}</Title>
-                    <Subtitle>
-                      Total alerts: {alertsHistoryWithDate.length}
-                    </Subtitle>
-                    <Subtitle>
-                      First Occurence: {minLastReceived.toString()}
-                    </Subtitle>
-                    <Subtitle>
-                      Last Occurence: {maxLastReceived.toString()}
-                    </Subtitle>
-                  </div>
-                  <Button
-                    className="mt-2 bg-white border-gray-200 text-gray-500 hover:bg-gray-50 hover:border-gray-300"
-                    onClick={() =>
-                      router.replace(
-                        `/alerts?selectedPreset=${getCurrentPreset()}`,
-                        { scroll: false }
-                      )
-                    }
-                  >
-                    Close
-                  </Button>
-                </Flex>
-                <Divider />
-                {selectedAlert && (
-                  <AlertHistoryCharts
-                    maxLastReceived={maxLastReceived}
-                    minLastReceived={minLastReceived}
-                    alerts={alertsHistoryWithDate}
-                  />
-                )}
-                <Divider />
-                <AlertTable
-                  alerts={alertsHistoryWithDate}
-                  columns={alertTableColumns}
-                  isMenuColDisplayed={false}
-                  isRefreshAllowed={false}
-                  rowPagination={{
-                    state: rowPagination,
-                    onChange: setRowPagination,
-                  }}
-                  presetName="alert-history"
+                <AlertHistoryPanel
+                  alertsHistoryWithDate={alertsHistoryWithDate}
                 />
               </Dialog.Panel>
             </Transition.Child>

--- a/keep-ui/app/alerts/alert-menu.tsx
+++ b/keep-ui/app/alerts/alert-menu.tsx
@@ -207,8 +207,8 @@ export default function AlertMenu({ alert, isMenuOpen, setIsMenuOpen }: Props) {
                       <button
                         onClick={() => {
                           router.replace(
-                            `/alerts?id=${
-                              alert.id
+                            `/alerts?fingerprint=${
+                              alert.fingerprint
                             }&selectedPreset=${getCurrentPreset()}`,
                             {
                               scroll: false,

--- a/keep-ui/app/alerts/alert-name.tsx
+++ b/keep-ui/app/alerts/alert-name.tsx
@@ -4,7 +4,7 @@ import {
   Cog8ToothIcon,
   TicketIcon,
   TrashIcon,
-  PencilSquareIcon
+  PencilSquareIcon,
 } from "@heroicons/react/24/outline";
 import { Icon } from "@tremor/react";
 import { AlertDto, AlertKnownKeys } from "./models";
@@ -44,13 +44,16 @@ interface Props {
   setNoteModalAlert?: (alert: AlertDto) => void;
   setTicketModalAlert?: (alert: AlertDto) => void;
 }
-export default function AlertName({ alert, setNoteModalAlert, setTicketModalAlert}: Props) {
+export default function AlertName({
+  alert,
+  setNoteModalAlert,
+  setTicketModalAlert,
+}: Props) {
   const router = useRouter();
   const { data: workflows = [] } = useWorkflows();
 
   const handleNoteClick = () => {
-    if(setNoteModalAlert)
-    {
+    if (setNoteModalAlert) {
       setNoteModalAlert(alert);
     }
   };
@@ -59,7 +62,7 @@ export default function AlertName({ alert, setNoteModalAlert, setTicketModalAler
     if (!ticketUrl && setTicketModalAlert) {
       setTicketModalAlert(alert);
     } else {
-      window.open(ticketUrl, '_blank'); // Open the ticket URL in a new tab
+      window.open(ticketUrl, "_blank"); // Open the ticket URL in a new tab
     }
   };
 
@@ -68,7 +71,6 @@ export default function AlertName({ alert, setNoteModalAlert, setTicketModalAler
     url,
     generatorURL,
     deleted,
-    lastReceived,
     note,
     ticket_url: ticketUrl,
     ticket_status: ticketStatus,
@@ -88,118 +90,118 @@ export default function AlertName({ alert, setNoteModalAlert, setTicketModalAler
     [alert, workflows]
   );
 
-
-
-
   return (
-      <div className="max-w-[340px]">
-        <div className="flex items-center justify-between">
-          <div className="truncate" title={alert.name}>
-            {name}{" "}
-          </div>
-          <div>
-            {(url ?? generatorURL) && (
-              <a href={url || generatorURL} target="_blank">
-                <Icon
-                  icon={ArrowTopRightOnSquareIcon}
-                  tooltip="Open Original Alert"
-                  color="gray"
-                  variant="solid"
-                  size="xs"
-                  className="ml-1"
-                />
-              </a>
-            )}
-            { setTicketModalAlert && (
-                <Icon
-                icon={TicketIcon}
-                tooltip={ticketUrl ? `Ticket Assigned ${ticketStatus ? `(status: ${ticketStatus})` : ''}` : "Click to assign Ticket"}
-                size="xs"
-                color={ticketUrl ? "green" : "gray"}
-                className="ml-1 cursor-pointer"
-                variant="solid"
-                onClick={handleTicketClick}
-              />
-            )}
-
-            {playbook_url && (
-              <a href={playbook_url} target="_blank">
-                <Icon
-                  icon={BookOpenIcon}
-                  tooltip="Playbook"
-                  size="xs"
-                  color="gray"
-                  className="ml-1"
-                  variant="solid"
-                />
-              </a>
-            )}
-            {
-              setNoteModalAlert && (
-                <Icon
-                icon={PencilSquareIcon}
-                tooltip="Click to add note"
-                size="xs"
-                color={note ? "green" : "gray"}
-                className="ml-1 cursor-pointer"
-                variant="solid"
-                onClick={handleNoteClick}
-              />
-            )}
-
-            {deleted && (
-              <Icon
-                icon={TrashIcon}
-                tooltip="This alert has been deleted"
-                size="xs"
-                color="gray"
-                className="ml-1"
-                variant="solid"
-              />
-            )}
-            {relevantWorkflows.length > 0 && (
-              <Icon
-                icon={Cog8ToothIcon}
-                size="xs"
-                color={`${
-                  relevantWorkflows.every(
-                    (wf) => wf.last_execution_status === "success"
-                  )
-                    ? "green"
-                    : relevantWorkflows.some(
-                        (wf) => wf.last_execution_status === "error"
-                      )
-                    ? "red"
-                    : relevantWorkflows.some(
-                        (wf) =>
-                          wf.last_execution_status === "providers_not_configured"
-                      )
-                    ? "amber"
-                    : "gray"
-                }`}
-                tooltip={`${
-                  relevantWorkflows.every(
-                    (wf) => wf.last_execution_status === "success"
-                  )
-                    ? "All workflows executed successfully"
-                    : relevantWorkflows.some(
-                        (wf) => wf.last_execution_status === "error"
-                      )
-                    ? "Some workflows failed to execute"
-                    : relevantWorkflows.some(
-                        (wf) =>
-                          wf.last_execution_status === "providers_not_configured"
-                      )
-                    ? "Some workflows are not configured"
-                    : "Workflows have yet to execute"
-                }`}
-                onClick={() => handleWorkflowClick(relevantWorkflows)}
-                className="ml-1 cursor-pointer"
-                variant="solid"
-              />
-            )}
-          </div>
-        </div>
+    <div className="flex items-center justify-between">
+      <div className="truncate" title={alert.name}>
+        {name}
       </div>
+      <div>
+        {(url ?? generatorURL) && (
+          <a href={url || generatorURL} target="_blank">
+            <Icon
+              icon={ArrowTopRightOnSquareIcon}
+              tooltip="Open Original Alert"
+              color="gray"
+              variant="solid"
+              size="xs"
+              className="ml-1"
+            />
+          </a>
+        )}
+        {setTicketModalAlert && (
+          <Icon
+            icon={TicketIcon}
+            tooltip={
+              ticketUrl
+                ? `Ticket Assigned ${
+                    ticketStatus ? `(status: ${ticketStatus})` : ""
+                  }`
+                : "Click to assign Ticket"
+            }
+            size="xs"
+            color={ticketUrl ? "green" : "gray"}
+            className="ml-1 cursor-pointer"
+            variant="solid"
+            onClick={handleTicketClick}
+          />
+        )}
+
+        {playbook_url && (
+          <a href={playbook_url} target="_blank">
+            <Icon
+              icon={BookOpenIcon}
+              tooltip="Playbook"
+              size="xs"
+              color="gray"
+              className="ml-1"
+              variant="solid"
+            />
+          </a>
+        )}
+        {setNoteModalAlert && (
+          <Icon
+            icon={PencilSquareIcon}
+            tooltip="Click to add note"
+            size="xs"
+            color={note ? "green" : "gray"}
+            className="ml-1 cursor-pointer"
+            variant="solid"
+            onClick={handleNoteClick}
+          />
+        )}
+
+        {deleted && (
+          <Icon
+            icon={TrashIcon}
+            tooltip="This alert has been deleted"
+            size="xs"
+            color="gray"
+            className="ml-1"
+            variant="solid"
+          />
+        )}
+        {relevantWorkflows.length > 0 && (
+          <Icon
+            icon={Cog8ToothIcon}
+            size="xs"
+            color={`${
+              relevantWorkflows.every(
+                (wf) => wf.last_execution_status === "success"
+              )
+                ? "green"
+                : relevantWorkflows.some(
+                    (wf) => wf.last_execution_status === "error"
+                  )
+                ? "red"
+                : relevantWorkflows.some(
+                    (wf) =>
+                      wf.last_execution_status === "providers_not_configured"
+                  )
+                ? "amber"
+                : "gray"
+            }`}
+            tooltip={`${
+              relevantWorkflows.every(
+                (wf) => wf.last_execution_status === "success"
+              )
+                ? "All workflows executed successfully"
+                : relevantWorkflows.some(
+                    (wf) => wf.last_execution_status === "error"
+                  )
+                ? "Some workflows failed to execute"
+                : relevantWorkflows.some(
+                    (wf) =>
+                      wf.last_execution_status === "providers_not_configured"
+                  )
+                ? "Some workflows are not configured"
+                : "Workflows have yet to execute"
+            }`}
+            onClick={() => handleWorkflowClick(relevantWorkflows)}
+            className="ml-1 cursor-pointer"
+            variant="solid"
+          />
+        )}
+      </div>
+    </div>
   );
 }

--- a/keep-ui/app/alerts/alert-table-utils.tsx
+++ b/keep-ui/app/alerts/alert-table-utils.tsx
@@ -154,10 +154,7 @@ export const useAlertTableCols = ({
       id: "description",
       header: "Description",
       cell: (context) => (
-        <div
-          className="max-w-[340px] flex items-center"
-          title={context.getValue()}
-        >
+        <div title={context.getValue()}>
           <div className="truncate">{context.getValue()}</div>
         </div>
       ),
@@ -217,6 +214,9 @@ export const useAlertTableCols = ({
       ? [
           columnHelper.display({
             id: "alertMenu",
+            meta: {
+              tdClassName: "flex justify-end",
+            },
             cell: (context) => (
               <AlertMenu
                 alert={context.row.original}

--- a/keep-ui/app/alerts/alert-table-utils.tsx
+++ b/keep-ui/app/alerts/alert-table-utils.tsx
@@ -199,11 +199,20 @@ export const useAlertTableCols = ({
       cell: (context) => (
         <AlertExtraPayload
           alert={context.row.original}
-          isToggled={expandedToggles[context.row.original.fingerprint]}
+          isToggled={
+            // When menu is not displayed, it means we're in History mode and therefore
+            // we need to use the alert id as the key to keep the state of the toggles and not the fingerprint
+            // because all fingerprints are the same. (it's the history of that fingerprint :P)
+            isMenuDisplayed
+              ? expandedToggles[context.row.original.fingerprint]
+              : expandedToggles[context.row.original.id]
+          }
           setIsToggled={(newValue) =>
             setExpandedToggles({
               ...expandedToggles,
-              [context.row.original.fingerprint]: newValue,
+              [isMenuDisplayed
+                ? context.row.original.fingerprint
+                : context.row.original.id]: newValue,
             })
           }
         />

--- a/keep-ui/app/alerts/alerts-table-body.tsx
+++ b/keep-ui/app/alerts/alerts-table-body.tsx
@@ -7,10 +7,10 @@ import { Table, flexRender } from "@tanstack/react-table";
 
 interface Props {
   table: Table<AlertDto>;
-  showSkeleton?: boolean;
+  showSkeleton: boolean;
 }
 
-export function AlertsTableBody({ table, showSkeleton = true }: Props) {
+export function AlertsTableBody({ table, showSkeleton }: Props) {
   return (
     <TableBody>
       {table.getRowModel().rows.map((row) => (
@@ -29,36 +29,16 @@ export function AlertsTableBody({ table, showSkeleton = true }: Props) {
           ))}
         </TableRow>
       ))}
-
       {showSkeleton && (
         <TableRow>
-          <TableCell>
-            <Skeleton />
-          </TableCell>
-          <TableCell>
-            <Skeleton />
-          </TableCell>
-          <TableCell>
-            <Skeleton />
-          </TableCell>
-          <TableCell>
-            <Skeleton />
-          </TableCell>
-          <TableCell>
-            <Skeleton />
-          </TableCell>
-          <TableCell>
-            <Skeleton />
-          </TableCell>
-          <TableCell>
-            <Skeleton />
-          </TableCell>
-          <TableCell>
-            <Skeleton />
-          </TableCell>
-          <TableCell>
-            <Skeleton />
-          </TableCell>
+          {table
+            .getAllColumns()
+            .filter((col) => col.getIsVisible())
+            .map((col) => (
+              <TableCell key={col.id}>
+                <Skeleton />
+              </TableCell>
+            ))}
         </TableRow>
       )}
     </TableBody>


### PR DESCRIPTION
closes #690 

- fix skeleton shifting the table layout. the amount of skeleton cells sometimes superseded the visible columns, and when loading was finished, the whole table would shift as it removed the skeleton cells
- remove set width from the `name` col
- move menu to _right_ (typo in the commit 😬)
- history modal should stay open whenever a fingerprint alert is added. changed to use `fingerprint` as an identifier. the problem was that I used to select the alerts to view their history by their ID. but whenever a new fingerprint alert was pushed, `getFormatAndMergePusherWithEndpointAlerts` replaced the last alert with the most current. so the ID essentially changed in the `alerts` and thus the history modal closed since the ID in params was `undefined`. 
- removed the `loading` component since it was disruptive whenever a new fingerprint alert was pushed. perhaps it's worth exploring showing some loading screen _only_ while waiting for long responses. 