### PR TITLE
build(api): chown `/venv` directory let the `keep` user install ngrok when enabled

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -29,5 +29,6 @@ COPY --from=builder /venv /venv
 # as per Openshift guidelines, https://docs.openshift.com/container-platform/4.11/openshift_images/create-images.html#use-uid_create-images
 RUN chgrp -R 0 /app && chmod -R g=u /app
 RUN chown -R keep:keep /app
+RUN chown -R keep:keep /venv
 USER keep
 ENTRYPOINT ["gunicorn", "keep.api.api:get_app", "--bind" , "0.0.0.0:8080" , "--workers", "4" , "-k" , "uvicorn.workers.UvicornWorker", "-c", "/venv/lib/python3.11/site-packages/keep/api/config.py"]


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Responds to a [Slack thread](https://getkeep.slack.com/archives/C04PT44MATS/p1709500666995089?thread_ts=1709498421.593459&cid=C04PT44MATS) without the issue being referenced on Github

## 📑 Description
<!-- Add a brief description of the pr -->
When one enable the backend ngrok feature through the `USE_NGROK=true` env variable, the python app ran by the low-priv user `keep` can't download ngrok binary inside `/venv/lib/python3.11/site-packages/pyngrok` and thus, can't enable the feature and cause the following : `PermissionError: [Errno 13] Permission denied: '/venv/lib/python3.11/site-packages/pyngrok/bin'`, ending the app.  

This PR aims to give the ownership of `keep` user over the `/venv` directory to circumvent this error. While this might not be the best of all fix security-wise, it works.
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Might be worth to look twice before merging this, as this could introduce appsec vulnerabilities to the Dockerfile.
