### PR TITLE
feat(ui): use workflow name and description

### DIFF
--- a/keep-ui/app/workflows/models.tsx
+++ b/keep-ui/app/workflows/models.tsx
@@ -19,6 +19,7 @@ export type Trigger = {
 
 export type Workflow = {
   id: string;
+  name: string;
   description: string;
   created_by: string;
   creation_time: string;

--- a/keep-ui/app/workflows/workflow-tile.tsx
+++ b/keep-ui/app/workflows/workflow-tile.tsx
@@ -385,7 +385,7 @@ function WorkflowTile({ workflow }: { workflow: Workflow }) {
       )}
       <Card>
         <div className="flex w-full justify-between items-center h-14">
-          <Title>{workflow.name.length > 30 ? `${workflow.name.substring(0, 50)}...` : workflow.name}</Title>
+          <Title className="truncate max-w-64 text-left text-lightBlack">{workflow.name}</Title>
           {WorkflowMenuSection({
             onDelete: handleDeleteClick,
             onRun: handleRunClick,
@@ -396,8 +396,8 @@ function WorkflowTile({ workflow }: { workflow: Workflow }) {
           })}
         </div>
 
-        <div className="flex w-fit justify-between items-center h-10">
-          <Text>{workflow.description.length > 50 ? `${workflow.description.substring(0, 50)}...` : workflow.description}</Text>
+        <div className="flex items-center justify-between h-10">
+          <Text className="truncate max-w-sm text-left text-lightBlack">{workflow.description}</Text>
         </div>
 
         <List>

--- a/keep-ui/app/workflows/workflow-tile.tsx
+++ b/keep-ui/app/workflows/workflow-tile.tsx
@@ -385,7 +385,7 @@ function WorkflowTile({ workflow }: { workflow: Workflow }) {
       )}
       <Card>
         <div className="flex w-full justify-between items-center h-14">
-          <Title>{workflow.description}</Title>
+          <Title>{workflow.name.length > 30 ? `${workflow.name.substring(0, 50)}...` : workflow.name}</Title>
           {WorkflowMenuSection({
             onDelete: handleDeleteClick,
             onRun: handleRunClick,
@@ -394,6 +394,10 @@ function WorkflowTile({ workflow }: { workflow: Workflow }) {
             onBuilder: handleBuilderClick,
             workflow,
           })}
+        </div>
+
+        <div className="flex w-fit justify-between items-center h-10">
+          <Text>{workflow.description.length > 50 ? `${workflow.description.substring(0, 50)}...` : workflow.description}</Text>
         </div>
 
         <List>


### PR DESCRIPTION
Closes #933 

## 📑 Description
Set workflow name as title of the workflow card and set 30 character limit.
Moved description to under the name with 50 character limit.

You can find how it looks like below:

![keep-933](https://github.com/keephq/keep/assets/65170388/890cec46-a353-4ef0-afce-2c30c66ddf2f)

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
