### PR TITLE
feat: update database conn envs

### DIFF
--- a/docker-compose.common.yml
+++ b/docker-compose.common.yml
@@ -21,7 +21,11 @@ services:
       - PORT=8080
       - SECRET_MANAGER_TYPE=FILE
       - SECRET_MANAGER_DIRECTORY=/state
-      - DATABASE_CONNECTION_STRING=sqlite:///./db.sqlite3?check_same_thread=False
+      - DATABASE_HOST=""
+      - DATABASE_PORT="3306"
+      - DATABASE_USER="root"
+      - DATABASE_PASSWORD=""
+      - DATABASE_NAME="keep"
       - OPENAI_API_KEY=$OPENAI_API_KEY
       - PUSHER_APP_ID=1
       - PUSHER_APP_KEY=keepappkey

--- a/docs/deployment/ecs.mdx
+++ b/docs/deployment/ecs.mdx
@@ -38,7 +38,11 @@ sidebarTitle: "AWS ECS"
                 - Protocol: TCP
             ![Container Details](/images/ecs-task-def-frontend3.png)
             - Environment Variables: (This can be static or you can use parameter store or secrets manager)
-                - DATABASE_CONNECTION_STRING
+                - DATABASE_HOST
+                - DATABASE_PORT
+                - DATABASE_USER
+                - DATABASE_PASSWORD
+                - DATABASE_NAME
                 - AUTH_TYPE
                 - KEEP_JWT_SECRET
                 - KEEP_DEFAULT_USERNAME
@@ -79,7 +83,11 @@ sidebarTitle: "AWS ECS"
                 - Protocol: TCP
                 ![Container Details](/images/ecs-task-def-backend3.png)
             - Environment Variables: (This can be static or you can use parameter store or secrets manager)
-                - DATABASE_CONNECTION_STRING
+                - DATABASE_HOST
+                - DATABASE_PORT
+                - DATABASE_USER
+                - DATABASE_PASSWORD
+                - DATABASE_NAME
                 - AUTH_TYPE
                 - KEEP_JWT_SECRET
                 - KEEP_DEFAULT_USERNAME

--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -91,18 +91,20 @@ def __get_conn_impersonate() -> pymysql.connections.Connection:
 # this is a workaround for gunicorn to load the env vars
 #   becuase somehow in gunicorn it doesn't load the .env file
 load_dotenv(find_dotenv())
-db_connection_string = config("DATABASE_CONNECTION_STRING", default=None)
+db_host = config("DATABASE_HOST", default="")
+db_port = config("DATABASE_PORT", default="3306")
+db_user = config("DATABASE_USER", default="root")
+db_password = config("DATABASE_PASSWORD", default="")
+db_name = config("DATABASE_NAME", default="keep")
+db_connection_string = "mysql+pymysql://" + db_user + ":" + db_password + "@" + db_host + ":" + db_port + "/" + db_name
+if db_host == "":
+    db_connection_string = ""
 pool_size = config("DATABASE_POOL_SIZE", default=5, cast=int)
 
 if RUNNING_IN_CLOUD_RUN:
     engine = create_engine(
         "mysql+pymysql://",
         creator=__get_conn,
-    )
-elif db_connection_string == "impersonate":
-    engine = create_engine(
-        "mysql+pymysql://",
-        creator=__get_conn_impersonate,
     )
 elif db_connection_string:
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,9 +139,6 @@ def db_session(request, mysql_container):
         )
     SQLModel.metadata.create_all(mock_engine)
 
-    # Mock the environment variables so db.py will use it
-    os.environ["DATABASE_CONNECTION_STRING"] = db_connection_string
-
     # Create a session
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=mock_engine)
     session = SessionLocal()


### PR DESCRIPTION
## 📑 Description
Right now while creating the db engine backend getting the DATABASE_CONNECTION_STRING env var and use it. It is really nice but when the time comes to deployment in helm chart I wouldn't want to declare this env variable inside of my values.yaml because I am keeping all of my helm charts in a gitops repo so it would cause a security problem if I declare my db connection string as clear text. So in order fix that I am proposing to declare

```
DATABASE_HOST
DATABASE_PORT
DATABASE_USER
DATABASE_PASSWORD
DATABASE_NAME 
```

env variables separately and combine them in the backend afterwards. This will let us to use secrets for DATABASE_PASSWORD and get this env from k8s secrets

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
I will also update helm chart as following.