### PR TITLE
fix: extraction create error

### DIFF
--- a/keep/api/routes/extraction.py
+++ b/keep/api/routes/extraction.py
@@ -45,7 +45,9 @@ def create_extraction_rule(
     new_rule = ExtractionRule(
         **rule_dto.dict(),
         created_by=authenticated_entity.email,
-        tenant_id=authenticated_entity.tenant_id
+        tenant_id=authenticated_entity.tenant_id,
+        updated_at=datetime.datetime.now(datetime.timezone.utc),
+        updated_by=authenticated_entity.email,
     )
     session.add(new_rule)
     session.commit()


### PR DESCRIPTION
## 📑 Description
While creating extraction rule it was throwing sql error since we were not supply `updated_at` and `updated_by` infos. This PR fixes it.

```json
{
    "message": "An internal server error occurred.",
    "trace_id": "x",
    "error_msg": "(sqlite3.OperationalError) no such column: updated_at\n[SQL: INSERT INTO extractionrule (tenant_id, priority, name, description, created_by, created_at, updated_by, updated_at, disabled, pre, condition, attribute, regex) VALUES (?, ?, ?, ?, ?, ?, ?, updated_at, ?, ?, ?, ?, ?) /*db_driver='pysqlite',db_framework='sqlalchemy%%3A0.41b0',traceparent='x'*/]\n[parameters: ('keep', 0, 'asd', 'asd', 'admin@keephq', '2024-04-20 12:30:39.005900', None, 0, 0, '', 'asd', '(?P<groupname>)')]\n(Background on this error at: https://sqlalche.me/e/14/e3q8)"
}
```

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
