### PR TITLE
fix: make name optional to prevent ui errors in workflowdto

### DIFF
--- a/keep/api/models/workflow.py
+++ b/keep/api/models/workflow.py
@@ -23,7 +23,7 @@ class ProviderDTO(BaseModel):
 
 class WorkflowDTO(BaseModel):
     id: str
-    name: str
+    name: Optional[str] = "Workflow file doesn't contain name"
     description: Optional[str] = "Workflow file doesn't contain description"
     created_by: str
     creation_time: datetime


### PR DESCRIPTION
## 📑 Description
If workflow name is `<null>` in db workflow page doesn't come up this PR aims to fix that.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
