### PR TITLE
fix: Validates New Relic provider api url has https #1152

### DIFF
--- a/keep-ui/app/providers/provider-form.tsx
+++ b/keep-ui/app/providers/provider-form.tsx
@@ -297,6 +297,9 @@ const ProviderForm = ({
         if (!response.ok) {
           // If the response is not okay, throw the error message
           return response_json.then((errorData) => {
+            if (response.status === 400) {
+              throw `${errorData.detail}`;
+            }
             if (response.status === 409) {
               throw `Provider with name ${formValues.provider_name} already exists`;
             }

--- a/keep/api/routes/providers.py
+++ b/keep/api/routes/providers.py
@@ -4,6 +4,8 @@ import logging
 import time
 import uuid
 from typing import Callable, Optional
+from keep.exceptions.provider_config_exception import ProviderConfigException
+from keep.exceptions.provider_exception import ProviderException
 
 import sqlalchemy
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
@@ -552,9 +554,15 @@ async def install_provider(
 
     # Instantiate the provider object and perform installation process
     context_manager = ContextManager(tenant_id=tenant_id)
-    provider = ProvidersFactory.get_provider(
-        context_manager, provider_id, provider_type, provider_config
-    )
+    try:
+        provider = ProvidersFactory.get_provider(
+            context_manager, provider_id, provider_type, provider_config
+        )
+    except (ProviderException, ProviderConfigException) as e:
+        raise HTTPException(
+            status_code=400,
+            detail=str(e)
+            )
 
     validated_scopes = validate_scopes(provider)
 

--- a/keep/providers/newrelic_provider/newrelic_provider.py
+++ b/keep/providers/newrelic_provider/newrelic_provider.py
@@ -124,8 +124,14 @@ class NewrelicProvider(BaseProvider):
         Raises:
             ProviderConfigException: user or account is missing in authentication.
             ProviderConfigException: private key
+            ProviderConfigException: new_relic_api_url must start with https
         """
         self.newrelic_config = NewrelicProviderAuthConfig(**self.config.authentication)
+        if (
+            self.newrelic_config.new_relic_api_url
+            and not self.newrelic_config.new_relic_api_url.startswith("https")
+        ):
+            raise ProviderException("New Relic API URL must start with https", self.provider_id)
 
     def __make_add_webhook_destination_query(self, url: str, name: str) -> dict:
         query = f"""mutation {{

--- a/keep/providers/newrelic_provider/newrelic_provider.py
+++ b/keep/providers/newrelic_provider/newrelic_provider.py
@@ -131,7 +131,7 @@ class NewrelicProvider(BaseProvider):
             self.newrelic_config.new_relic_api_url
             and not self.newrelic_config.new_relic_api_url.startswith("https")
         ):
-            raise ProviderException("New Relic API URL must start with https", self.provider_id)
+            raise ProviderConfigException("New Relic API URL must start with https", self.provider_id)
 
     def __make_add_webhook_destination_query(self, url: str, name: str) -> dict:
         query = f"""mutation {{


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1152

## 📑 Description
<!-- Add a brief description of the pr -->
Added a validation that the api url starts with 'https' in `validate_config` of `NewrelicProvider`.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Old behaviour - 
Earlier it used to show this error instead of validating url.
![image](https://github.com/keephq/keep/assets/56185464/b2ffe9bd-dbfe-4102-9c17-1c888b25392a)

New - 
Added `https` validation in the config, hence this meaningful `error_msg`.
![image](https://github.com/keephq/keep/assets/56185464/a182fa04-2981-4215-a7eb-b1d560f3469c)

- I am not sure if this is the expected fix.

Thanks
