### PR TITLE
fix: _notify and _query kwargs, params and UI step parameters/action params..

### DIFF
--- a/keep-ui/app/workflows/builder/editors.tsx
+++ b/keep-ui/app/workflows/builder/editors.tsx
@@ -51,6 +51,7 @@ interface keepEditorProps {
   updateProperty: (key: string, value: any) => void;
   installedProviders?: Provider[] | null | undefined;
   providerType?: string;
+  type?: string;
 }
 
 function KeepStepEditor({
@@ -58,10 +59,9 @@ function KeepStepEditor({
   updateProperty,
   installedProviders,
   providerType,
+  type,
 }: keepEditorProps) {
-  const stepParams = (properties.stepParams ??
-    properties.actionParams ??
-    []) as string[];
+  const stepParams = type?.includes("step-") ? properties.stepParams : properties.actionParams;
   const existingParams = Object.keys((properties.with as object) ?? {});
   const params = [...stepParams, ...existingParams];
   const uniqueParams = params.filter(
@@ -413,6 +413,7 @@ export default function StepEditor({
           updateProperty={setProperty}
           installedProviders={installedProviders}
           providerType={providerType}
+          type={type}
         />
       ) : type === "condition-threshold" ? (
         <KeepThresholdConditionEditor

--- a/keep/providers/axiom_provider/axiom_provider.py
+++ b/keep/providers/axiom_provider/axiom_provider.py
@@ -57,6 +57,7 @@ class AxiomProvider(BaseProvider):
 
     def _query(
         self,
+        dataset=None,
         datasets_api_url=None,
         organization_id=None,
         startTime=None,
@@ -79,7 +80,6 @@ class AxiomProvider(BaseProvider):
         if not organization_id:
             raise Exception("organization_id is required for Axiom provider")
 
-        dataset = kwargs.get("dataset")
         if not dataset:
             raise Exception("dataset is required for Axiom provider")
 

--- a/keep/providers/bash_provider/bash_provider.py
+++ b/keep/providers/bash_provider/bash_provider.py
@@ -19,14 +19,19 @@ class BashProvider(BaseProvider):
     def validate_config(self):
         pass
 
-    def _query(self, **kwargs):
+    def _query(
+            self,
+            timeout: int = 60,
+            command: str = "",
+            **kwargs
+            ):
         """Bash provider eval shell command to get results
 
         Returns:
             _type_: _description_
         """
-        timeout = kwargs.get("timeout", 60)
-        command = kwargs.get("command", "")
+        # timeout = kwargs.get("timeout", 60)
+        # command = kwargs.get("command", "")
         parsed_command = self.io_handler.parse(command)
         # parse by pipes
         parsed_commands = parsed_command.split("|")

--- a/keep/providers/cloudwatch_provider/cloudwatch_provider.py
+++ b/keep/providers/cloudwatch_provider/cloudwatch_provider.py
@@ -310,10 +310,16 @@ class CloudwatchProvider(BaseProvider):
             self.client = self.__generate_client(self.aws_client_type)
         return self._client
 
-    def _query(self, **kwargs: dict) -> dict:
-        log_group = kwargs.get("log_group")
-        query = kwargs.get("query")
-        hours = kwargs.get("hours", 24)
+    def _query(
+            self,
+            log_group: str = None,
+            query: str = None,
+            hours: int = 24,
+            **kwargs: dict
+            ) -> dict:
+        # log_group = kwargs.get("log_group")
+        # query = kwargs.get("query")
+        # hours = kwargs.get("hours", 24)
         logs_client = self.__generate_client("logs")
         try:
             start_query_response = logs_client.start_query(

--- a/keep/providers/console_provider/console_provider.py
+++ b/keep/providers/console_provider/console_provider.py
@@ -25,7 +25,11 @@ class ConsoleProvider(BaseProvider):
         # No need to dispose of anything, so just do nothing.
         pass
 
-    def _notify(self, **kwargs: dict):
+    def _notify(
+            self,
+            message: str = "",
+            **kwargs: dict
+            ):
         """
         Output alert message simply using the print method.
 
@@ -33,7 +37,7 @@ class ConsoleProvider(BaseProvider):
             alert_message (str): The alert message to be printed in to the console
         """
         self.logger.debug("Outputting alert message to console")
-        message = kwargs.get("alert_message")
+        # message = kwargs.get("alert_message")
         print(message)
         self.logger.debug("Alert message outputted to console")
         return message

--- a/keep/providers/github_workflows_provider/github_workflows_provider.py
+++ b/keep/providers/github_workflows_provider/github_workflows_provider.py
@@ -44,9 +44,14 @@ class GithubWorkflowsProvider(BaseProvider):
         """
         pass
 
-    def notify(self, **kwargs):
-        url = kwargs.pop("github_url")
-        method = kwargs.pop("github_method").upper()
+    def _notify(
+            self,
+            github_url: str = "",
+            github_method: str = "",
+            **kwargs
+            ):
+        url = github_url
+        method = github_method.upper()
 
         result = self.query(url=url, method=method, **kwargs)
 

--- a/keep/providers/gitlabpipelines_provider/gitlabpipelines_provider.py
+++ b/keep/providers/gitlabpipelines_provider/gitlabpipelines_provider.py
@@ -14,9 +14,9 @@ from keep.providers.models.provider_config import ProviderConfig
 
 
 @pydantic.dataclasses.dataclass
-class GitlabPipelinesProviderAuthConfig:
+class GitlabpipelinesProviderAuthConfig:
     """
-    GitlabPipelinesProviderAuthConfig is a class that represents the authentication configuration for the GitlabPipelinesProvider.
+    GitlabpipelinesProviderAuthConfig is a class that represents the authentication configuration for the GitlabPipelinesProvider.
     """
 
     access_token: str = dataclasses.field(
@@ -37,7 +37,7 @@ class GitlabpipelinesProvider(BaseProvider):
         super().__init__(context_manager, provider_id, config)
 
     def validate_config(self):
-        self.authentication_config = GitlabPipelinesProviderAuthConfig(
+        self.authentication_config = GitlabpipelinesProviderAuthConfig(
             **self.config.authentication
         )
 
@@ -47,10 +47,14 @@ class GitlabpipelinesProvider(BaseProvider):
         """
         pass
 
-    def notify(self, **kwargs):
-        url = kwargs.get("gitlab_url")
-        method = kwargs.get("gitlab_method")
-        method.upper()
+    def _notify(
+            self,
+            gitlab_url: str = "",
+            gitlab_method: str = "",
+            **kwargs
+            ):
+        url = gitlab_url
+        method = gitlab_method.upper()
 
         result = self.query(url=url, method=method, **kwargs)
 

--- a/keep/providers/google_chat_provider/google_chat_provider.py
+++ b/keep/providers/google_chat_provider/google_chat_provider.py
@@ -49,7 +49,7 @@ class GoogleChatProvider(BaseProvider):
         """
         pass
 
-    def notify(self, message="", **kwargs: dict):
+    def _notify(self, message="", **kwargs: dict):
         """
         Notify a message to a Google Chat room using a webhook URL.
 
@@ -79,6 +79,7 @@ class GoogleChatProvider(BaseProvider):
             )
 
         self.logger.debug("Alert message sent to Google Chat successfully")
+        return "Alert message sent to Google Chat successfully"
 
 
 if __name__ == "__main__":

--- a/keep/providers/http_provider/http_provider.py
+++ b/keep/providers/http_provider/http_provider.py
@@ -47,7 +47,7 @@ class HttpProvider(BaseProvider):
         No configuration to validate here
         """
 
-    def notify(
+    def _notify(
         self,
         url: str,
         method: typing.Literal["GET", "POST", "PUT", "DELETE"],

--- a/keep/providers/microsoft-planner-provider/microsoft-planner-provider.py
+++ b/keep/providers/microsoft-planner-provider/microsoft-planner-provider.py
@@ -115,7 +115,7 @@ class PlannerProvider(BaseProvider):
 
         return response_data
 
-    def notify(
+    def _notify(
         self,
         plan_id="",
         title="",

--- a/keep/providers/opsgenie_provider/opsgenie_provider.py
+++ b/keep/providers/opsgenie_provider/opsgenie_provider.py
@@ -179,7 +179,7 @@ class OpsgenieProvider(BaseProvider):
         """
         pass
 
-    def notify(
+    def _notify(
         self,
         user: str | None = None,
         note: str | None = None,

--- a/keep/providers/pagerduty_provider/pagerduty_provider.py
+++ b/keep/providers/pagerduty_provider/pagerduty_provider.py
@@ -119,6 +119,7 @@ class PagerdutyProvider(BaseProvider):
 
         self.logger.debug("Alert status: %s", result.status_code)
         self.logger.debug("Alert response: %s", result.text)
+        return result.text
 
     def _trigger_incident(
         self,
@@ -155,6 +156,7 @@ class PagerdutyProvider(BaseProvider):
 
         print(f"Status Code: {r.status_code}")
         print(r.json())
+        return r.json()
 
     def dispose(self):
         """
@@ -284,7 +286,7 @@ class PagerdutyProvider(BaseProvider):
             service=service,
         )
 
-    def notify(
+    def _notify(
         self,
         title: str = "",
         alert_body: str = "",
@@ -303,9 +305,9 @@ class PagerdutyProvider(BaseProvider):
             kwargs (dict): The providers with context
         """
         if self.authentication_config.routing_key:
-            self._send_alert(title, alert_body, dedup=dedup, **kwargs)
+            return self._send_alert(title, alert_body, dedup=dedup, **kwargs)
         else:
-            self._trigger_incident(
+            return self._trigger_incident(
                 service_id, title, alert_body, requester, incident_id, **kwargs
             )
 

--- a/keep/providers/pagertree_provider/pagertree_provider.py
+++ b/keep/providers/pagertree_provider/pagertree_provider.py
@@ -179,7 +179,7 @@ class PagertreeProvider(BaseProvider):
         self.logger.info("Incident status: %s", response.status_code)
         self.logger.info("Incident created successfully", response.json())
 
-    def notify(self,
+    def _notify(self,
                title: str,
                urgency: Literal["low", "medium", "high", "critical"],
                incident: bool = False,

--- a/keep/providers/postgres_provider/postgres_provider.py
+++ b/keep/providers/postgres_provider/postgres_provider.py
@@ -103,14 +103,17 @@ class PostgresProvider(BaseProvider):
             **self.config.authentication
         )
 
-    def _query(self, **kwargs: dict) -> list | tuple:
+    def _query(
+            self,
+            query: str,
+            **kwargs: dict
+            ) -> list | tuple:
         """
         Executes a query against the Postgres database.
 
         Returns:
             list | tuple: list of results or single result if single_row is True
         """
-        query = kwargs.get("query")
         if not query:
             raise ValueError("Query is required")
 
@@ -131,12 +134,15 @@ class PostgresProvider(BaseProvider):
             # Close the database connection
             conn.close()
 
-    def notify(self, **kwargs):
+    def _notify(
+            self,
+            query: str,
+            **kwargs
+            ):
         """
         Notifies the Postgres database.
         """
         # notify and query are the same for Postgres
-        query = kwargs.get("query")
         if not query:
             raise ValueError("Query is required")
 

--- a/keep/providers/python_provider/python_provider.py
+++ b/keep/providers/python_provider/python_provider.py
@@ -22,14 +22,18 @@ class PythonProvider(BaseProvider):
     def validate_config(self):
         pass
 
-    def _query(self, **kwargs):
+    def _query(
+            self,
+            code: str = "",
+            imports: str = "",
+            **kwargs
+            ):
         """Python provider eval python code to get results
 
         Returns:
             _type_: _description_
         """
-        code = kwargs.pop("code", "")
-        modules = kwargs.pop("imports", "")
+        modules = imports
         loaded_modules = {}
         for module in modules.split(","):
             try:

--- a/keep/providers/telegram_provider/telegram_provider.py
+++ b/keep/providers/telegram_provider/telegram_provider.py
@@ -44,7 +44,12 @@ class TelegramProvider(BaseProvider):
         """
         pass
 
-    async def _notify(self, **kwargs: dict):
+    async def _notify(
+            self,
+            chat_id: str = "",
+            message: str = "",
+            **kwargs: dict
+            ):
         """
         Notify alert message to Telegram using the Telegram Bot API
         https://core.telegram.org/bots/api
@@ -53,8 +58,6 @@ class TelegramProvider(BaseProvider):
             kwargs (dict): The providers with context
         """
         self.logger.debug("Notifying alert message to Telegram")
-        chat_id = kwargs.pop("chat_id", "")
-        message = kwargs.pop("message", [])
 
         if not chat_id:
             raise ProviderException(

--- a/keep/providers/trello_provider/trello_provider.py
+++ b/keep/providers/trello_provider/trello_provider.py
@@ -47,7 +47,12 @@ class TrelloProvider(BaseProvider):
         """
         pass
 
-    def _query(self, **kwargs: dict):
+    def _query(
+            self,
+            board_id: str = "",
+            filter: str = "createCard",
+            **kwargs: dict
+            ):
         """
         Notify alert message to Slack using the Slack Incoming Webhook API
         https://api.slack.com/messaging/webhooks
@@ -59,9 +64,6 @@ class TrelloProvider(BaseProvider):
 
         trello_api_key = self.authentication_config.api_key
         trello_api_token = self.authentication_config.api_token
-
-        board_id = kwargs.pop("board_id", "")
-        filter = kwargs.pop("filter", "createCard")
 
         request_url = f"https://api.trello.com/1/boards/{board_id}/actions?key={trello_api_key}&token={trello_api_token}&filter={filter}"
         response = requests.get(request_url)

--- a/keep/providers/twilio_provider/twilio_provider.py
+++ b/keep/providers/twilio_provider/twilio_provider.py
@@ -111,14 +111,17 @@ class TwilioProvider(BaseProvider):
         """
         pass
 
-    def _notify(self, **kwargs: dict):
+    def _notify(
+            self,
+            message_body: str = "",
+            to_phone_number: str = "",
+            **kwargs: dict
+            ):
         """
         Notify alert with twilio SMS
         """
         # extract the required params
         self.logger.debug("Notifying alert SMS via Twilio")
-        message_body = kwargs.get("message_body", "")
-        to_phone_number = kwargs.get("to_phone_number", "")
 
         if not to_phone_number:
             raise ProviderException(

--- a/keep/providers/zenduty_provider/zenduty_provider.py
+++ b/keep/providers/zenduty_provider/zenduty_provider.py
@@ -37,7 +37,15 @@ class ZendutyProvider(BaseProvider):
         """
         pass
 
-    def _notify(self, **kwargs: dict):
+    def _notify(
+            self,
+            title: str = "",
+            summary: str = "",
+            service: str = "",
+            user: str = "",
+            policy: str = "",
+            **kwargs: dict
+            ):
         """
         Create incident Zenduty using the Zenduty API
 
@@ -47,11 +55,6 @@ class ZendutyProvider(BaseProvider):
             kwargs (dict): The providers with context
         """
         self.logger.debug("Notifying incident to Zenduty")
-        title = kwargs.pop("title", "")
-        summary = kwargs.pop("summary", "")
-        user = kwargs.pop("user", None)
-        service = kwargs.pop("service", "")
-        policy = kwargs.pop("policy", "")
 
         if not service:
             raise ProviderException("Service is required")


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1179

## 📑 Description
<!-- Add a brief description of the pr -->
1. Fixed the parameters for `_notify` and `_query` for the providers which were using `**kwargs`.
2. Fixed UI for the workflow builder page, video attached here - #1179 
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

1. AxiomProvider - 
    1. _query - 
        1. dataset
2. BashProvider - 
    1. _query - 
        1. timeout, command
3. CloudwatchProvider -
    1.  _query - 
        1. log_group, query, hours
4. ConsoleProvider -
    1. _notify -
        1. message
5. GithubWorkflowsProvider -
    1. changed notify -> _notify, removed usage of kwargs to parameters -
        1. github_url
        2. github_method
6. GitlabpipelinsProvider - 
    1. fixed spelling of it’s AuthConfig class, which was causing no parameters to appear in UI.
    2. changed notify -> _notify, moved kwargs to parameters -
        1. github_url
        2. github_method
7. GoogleChatProvider -
    1. changed notify -> _notify
8. HttpProvider - 
    1. changed notify -> _notify
9. PlannerProvider - 
    1. changed notify -> _notify
10. OpsgenieProvider - 
    1. changed notify -> _notify
11. PagerdutyProvider - 
    1. changed notify -> _notify and fixed returning values properly
12. PagertreeProvider - 
    1. changed notify -> _notify
13. PostgresProvider - 
    1. changed notify -> _notify, added params instead of kwargs
        1. query
    2. _query - added params instead of kwargs
        1. query
14. PythonProvider - 
    1. _query -> added params
        1. code
        2. imports
15. TelegramProvider - 
    1. _notify -> added params
        1. chat_id
        2. message
16. TrelloProvider - 
    1. _query -> added params
        1. board_id
        2. filter
17. TwilioProvider - 
    1. _notify -> added params - 
        1. message_body
        2. to_phone_number
18. ZendutyProvider - 
    1. _notify -> added params - 
        1. title
        2. summary
        3. service
        4. user
        5. policy

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
