### PR TITLE
chore(provider): PagerDuty scopes added and fix: mongodb connection check

### DIFF
--- a/docs/providers/documentation/pagerduty-provider.mdx
+++ b/docs/providers/documentation/pagerduty-provider.mdx
@@ -5,25 +5,19 @@ description: "Pagerduty Provider is a provider that allows to create incidents o
 
 ## Inputs
 
-The `notify` function in the `PagerdutyProvider` class takes the following parameters:
-
-```python
-kwargs (dict):
-    title (str): Title of the alert or incident. *Required*
-    alert_body (str): UTF-8 string of custom message for alert. Shown in incident body for events, and in the body for incidents. *Required for events, optional for incidents*
-    dedup (str | None): Any string, max 255 characters, used to deduplicate alerts for events. *Required for events, optional for incidents*
-    service_id (str): ID of the service for incidents. *Required for incidents, optional for events*
-    body (dict): Body of the incident. *Required for incidents, optional for events*
-    requester (str): Requester of the incident. *Required for incidents, optional for events*
-    incident_key (str | None): Key to identify the incident. If not given, a UUID will be generated. *Required for incidents, optional for events*
-```
+- `title`: str: Title of the alert or incident.
+- `alert_body`: str: UTF-8 string of custom message for alert. Shown in incident body for events, and in the body for incidents.
+- `dedup`: str | None: Any string, max 255 characters, used to deduplicate alerts for events.
+- `service_id`: str: ID of the service for incidents.
+- `body`: dict: Body of the incident.
+- `requester`: str: Requester of the incident.
+- `incident_key`: str | None: Key to identify the incident. If not given, a UUID will be generated.
 
 ## Authentication Parameters
 
-The PagerdutyProviderAuthConfig class takes the following parameters:
-python
-routing*key (str | None): Routing key, which is an integration or ruleset key. Optional, default is `None`. \_Required for events, optional for incidents*_No
-api*key (str | None): API key, which is a user or team API key. Optional, default is `None`. \_Required for incidents, optional for events*_
+The `api_key` or `routing_key` are required for connecting to the Pagerduty provider. You can obtain them as described in the "Connecting with the Provider" section.
+
+Routing key, which is an integration or ruleset key. API key, which is a user or team API key.
 
 ## Connecting with the Provider
 
@@ -34,6 +28,26 @@ You can find your API key in the PagerDuty web app under **Configuration** > **A
 
 The routing_key is used to post events to Pagerduty using the events API.
 The api_key is used to create incidents using the incidents API.
+
+## Scopes
+
+Certain scopes may be required to perform specific actions or queries via the Pagerduty Provider. Below is a summary of relevant scopes and their use cases:
+
+- incidents_read (Incidents Read)
+    Required: True
+    Description: View incidents.
+- incidents_write (Incidents Write)
+    Required: False
+    Description: Write incidents.
+- webhook_subscriptions_read (Webhook Subscriptions Read)
+    Required: False
+    Description: View webhook subscriptions.
+    (*Required for auto-webhook integration)
+- webhook_subscriptions_write (Webhook Subscriptions Write)
+    Required: False
+    Description: Write webhook subscriptions.
+    (*Required for auto-webhook integration)
+
 
 ## Notes
 

--- a/keep/providers/mongodb_provider/mongodb_provider.py
+++ b/keep/providers/mongodb_provider/mongodb_provider.py
@@ -77,6 +77,7 @@ class MongodbProvider(BaseProvider):
         """
         try:
             client = self.__generate_client()
+            client.admin.command('ping') # will raise an exception if the server is not available
             client.close()
             scopes = {
                 "connect_to_server": True,
@@ -84,7 +85,7 @@ class MongodbProvider(BaseProvider):
         except Exception as e:
             self.logger.exception("Error validating scopes")
             scopes = {
-                "connect_to_server": str(e),
+                "connect_to_server": "Unable to connect to server. Please check the connection details.",
             }
         return scopes
 
@@ -117,7 +118,7 @@ class MongodbProvider(BaseProvider):
             and k != "additional_options"  # additional_options will go seperately
             and k != "database"
         }  # database is not a valid mongo option
-        client = MongoClient(**client_conf, **additional_options)
+        client = MongoClient(**client_conf, **additional_options, serverSelectionTimeoutMS=10000) # 10 seconds timeout
         return client
 
     def dispose(self):

--- a/keep/providers/mongodb_provider/mongodb_provider.py
+++ b/keep/providers/mongodb_provider/mongodb_provider.py
@@ -82,7 +82,7 @@ class MongodbProvider(BaseProvider):
             scopes = {
                 "connect_to_server": True,
             }
-        except Exception as e:
+        except Exception:
             self.logger.exception("Error validating scopes")
             scopes = {
                 "connect_to_server": "Unable to connect to server. Please check the connection details.",

--- a/keep/providers/pagerduty_provider/pagerduty_provider.py
+++ b/keep/providers/pagerduty_provider/pagerduty_provider.py
@@ -127,7 +127,7 @@ class PagerdutyProvider(BaseProvider):
                 else:
                     scopes[scope.name] = response.reason
             except Exception as e:
-                self.logger.error("Error validating scopes", extra={"error": str(e)})
+                self.logger.exception("Error validating scopes")
                 scopes[scope.name] = str(e)
         return scopes
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1031 and #903

## 📑 Description
<!-- Add a brief description of the pr -->
Added `validate_scopes` for `PagerdutyProvider`. 
Included the following scopes - 
1. `incidents.read`
2. `incidents.write`
3. `webhook_subscriptions.read`
4. `webhook_subscriptions.write`
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
- [x] Scopes added and created `validate_scopes`
- [x] Edit Documentation - Add Scopes, Edit Inputs and Authentication Parameters

Also fixed mongodb always validating scopes.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Pagerduty - 
If api key is wrong (Unauthorized) - 
![image](https://github.com/keephq/keep/assets/56185464/e9628c63-6f58-48cc-ae8e-98a55c96ef6d)

If valid api key and authorized - 
![image](https://github.com/keephq/keep/assets/56185464/989bb162-8921-48ad-8cc7-f4a76f363873)


Mongodb - 
If wrong URI - 
![image](https://github.com/keephq/keep/assets/56185464/f1874b81-4a68-4acc-8a11-094d573c445f)

If right URI -
![image](https://github.com/keephq/keep/assets/56185464/217a053e-c0f2-4747-b1fe-380b8ff31073)
