### PR TITLE
Ilya faynzilber cloudwwatch provider fix

### DIFF
--- a/keep/api/api.py
+++ b/keep/api/api.py
@@ -16,6 +16,7 @@ from starlette_context.middleware import RawContextMiddleware
 
 import keep.api.logging
 import keep.api.observability
+from keep.exceptions.config_exception import ConfigException
 from keep.api.core.config import AuthenticationType
 from keep.api.core.db import get_user
 from keep.api.core.dependencies import SINGLE_TENANT_UUID
@@ -129,6 +130,9 @@ def get_app(
     if not os.environ.get("KEEP_API_URL", None):
         os.environ["KEEP_API_URL"] = f"http://{HOST}:{PORT}"
         logger.info(f"Starting Keep with {os.environ['KEEP_API_URL']} as URL")
+    elif os.environ.get("KEEP_API_URL").startswith("http://") and HOST != "0.0.0.0":
+        logger.warning("Wrong protocol for KEEP_API_URL")
+        raise ConfigException("For production KEEP Api must use HTTPS not HTTP")
 
     app = FastAPI(
         title="Keep API",

--- a/keep/api/api.py
+++ b/keep/api/api.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from importlib import metadata
+from typing import Type
 
 import jwt
 import uvicorn
@@ -125,12 +126,12 @@ class EventCaptureMiddleware(BaseHTTPMiddleware):
 
 
 def get_app(
-    auth_type: AuthenticationType = AuthenticationType.NO_AUTH.value,
+    auth_type: AuthenticationType = AuthenticationType.NO_AUTH.value
 ) -> FastAPI:
     if not os.environ.get("KEEP_API_URL", None):
         os.environ["KEEP_API_URL"] = f"http://{HOST}:{PORT}"
         logger.info(f"Starting Keep with {os.environ['KEEP_API_URL']} as URL")
-    elif os.environ.get("KEEP_API_URL").startswith("http://") and HOST != "0.0.0.0":
+    if os.environ.get("KEEP_API_URL").startswith("http://") and HOST != "0.0.0.0":
         logger.warning("Wrong protocol for KEEP_API_URL")
         raise ConfigException("For production KEEP Api must use HTTPS not HTTP")
 

--- a/keep/api/routes/providers.py
+++ b/keep/api/routes/providers.py
@@ -765,7 +765,8 @@ def install_provider_webhook(
     provider = ProvidersFactory.get_provider(
         context_manager, provider_id, provider_type, provider_config
     )
-    api_url = config("KEEP_API_URL")
+    api_url = config("WEBHOOK_URL", None)
+    api_url = config("KEEP_API_URL") if not api_url else api_url
     keep_webhook_api_url = (
         f"{api_url}/alerts/event/{provider_type}?provider_id={provider_id}"
     )

--- a/keep/exceptions/config_exception.py
+++ b/keep/exceptions/config_exception.py
@@ -1,0 +1,6 @@
+class ConfigException(Exception):
+    """ Exception for configuration errors """
+    def __init__(self, messoge: str, *args: object):
+        super().__init__(messoge, args)
+
+

--- a/tests/test_api_url_protocol.py
+++ b/tests/test_api_url_protocol.py
@@ -1,0 +1,32 @@
+import os
+from pathlib import Path
+from typing import List
+
+import pytest
+from fastapi.testclient import TestClient
+from keep.api import api
+from keep.exceptions.config_exception import ConfigException
+
+
+def set_env(lines: List[str]):
+    env_file = Path(__file__).parent / ".env"
+    with open(env_file, "w") as f:
+        f.write("\n".join(lines))
+
+
+def test_get_app_lc_host():
+    env_file = Path(__file__).parent / ".env"
+    env_file.touch()
+    list_lines = ["KEEP_API_URL=http://example.com", "KEEP_HOST=0.0.0.0", "PORT=8080"]
+    set_env(list_lines)
+    a = TestClient(api.get_app())
+
+
+def test_get_app_not_lc_host_raise_exception():
+    env_file = Path(__file__).parent.parent / ".env"
+    env_file.touch()
+    list_lines = ["KEEP_API_URL=http://example.com", "KEEP_HOST=8.8.8.8", "PORT=8080"]
+    set_env(list_lines)
+    with pytest.raises(ConfigException) as exc_info:
+        a = TestClient(api.get_app())
+    env_file.unlink()

--- a/tests/test_cloudwatch_provider.py
+++ b/tests/test_cloudwatch_provider.py
@@ -1,0 +1,30 @@
+import pytest
+
+from keep.exceptions.config_exception import ConfigException
+from keep.providers.cloudwatch_provider.cloudwatch_provider import CloudwatchProvider
+import logging
+
+
+@pytest.mark.parametrize(
+    "wh_url, api_key, expected_result, expected_exception",
+    [
+        ("http://test_utl", "1212s", "http://api_key:1212s@test_utl", None),
+        ("https://test_utl", "1212s", "https://api_key:1212s@test_utl", None),
+        ("wronghttp://api_key:1212s@test_utl", "1212s", None, ConfigException)
+    ]
+)
+def test_add_credentials_to_wh_url(wh_url, api_key, expected_result, expected_exception):
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            url = CloudwatchProvider.add_credentials_to_wh_url(
+                logging.getLogger(__file__),
+                webhook_url=wh_url,
+                api_key=api_key
+            )
+    else:
+        url = CloudwatchProvider.add_credentials_to_wh_url(
+            logging.getLogger(__file__),
+            webhook_url=wh_url,
+            api_key=api_key
+        )
+        assert url == expected_result


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
Here is my implementation for https://github.com/keephq/keep/issues/395
## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ v] My pull request adheres to the code style of this project
- [ v] My code requires changes to the documentation
- [ v] All the tests have passed

## ℹ Additional Information
After talking to Shahar it was decided to add additional environment variable: WEBHOOK_URL, if it was provided then exactly this url will be used for web hook purpose , if not - default KEEP_API_URL will be used; This change solutes the problem of static protocol value for SNS subscription and allows to use reverse proxy;
Also upon start api.get_app() function also checks if KEEP_API_URL uses HTTPS only (this specification was also mentioned by Shahar)
