### PR TITLE
fix: "no such column updated_at" during extraction creating

### DIFF
--- a/keep/api/models/db/extraction.py
+++ b/keep/api/models/db/extraction.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from pydantic import BaseModel
+from sqlalchemy import DateTime
 from sqlalchemy.sql import func
 from sqlmodel import Column, Field, SQLModel
 
@@ -15,7 +16,12 @@ class ExtractionRule(SQLModel, table=True):
     created_by: Optional[str] = Field(max_length=255)
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
     updated_by: Optional[str] = Field(max_length=255)
-    updated_at: Optional[datetime] = Column(name="updated_at", onupdate=func.now())
+    updated_at: Optional[datetime] = Field(
+        sa_column=Column(
+            DateTime(timezone=True), name="updated_at",
+            onupdate=func.now(), server_default=func.now()
+        )
+    )
     disabled: bool = Field(default=False)
     pre: bool = Field(default=False)
     condition: Optional[str] = Field(max_length=2000)  # cel

--- a/keep/api/routes/extraction.py
+++ b/keep/api/routes/extraction.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException

--- a/keep/api/routes/extraction.py
+++ b/keep/api/routes/extraction.py
@@ -77,7 +77,6 @@ def update_extraction_rule(
     for key, value in rule_dto.dict(exclude_unset=True).items():
         setattr(rule, key, value)
     rule.updated_by = authenticated_entity.email
-    rule.updated_at = datetime.datetime.now(datetime.timezone.utc)
     session.commit()
     session.refresh(rule)
     return ExtractionRuleDtoOut(**rule.dict())

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -1,0 +1,62 @@
+import hashlib
+import importlib
+import sys
+
+import pytest
+
+from fastapi.testclient import TestClient
+
+from keep.api.core.dependencies import SINGLE_TENANT_UUID
+from keep.api.models.db.tenant import TenantApiKey
+
+
+@pytest.fixture
+def test_app(monkeypatch, request):
+    auth_type = request.param
+    monkeypatch.setenv("AUTH_TYPE", auth_type)
+    monkeypatch.setenv("KEEP_JWT_SECRET", "somesecret")
+    # Ok this is bit complex so stay with me:
+    #   We need to reload the app to make sure the AuthVerifier is instantiated with the correct environment variable
+    #   However, we can't just reload the module because the app is instantiated in the get_app() function
+    #    So we need to delete the module from sys.modules and re-import it
+
+    # First, delete all the routes modules from sys.modules
+    for module in list(sys.modules):
+        if module.startswith("keep.api.routes"):
+            del sys.modules[module]
+    # Second, delete the api module from sys.modules
+    if "keep.api.api" in sys.modules:
+        importlib.reload(sys.modules["keep.api.api"])
+
+    # Now, import it, and it will re-instantiate the app with the correct environment variable
+    from keep.api.api import get_app
+
+    # Finally, return the app
+    app = get_app()
+    return app
+
+
+# Fixture for TestClient using the test_app fixture
+@pytest.fixture
+def client(test_app, db_session, monkeypatch):
+    # disable pusher
+    monkeypatch.setenv("PUSHER_DISABLED", "true")
+    return TestClient(test_app)
+
+
+
+# Common setup for tests
+def setup_api_key(
+    db_session, api_key_value, tenant_id=SINGLE_TENANT_UUID, role="admin"
+):
+    hash_api_key = hashlib.sha256(api_key_value.encode()).hexdigest()
+    db_session.add(
+        TenantApiKey(
+            tenant_id=tenant_id,
+            reference_id="test_api_key",
+            key_hash=hash_api_key,
+            created_by="admin@keephq",
+            role=role,
+        )
+    )
+    db_session.commit()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,14 +1,11 @@
-import hashlib
-import importlib
 import os
-import sys
 from unittest.mock import patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 from keep.api.core.dependencies import SINGLE_TENANT_UUID
-from keep.api.models.db.tenant import TenantApiKey
+
+from tests.fixtures.client import test_app, client, setup_api_key
 
 MOCK_TOKEN = "MOCKTOKEN"
 
@@ -28,40 +25,6 @@ class MockJWKClient:
 def mock_get_signing_key_from_jwt(token):
     # Return a mock key. Adjust the value as needed for your tests.
     return MockSigningKey(key="mock_key")
-
-
-@pytest.fixture
-def test_app(monkeypatch, request):
-    auth_type = request.param
-    monkeypatch.setenv("AUTH_TYPE", auth_type)
-    monkeypatch.setenv("KEEP_JWT_SECRET", "somesecret")
-    # Ok this is bit complex so stay with me:
-    #   We need to reload the app to make sure the AuthVerifier is instantiated with the correct environment variable
-    #   However, we can't just reload the module because the app is instantiated in the get_app() function
-    #    So we need to delete the module from sys.modules and re-import it
-
-    # First, delete all the routes modules from sys.modules
-    for module in list(sys.modules):
-        if module.startswith("keep.api.routes"):
-            del sys.modules[module]
-    # Second, delete the api module from sys.modules
-    if "keep.api.api" in sys.modules:
-        importlib.reload(sys.modules["keep.api.api"])
-
-    # Now, import it, and it will re-instantiate the app with the correct environment variable
-    from keep.api.api import get_app
-
-    # Finally, return the app
-    app = get_app()
-    return app
-
-
-# Fixture for TestClient using the test_app fixture
-@pytest.fixture
-def client(test_app, db_session, monkeypatch):
-    # disable pusher
-    monkeypatch.setenv("PUSHER_DISABLED", "true")
-    return TestClient(test_app)
 
 
 def get_mock_jwt_payload(token, *args, **kwargs):
@@ -87,22 +50,6 @@ def get_mock_jwt_payload(token, *args, **kwargs):
         # Default payload or raise an exception if needed
         return {}
 
-
-# Common setup for tests
-def setup_api_key(
-    db_session, api_key_value, tenant_id=SINGLE_TENANT_UUID, role="admin"
-):
-    hash_api_key = hashlib.sha256(api_key_value.encode()).hexdigest()
-    db_session.add(
-        TenantApiKey(
-            tenant_id=tenant_id,
-            reference_id="test_api_key",
-            key_hash=hash_api_key,
-            created_by="admin@keephq",
-            role=role,
-        )
-    )
-    db_session.commit()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_extraction_rules.py
+++ b/tests/test_extraction_rules.py
@@ -1,0 +1,81 @@
+from time import sleep
+
+import pytest
+
+from isodate import parse_datetime
+
+from tests.fixtures.client import client, test_app, setup_api_key
+
+VALID_API_KEY = "valid_api_key"
+
+
+@pytest.mark.parametrize(
+    "test_app", ["NO_AUTH"], indirect=True
+)
+def test_create_extraction_rule(client, test_app, db_session):
+    setup_api_key(db_session, VALID_API_KEY, role="webhook")
+
+    # Try to create invalid extraction
+    invalid_rule_dict = {}
+    response = client.post(
+        "/extraction", json=invalid_rule_dict, headers={"x-api-key": VALID_API_KEY}
+    )
+    assert response.status_code == 422
+
+    valid_rule_dict = {
+        "name": "rule",
+        "attribute": "test",
+        "regex": "(?P<test>.*)",
+    }
+    response = client.post(
+        "/extraction", json=valid_rule_dict, headers={"x-api-key": VALID_API_KEY}
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "test_app", ["NO_AUTH"], indirect=True
+)
+def test_extraction_rule_updated_at(client, test_app, db_session):
+    setup_api_key(db_session, VALID_API_KEY, role="webhook")
+
+    rule_dict = {
+        "name": "rule",
+        "attribute": "test",
+        "regex": "(?P<test>.*)",
+    }
+    # Creating an extraction
+    response = client.post(
+        "/extraction", json=rule_dict, headers={"x-api-key": VALID_API_KEY}
+    )
+    assert response.status_code == 200
+
+    response_data = response.json()
+
+    assert "id" in response_data
+    assert "updated_at" in response_data
+
+    rule_id = response_data["id"]
+    updated_at = parse_datetime(response_data["updated_at"])
+    updated_rule_dict = {
+        "name": "rule2",
+        "attribute": "test",
+        "regex": "(?P<test>.*)",
+    }
+    # Taking a deep breath before updating, to ensure updated_at will change
+    # Without it update can happen in the same second, so we will not see any changes
+    sleep(1)
+    updated_response = client.put(
+        f"/extraction/{rule_id}", json=updated_rule_dict, headers={"x-api-key": VALID_API_KEY}
+    )
+
+    assert updated_response.status_code == 200
+
+    updated_response_data = updated_response.json()
+    new_updated_at = parse_datetime(updated_response_data["updated_at"])
+
+    assert new_updated_at > updated_at
+
+
+
+


### PR DESCRIPTION
## 📑 Description

While creating extraction rule it was throwing SQL error:

```json
{
    "message": "An internal server error occurred.",
    "trace_id": "x",
    "error_msg": "(sqlite3.OperationalError) no such column: updated_at\n[SQL: INSERT INTO extractionrule (tenant_id, priority, name, description, created_by, created_at, updated_by, updated_at, disabled, pre, condition, attribute, regex) VALUES (?, ?, ?, ?, ?, ?, ?, updated_at, ?, ?, ?, ?, ?) /*db_driver='pysqlite',db_framework='sqlalchemy%%3A0.41b0',traceparent='x'*/]\n[parameters: ('keep', 0, 'asd', 'asd', 'admin@keephq', '2024-04-20 12:30:39.005900', None, 0, 0, '', 'asd', '(?P<groupname>)')]\n(Background on this error at: https://sqlalche.me/e/14/e3q8)"
}
```

The issue was already mentioned in PR https://github.com/keephq/keep/pull/1132, but the solution was just bypassing consequences.

The problem here was in using sa.Column instance directly, without wrapping it with Field. As a result, when no value for updated_at was provided during the SQL query string generation, the engine treated this Column as an expression. Like if we were doing INSERT INTO SELECT. 

`VALUES (?, ?, ?, ?, ?, ?, ?, updated_at, ?, ?, ?, ?, ?)` <- SQL engine is trying to find column `updated_at` in our INSERT statement (not in target table), and of course can't. That's why we have `no such column: updated_at` - this is not about the field in the table but the virtual field in the request.


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

1. I extracted some functions to a separate module to re-use test_app and client, created in test_auth.
2. The original goal of using Column for update_at was to make this field automatically updated. But I see some inconsistency here with [MappingRule.last_updated_at](https://github.com/keephq/keep/blob/main/keep/api/models/db/mapping.py#L29). Sould we align then to have the same behavior?