### PR TITLE
chore: remove deprecated utcnow

### DIFF
--- a/docs/workflows/functions/datetime-compare.mdx
+++ b/docs/workflows/functions/datetime-compare.mdx
@@ -23,6 +23,6 @@ def datetime_compare(t1: datetime, t2: datetime) -> int:
     return int((t1 - t2).total_seconds())
 
 # Example usage:
-# t1 = datetime.utcnow()
-# t2 = datetime.utcnow() - timedelta(hours=2)
+# t1 = datetime.now(tz=timezone.utc)
+# t2 = datetime.now(tz=timezone.utc) - timedelta(hours=2)
 # print(datetime_compare(t1, t2))  # Should return 7200 (2 hours * 3600 seconds)

--- a/keep/api/models/__init__.py
+++ b/keep/api/models/__init__.py
@@ -1,0 +1,5 @@
+from datetime import datetime, timezone
+
+
+def utcnow():
+    return datetime.now(tz=timezone.utc)

--- a/keep/api/models/db/alert.py
+++ b/keep/api/models/db/alert.py
@@ -90,8 +90,8 @@ class Alert(SQLModel, table=True):
     #            todo: on MSSQL, the index is "nonclustered" index which cannot be controlled by SQLModel
     timestamp: datetime = Field(
         sa_column=Column(datetime_column_type, index=True, nullable=False),
-        default_factory=lambda: datetime.utcnow().replace(
-            microsecond=int(datetime.utcnow().microsecond / 1000) * 1000
+        default_factory=lambda: datetime.now(tz=timezone.utc).replace(
+            microsecond=int(datetime.now(tz=timezone.utc).microsecond / 1000) * 1000
         ),
     )
     provider_type: str

--- a/keep/api/models/db/alert.py
+++ b/keep/api/models/db/alert.py
@@ -13,6 +13,7 @@ from sqlmodel import JSON, Column, DateTime, Field, Relationship, SQLModel
 
 from keep.api.consts import RUNNING_IN_CLOUD_RUN
 from keep.api.core.config import config
+from keep.api.models import utcnow
 from keep.api.models.db.tenant import Tenant
 
 db_connection_string = config("DATABASE_CONNECTION_STRING", default=None)
@@ -45,7 +46,7 @@ else:
 # many to many map between alerts and groups
 class AlertToGroup(SQLModel, table=True):
     tenant_id: str = Field(foreign_key="tenant.id")
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=utcnow)
     alert_id: UUID = Field(foreign_key="alert.id", primary_key=True)
     group_id: UUID = Field(
         sa_column=Column(
@@ -64,7 +65,7 @@ class Group(SQLModel, table=True):
             UUIDType(binary=False), ForeignKey("rule.id", ondelete="CASCADE")
         ),
     )
-    creation_time: datetime = Field(default_factory=datetime.utcnow)
+    creation_time: datetime = Field(default_factory=utcnow)
     # the instance of the grouping criteria
     # e.g. grouping_criteria = ["event.labels.queue", "event.labels.cluster"] => group_fingerprint = "queue1,cluster1"
 
@@ -121,7 +122,7 @@ class Alert(SQLModel, table=True):
 class AlertEnrichment(SQLModel, table=True):
     id: UUID = Field(default_factory=uuid4, primary_key=True)
     tenant_id: str = Field(foreign_key="tenant.id")
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=utcnow)
     alert_fingerprint: str = Field(unique=True)
     enrichments: dict = Field(sa_column=Column(JSON))
 

--- a/keep/api/models/db/alert.py
+++ b/keep/api/models/db/alert.py
@@ -1,6 +1,6 @@
 import hashlib
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 from uuid import UUID, uuid4
 

--- a/keep/api/models/db/dashboard.py
+++ b/keep/api/models/db/dashboard.py
@@ -5,6 +5,8 @@ from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSON
 from sqlmodel import Column, Field, SQLModel
 
+from keep.api.models import utcnow
+
 
 class Dashboard(SQLModel, table=True):
     id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True)
@@ -12,9 +14,9 @@ class Dashboard(SQLModel, table=True):
     dashboard_name: str = Field(index=True)  # Index for faster uniqueness checks
     dashboard_config: dict = Field(sa_column=Column(JSON))
     created_by: str = Field(default=None)
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=utcnow)
     updated_by: str = Field(default=None)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=utcnow)
     is_active: bool = Field(default=True)
     is_private: bool = Field(default=False)
 

--- a/keep/api/models/db/mapping.py
+++ b/keep/api/models/db/mapping.py
@@ -4,6 +4,8 @@ from typing import Optional
 from pydantic import BaseModel
 from sqlmodel import JSON, Column, Field, SQLModel
 
+from keep.api.models import utcnow
+
 
 class MappingRule(SQLModel, table=True):
     id: Optional[int] = Field(primary_key=True, default=None)
@@ -26,7 +28,7 @@ class MappingRule(SQLModel, table=True):
         nullable=False,
     )  # max_length=204800)
     updated_by: Optional[str] = Field(max_length=255, default=None)
-    last_updated_at: datetime = Field(default_factory=datetime.utcnow)
+    last_updated_at: datetime = Field(default_factory=utcnow)
 
 
 class MappRuleDtoBase(BaseModel):

--- a/keep/api/models/db/tenant.py
+++ b/keep/api/models/db/tenant.py
@@ -1,8 +1,10 @@
+from datetime import datetime
 from typing import List, Optional
 from uuid import UUID, uuid4
-from datetime import datetime
 
 from sqlmodel import Field, Relationship, SQLModel
+
+from keep.api.models import utcnow
 
 
 class Tenant(SQLModel, table=True):
@@ -22,7 +24,7 @@ class TenantApiKey(SQLModel, table=True):
     system_description: Optional[str] = None
     created_by: str
     role: str
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=utcnow)
     last_used: str = Field(default=None)
 
     class Config:

--- a/keep/api/models/db/user.py
+++ b/keep/api/models/db/user.py
@@ -4,6 +4,7 @@ from sqlmodel import Field, SQLModel
 
 # THIS IS ONLY FOR SINGLE TENANT (self-hosted) USAGES
 from keep.api.core.dependencies import SINGLE_TENANT_UUID
+from keep.api.models import utcnow
 
 
 class User(SQLModel, table=True):
@@ -25,4 +26,4 @@ class User(SQLModel, table=True):
     last_sign_in: datetime = Field(default=None)
 
     # Account creation timestamp
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=utcnow)

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from sqlalchemy import TEXT

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 from sqlalchemy import TEXT
 from sqlmodel import JSON, Column, Field, Relationship, SQLModel, UniqueConstraint
 
+from keep.api.models import utcnow
+
 
 class Workflow(SQLModel, table=True):
     id: str = Field(default=None, primary_key=True)
@@ -12,12 +14,12 @@ class Workflow(SQLModel, table=True):
     description: Optional[str]
     created_by: str = Field(sa_column=Column(TEXT))
     updated_by: Optional[str] = None
-    creation_time: datetime = Field(default_factory=datetime.utcnow)
+    creation_time: datetime = Field(default_factory=utcnow)
     interval: Optional[int]
     workflow_raw: str = Field(sa_column=Column(TEXT))
     is_deleted: bool = Field(default=False)
     revision: int = Field(default=1, nullable=False)
-    last_updated: datetime = Field(default_factory=datetime.utcnow)
+    last_updated: datetime = Field(default_factory=utcnow)
 
     class Config:
         orm_mode = True
@@ -31,7 +33,7 @@ class WorkflowExecution(SQLModel, table=True):
     id: str = Field(default=None, primary_key=True)
     workflow_id: str = Field(foreign_key="workflow.id")
     tenant_id: str = Field(foreign_key="tenant.id")
-    started: datetime = Field(default_factory=datetime.utcnow)
+    started: datetime = Field(default_factory=utcnow)
     triggered_by: str = Field(sa_column=Column(TEXT))
     status: str = Field(sa_column=Column(TEXT))
     is_running: int = Field(default=1)

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -36,7 +36,7 @@ class WorkflowExecution(SQLModel, table=True):
     status: str = Field(sa_column=Column(TEXT))
     is_running: int = Field(default=1)
     timeslot: int = Field(
-        default_factory=lambda: int(datetime.utcnow().timestamp() / 120)
+        default_factory=lambda: int(datetime.now(tz=timezone.utc).timestamp() / 120)
     )
     execution_number: int
     logs: Optional[str]

--- a/keep/providers/gcpmonitoring_provider/gcpmonitoring_provider.py
+++ b/keep/providers/gcpmonitoring_provider/gcpmonitoring_provider.py
@@ -91,7 +91,7 @@ To send alerts from GCP Monitoring to Keep, Use the following webhook url to con
         if event_time:
             event_time = datetime.datetime.fromtimestamp(event_time)
         else:
-            event_time = datetime.datetime.utcnow()
+            event_time = datetime.datetime.now(tz=timezone.utc)
             # replace timezone to utc
             event_time = event_time.replace(tzinfo=datetime.timezone.utc)
 

--- a/keep/providers/signalfx_provider/signalfx_provider.py
+++ b/keep/providers/signalfx_provider/signalfx_provider.py
@@ -227,7 +227,7 @@ class SignalfxProvider(BaseProvider):
         message = event.pop("messageBody", "")
         description = event.pop("description", "")
         name = event.pop("messageTitle", "")
-        lastReceived = event.pop("timestamp", datetime.datetime.utcnow().isoformat())
+        lastReceived = event.pop("timestamp", datetime.datetime.now(tz=timezone.utc).isoformat())
         inputs: dict = event.pop("inputs", {})
         new_inputs = []
         for key, value in inputs.items():

--- a/tests/test_iohandler.py
+++ b/tests/test_iohandler.py
@@ -349,7 +349,7 @@ def test_render_uppercase(context_manager):
 
 
 def test_render_datetime_compare(context_manager):
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(tz=timezone.utc)
     one_hour_ago = now - datetime.timedelta(hours=1)
     context_manager.steps_context = {
         "now": now.isoformat(),


### PR DESCRIPTION
## 📑 Description

Remove deprecated `datetime.utcnow` replaced by `datetime.now(tz=timezone.utc)`.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
