### PR TITLE
fix: PostgreSQL datetime formatting with `to_char`

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -26,6 +26,7 @@ from keep.api.consts import RUNNING_IN_CLOUD_RUN
 from keep.api.core.config import config
 from keep.api.core.rbac import Admin as AdminRole
 from keep.api.models.alert import AlertStatus
+from keep.api.models.db.action import Action
 from keep.api.models.db.alert import *
 from keep.api.models.db.dashboard import *
 from keep.api.models.db.extraction import *
@@ -1739,6 +1740,7 @@ def delete_dashboard(tenant_id, dashboard_id):
             session.commit()
             return True
         return False
+
 def get_all_actions(tenant_id: str) -> List[Action]:
     with Session(engine) as session:
         actions = session.exec(

--- a/tests/e2e_tests/test_end_to_end.py
+++ b/tests/e2e_tests/test_end_to_end.py
@@ -10,7 +10,7 @@
 #   for postgres: docker-compose --project-directory . -f tests/e2e_tests/docker-compose-e2e-postgres.yml up -d
 # 2. Run the tests using pytest.
 # NOTE: to clean the database, run docker volume rm keep_postgres_data keep_mysql-data
-# NOTE 2: to run the tests with a browser, uncommant this:
+# NOTE 2: to run the tests with a browser, uncomment this:
 # import os
 
 # os.environ["PLAYWRIGHT_HEADLESS"] = "false"


### PR DESCRIPTION
## 📑 Description

When using `PostgreSQL` as backend database an error occur when converting datetime to string with the `to_char` `PostgreSQL` function as it expects a [specific formatting](https://www.postgresql.org/docs/current/functions-formatting.html#FUNCTIONS-FORMATTING)

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information

This PR fix a bug that makes unusable the web application. On `Providers` page, the KPI displaying the number of alerts per integration crashed. Thus, it is impossible to manage integration because of query crashing in the backend.