### PR TITLE
Call provider_class.format_alert in process_event only when an event is a dict

### DIFF
--- a/keep/api/tasks/process_event_task.py
+++ b/keep/api/tasks/process_event_task.py
@@ -368,16 +368,18 @@ def process_event(
         except Exception:
             logger.exception("Failed to run pre-formatting extraction rules")
 
-        if provider_type is not None:
+        if provider_type is not None and type(event) is dict:
             provider_class = ProvidersFactory.get_provider_class(provider_type)
             event = provider_class.format_alert(event, None)
+
+        # In case when provider_type is not set
+        if isinstance(event, dict):
+            event = [AlertDto(**event)]
 
         # Prepare the event for the digest
         if isinstance(event, AlertDto):
             event = [event]
 
-        if isinstance(event, dict):
-            event = [AlertDto(**event)]
 
         __internal_prepartion(event, fingerprint, api_key_name)
         __handle_formatted_events(


### PR DESCRIPTION
## 📑 Description
<!-- Add a brief description of the pr -->
Fixes issue for some providers

```
Traceback (most recent call last):
  File "/app/keep/api/tasks/process_event_task.py", line 373, in process_event
    event = provider_class.format_alert(event, None)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/keep/providers/base/base_provider.py", line 263, in format_alert
    formatted_alert = cls._format_alert(event, provider_instance)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/keep/providers/grafana_provider/grafana_provider.py", line 199, in _format_alert
    alerts = event.get("alerts", [])
             ^^^^^^^^^
AttributeError: 'list' object has no attribute 'get'
```


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
