### PR TITLE
fix: mobile mode (#1283)

### DIFF
--- a/keep-ui/app/dashboard/styles.css
+++ b/keep-ui/app/dashboard/styles.css
@@ -9,3 +9,13 @@
 .grid-item__widget .panel:focus {
   outline: none;
 }
+
+.hidden-on-small {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .hidden-on-small {
+    display: inherit;
+  }
+}

--- a/keep-ui/components/navbar/MinimizeMenuButton.tsx
+++ b/keep-ui/components/navbar/MinimizeMenuButton.tsx
@@ -11,7 +11,7 @@ export const MinimizeMenuButton = () => {
   );
 
   return (
-    <div className="flex items-center h-full jusity-center">
+    <div className="flex items-center h-full jusity-center hidden-on-small">
       <button
         className="flex items-center justify-center"
         onClick={() => setisMenuMinimized(!isMenuMinimized)}


### PR DESCRIPTION
On large screens, there is a MinimizeMenuButton to hide and display the menu, and for small screens, a Popover.Button.

However, both buttons are displayed on small screens by mistake, and due to the change of grid to flex MinimizeMenuButton takes up too much space.

Problem is solved.