### PR TITLE
fix: dashboard overflow (#1283)

### DIFF
--- a/keep-ui/app/dashboard/[id]/dashboard.tsx
+++ b/keep-ui/app/dashboard/[id]/dashboard.tsx
@@ -141,7 +141,7 @@ const DashboardPage = () => {
   };
 
   return (
-    <div className="flex flex-col overflow-hidden h-full p-4">
+    <div className="flex flex-col h-full p-4">
       <div className="flex items-center justify-between mb-4">
         <div className="relative">
           {isEditingName ? (

--- a/keep-ui/app/layout.tsx
+++ b/keep-ui/app/layout.tsx
@@ -28,7 +28,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
           <Navbar />
           {/* https://discord.com/channels/752553802359505017/1068089513253019688/1117731746922893333 */}
           <main className="flex flex-col col-start-3 p-4 overflow-auto">
-            <div className="flex-1 h-0">
+            <div className="flex-1">
               <ErrorBoundary>{children}</ErrorBoundary>
             </div>
             <ToastContainer />


### PR DESCRIPTION
If you mistakenly move dashboard widget too much down, it disappears from screen. 

Solved. The screen grows accordingly.