### PR TITLE
fix: Create Correlation form overflow (#1375)

### DIFF
--- a/keep-ui/app/rules/CorrelationSidebar/CorrelationSidebarBody.css
+++ b/keep-ui/app/rules/CorrelationSidebar/CorrelationSidebarBody.css
@@ -1,0 +1,5 @@
+@media (max-width: 1600px) {
+    .sidebar-form {
+        grid-template-columns: 1fr;
+    }
+}

--- a/keep-ui/app/rules/CorrelationSidebar/CorrelationSidebarBody.tsx
+++ b/keep-ui/app/rules/CorrelationSidebar/CorrelationSidebarBody.tsx
@@ -12,6 +12,7 @@ import { useRules } from "utils/hooks/useRules";
 import { CorrelationForm as CorrelationFormType } from ".";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSearchAlerts } from "utils/hooks/useSearchAlerts";
+import "./CorrelationSidebarBody.css";
 
 export const TIMEFRAME_UNITS = {
   seconds: (amount: number) => amount,
@@ -113,11 +114,13 @@ export const CorrelationSidebarBody = ({
       )}
       <FormProvider {...methods}>
         <form
-          className="grid grid-cols-2 gap-x-10 flex-1"
+          className="flex flex-col justify-between h-full"
           onSubmit={methods.handleSubmit(onCorrelationFormSubmit)}
         >
-          <CorrelationForm alertsFound={alertsFound} isLoading={isLoading} />
-          <CorrelationGroups />
+          <div className="grid grid-cols-2 gap-10 sidebar-form w-full">
+            <CorrelationForm alertsFound={alertsFound} isLoading={isLoading} />
+            <CorrelationGroups />
+          </div>
 
           <CorrelationSubmission
             toggle={toggle}


### PR DESCRIPTION
How to reproduce:

1) Go to /rules

2) Click on the Create Correlation button

3) Resize the window

Problem:
The elements in this form do not adapt and overflow their containers

Fixed.