### PR TITLE
fix: converting workflow results datetime objects (#1255)

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -1009,6 +1009,14 @@ def create_user(tenant_id, username, password, role):
         session.refresh(user)
     return user
 
+def serialize_workflow_results(results):
+    # Converting datetime objects to strings
+    for key, value in results.items():
+        if isinstance(value, datetime.datetime):
+            results[key] = value.isoformat()
+        elif isinstance(value, dict):
+            results[key] = serialize_workflow_results(value)
+    return results
 
 def save_workflow_results(tenant_id, workflow_execution_id, workflow_results):
     with Session(engine) as session:
@@ -1018,7 +1026,8 @@ def save_workflow_results(tenant_id, workflow_execution_id, workflow_results):
             .where(WorkflowExecution.id == workflow_execution_id)
         ).one()
 
-        workflow_execution.results = workflow_results
+        serialized_results = serialize_workflow_results(workflow_results)
+        workflow_execution.results = serialized_results
         session.commit()
 
 


### PR DESCRIPTION
Describe the bug
When the result of a workflow execution might include datetime object, we're unable to save it in to the database because of a serialization problem.

Solution:
So now, according to mock testing data:
e.g.
mock_action1 = Mock(name="action1")
mock_action1.name = "action1"
mock_action 1.provider.results = {"result": "value1"}

results dict's fields will be iterated and datetime objects will be converted to be properly saved in DB

![image](https://github.com/user-attachments/assets/86f6aeb6-bc03-4af5-89d5-1bdebf04dab9)

Needs to be double checked with relevant workflowexecution data