### PR TITLE
#1447 Fix incident Predictions UI table for long texts in cells

### DIFF
--- a/keep-ui/app/incidents/incidents-table.tsx
+++ b/keep-ui/app/incidents/incidents-table.tsx
@@ -69,12 +69,12 @@ export default function IncidentsTable({
     columnHelper.display({
       id: "name",
       header: "Name",
-      cell: ({ row }) => row.original.name,
+      cell: ({ row }) => <div className="text-wrap">{row.original.name}</div>,
     }),
     columnHelper.display({
       id: "description",
       header: "Description",
-      cell: (context) => context.row.original.description,
+      cell: ({ row }) => <div className="text-wrap">{row.original.description}</div>,
     }),
     // columnHelper.display({
     //   id: "severity",
@@ -166,7 +166,7 @@ export default function IncidentsTable({
   const table = useReactTable({
     columns,
     data: incidents.items,
-    state: { expanded, pagination},
+    state: { expanded, pagination },
     getCoreRowModel: getCoreRowModel(),
     manualPagination: true,
     rowCount: incidents.count,

--- a/keep-ui/app/incidents/predicted-incidents-table.tsx
+++ b/keep-ui/app/incidents/predicted-incidents-table.tsx
@@ -16,14 +16,12 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import {MdRemoveCircle, MdModeEdit, MdDone, MdBlock} from "react-icons/md";
+import { MdDone, MdBlock} from "react-icons/md";
 import { useSession } from "next-auth/react";
 import { getApiURL } from "utils/apiUrl";
 import { toast } from "react-toastify";
 import {IncidentDto, PaginatedIncidentsDto} from "./model";
 import React, { useState } from "react";
-import { useIncidents } from "utils/hooks/useIncidents";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
 
 const columnHelper = createColumnHelper<IncidentDto>();
@@ -68,12 +66,12 @@ export default function PredictedIncidentsTable({
     columnHelper.display({
       id: "name",
       header: "Name",
-      cell: ({ row }) => row.original.name,
+      cell: ({ row }) => <div className="text-wrap">{row.original.name}</div>,
     }),
     columnHelper.display({
       id: "description",
       header: "Description",
-      cell: (context) => context.row.original.description,
+      cell: ({ row }) => <div className="text-wrap">{row.original.description}</div>,
     }),
     // columnHelper.display({
     //   id: "severity",
@@ -111,9 +109,10 @@ export default function PredictedIncidentsTable({
     columnHelper.display({
       id: "services",
       header: "Involved Services",
-      cell: (context) => context.row.original.services.map((service) =>
-        <Badge key={service} className="mr-1">{service}</Badge>
-      ),
+      cell: ({row}) => <div className="text-wrap">{row.original.services.map((service) =>
+          <Badge key={service} className="mr-1">{service}</Badge>
+        )}
+      </div>,
     }),
     columnHelper.display({
       id: "delete",

--- a/keep-ui/components/navbar/IncidentLinks.tsx
+++ b/keep-ui/components/navbar/IncidentLinks.tsx
@@ -61,7 +61,7 @@ export const IncidentsLinks = ({ session }: IncidentsLinksProps) => {
                 "bg-gray-200": currentPath === `/incidents/${incident.id}`,
               })}
             >
-              <Subtitle className="text-sm">{incident.name}</Subtitle>
+              <Subtitle className="text-sm max-w-[7.7rem]">{incident.name}</Subtitle>
             </LinkWithIcon>
           </li>
         ))}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1447

## 📑 Description
<!-- Add a brief description of the pr -->
Add word wrap to cells in the Incident prediction table

![image](https://github.com/user-attachments/assets/23e5516a-ba30-4235-8ad6-7f5807592e74)

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
