### PR TITLE
feat: bulk actions on alerts

### DIFF
--- a/docker/Dockerfile.dev.ui
+++ b/docker/Dockerfile.dev.ui
@@ -19,7 +19,7 @@ COPY ./keep-ui/ /app
 RUN npm install
 # Install next globally and create a symlink
 RUN npm install -g next
-RUN ln -s /usr/local/lib/node_modules/next/dist/bin/next /usr/local/bin/next
+RUN ln -s /usr/local/lib/node_modules/next/dist/bin/next /usr/local/bin/next || echo "next binary already linked to bin"
 # Ensure port 3000 is accessible to our system
 EXPOSE 3000
 

--- a/keep-ui/app/alerts/alert-table-tab-panel.tsx
+++ b/keep-ui/app/alerts/alert-table-tab-panel.tsx
@@ -30,7 +30,7 @@
     setNoteModalAlert: (alert: AlertDto | null) => void;
     setRunWorkflowModalAlert: (alert: AlertDto | null) => void;
     setDismissModalAlert: (alert: AlertDto[] | null) => void;
-    setChangeStatusAlert: (alert: AlertDto | null) => void;
+    setChangeStatusAlert: (alert: AlertDto[] | null) => void;
   }
 
   export default function AlertTableTabPanel({
@@ -88,6 +88,7 @@
           alerts={sortedPresetAlerts}
           columns={alertTableColumns}
           setDismissedModalAlert={setDismissModalAlert}
+          setChangeStatusAlert={setChangeStatusAlert}
           isAsyncLoading={isAsyncLoading}
           presetName={preset.name}
           presetPrivate={preset.is_private}

--- a/keep-ui/app/alerts/alert-table-utils.tsx
+++ b/keep-ui/app/alerts/alert-table-utils.tsx
@@ -108,7 +108,7 @@ interface GenerateAlertTableColsArg {
   setTicketModalAlert?: (alert: AlertDto) => void;
   setRunWorkflowModalAlert?: (alert: AlertDto) => void;
   setDismissModalAlert?: (alert: AlertDto[]) => void;
-  setChangeStatusAlert?: (alert: AlertDto) => void;
+  setChangeStatusAlert?: (alert: AlertDto[]) => void;
   presetName: string;
   presetNoisy?: boolean;
 }

--- a/keep-ui/app/alerts/alert-table.tsx
+++ b/keep-ui/app/alerts/alert-table.tsx
@@ -51,6 +51,7 @@ interface Props {
   isRefreshAllowed?: boolean;
   isMenuColDisplayed?: boolean;
   setDismissedModalAlert?: (alert: AlertDto[] | null) => void;
+  setChangeStatusAlert?: (alerts: AlertDto[] | null) => void;
 }
 
 export function AlertTable({
@@ -65,6 +66,7 @@ export function AlertTable({
   presetTabs = [],
   isRefreshAllowed = true,
   setDismissedModalAlert,
+  setChangeStatusAlert,
 }: Props) {
   const [theme, setTheme] = useLocalStorage(
     "alert-table-theme",
@@ -184,8 +186,10 @@ export function AlertTable({
           <AlertActions
             selectedRowIds={selectedRowIds}
             alerts={alerts}
+            presetName={presetName}
             clearRowSelection={table.resetRowSelection}
             setDismissModalAlert={setDismissedModalAlert}
+            setChangeStatusAlert={setChangeStatusAlert}
           />
         ) : (
           <AlertPresets

--- a/keep-ui/app/alerts/alerts.tsx
+++ b/keep-ui/app/alerts/alerts.tsx
@@ -72,7 +72,7 @@ export default function Alerts({ presetName }: AlertsProps) {
   const [dismissModalAlert, setDismissModalAlert] = useState<
     AlertDto[] | null
   >();
-  const [changeStatusAlert, setChangeStatusAlert] = useState<AlertDto | null>();
+  const [changeStatusAlert, setChangeStatusAlert] = useState<AlertDto[] | null>();
   const [viewAlertModal, setViewAlertModal] = useState<AlertDto | null>();
   const { useAllPresets } = usePresets();
 
@@ -147,7 +147,7 @@ export default function Alerts({ presetName }: AlertsProps) {
         handleClose={() => setDismissModalAlert(null)}
       />
       <AlertChangeStatusModal
-        alert={changeStatusAlert}
+        alerts={changeStatusAlert}
         presetName={selectedPreset.name}
         handleClose={() => setChangeStatusAlert(null)}
       />

--- a/keep-ui/utils/hooks/useAlertActions.ts
+++ b/keep-ui/utils/hooks/useAlertActions.ts
@@ -1,0 +1,44 @@
+import { AlertDto, Status } from "app/alerts/models";
+import { useSession } from "next-auth/react";
+import { getApiURL } from "utils/apiUrl";
+
+const post = async (path: string, accessToken: string | null, body: any = null) => {
+  return await fetch(`${getApiURL()}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body,
+  });
+}
+
+export const useAlertActions = () => {
+  const { data: session } = useSession();
+
+  const changeAlertStatusRequest = async (
+    alert: AlertDto,
+    selectedStatus: Status,
+  ): Promise<Response> => {
+    console.log("changeAlertStatusRequest", alert, selectedStatus);
+    const path = `/alerts/enrich?dispose_on_new_alert=true`;
+    const body = JSON.stringify({
+      enrichments: {
+        status: selectedStatus,
+      },
+      fingerprint: alert.fingerprint,
+    });
+    return await post(path, session?.accessToken, body);
+  };
+
+  const selfAssignAlertRequest = async (alert: AlertDto): Promise<Response> => {
+    console.log("selfAssignAlertRequest", alert);
+    const path = `/alerts/${alert.fingerprint}/assign/${alert.lastReceived.toISOString()}`;
+    return await post(path, session?.accessToken, null);
+  }
+
+  return {
+    changeAlertStatusRequest,
+    selfAssignAlertRequest,
+  }
+};


### PR DESCRIPTION
Closes #1495

## 📑 Description
Add bulk change status and self-assign for selected alerts. Not added "Run workflow" bulk action yet (now user is redirected to workflow logs after run, so this may be ambiguous)

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information

* Removed "Create or update preset" from bulk actions list; it requires space and is out of sync with main "create preset" functionality 
* Prevent crash in `Dockerfile.dev.ui` in case next binary already linked
* Adjust height of group actions (prevent table jump), more consistent action icons
