### PR TITLE
fix: when preset is private it needs to filtered form the asset links

### DIFF
--- a/keep-ui/app/alerts/models.tsx
+++ b/keep-ui/app/alerts/models.tsx
@@ -76,6 +76,7 @@ export interface Preset {
   is_noisy: boolean;
   should_do_noise_now: boolean;
   alerts_count: number;
+  created_by?: string;
 }
 
 export function getTabsFromPreset(preset: Preset): any[] {

--- a/keep-ui/components/navbar/CustomPresetAlertLinks.tsx
+++ b/keep-ui/components/navbar/CustomPresetAlertLinks.tsx
@@ -112,7 +112,14 @@ export const CustomPresetAlertLinks = ({
   const [presetsOrder, setPresetsOrder] = useState<Preset[]>([]);
 
   // Check for noisy presets and control sound playback
-  const anyNoisyNow = presets.some(preset => preset.should_do_noise_now);
+  const anyNoisyNow = presets.some((preset) => preset.should_do_noise_now);
+
+  const checkValidPreset = (preset: Preset) => {
+    if (!preset.is_private) {
+      return true;
+    }
+    return preset && preset.created_by == session?.user?.email;
+  };
 
   useEffect(() => {
     const filteredLS = presetsOrderFromLS.filter(
@@ -120,11 +127,11 @@ export const CustomPresetAlertLinks = ({
     );
 
     // Combine live presets and local storage order
-    const combinedOrder = presets.reduce<Preset[]>((acc, preset) => {
-      if (!acc.find(p => p.id === preset.id)) {
+    const combinedOrder = presets.reduce<Preset[]>((acc, preset: Preset) => {
+      if (!acc.find((p) => p.id === preset.id)) {
         acc.push(preset);
       }
-      return acc;
+      return acc.filter((preset) => checkValidPreset(preset));
     }, [...filteredLS]);
 
     // Only update state if there's an actual change to prevent infinite loops

--- a/keep-ui/utils/hooks/usePresets.ts
+++ b/keep-ui/utils/hooks/usePresets.ts
@@ -43,7 +43,9 @@ export const usePresets = () => {
           updatedPresets.set(newPresetId, {
             ...currentPreset,
             alerts_count: currentPreset.alerts_count + newPreset.alerts_count,
-          });
+            created_by: newPreset.created_by,
+            is_private: newPreset.is_private
+          }); 
         } else {
           // If the preset is not in the current presets, add it
           updatedPresets.set(newPresetId, {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->
/claim #1163 
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1163

## 📑 Description
<!-- Add a brief description of the pr -->
If there is a private preset. we will check preset-created_by. if it matches the current session user then we will allow the preset on the UI or else we will ignore it.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
