### PR TITLE
fix: core/db - remove unused function. closes #1561

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -1840,16 +1840,6 @@ def update_preset_options(tenant_id: str, preset_id: str, options: dict) -> Pres
     return preset
 
 
-def get_incident_by_id(incident_id: UUID) -> Incident:
-    with Session(engine) as session:
-        incident = session.exec(
-            select(Incident)
-            .options(selectinload(Incident.alerts))
-            .where(Incident.id == incident_id)
-        ).first()
-    return incident
-
-
 def assign_alert_to_incident(
     alert_id: UUID, incident_id: UUID, tenant_id: str
 ) -> AlertToIncident:


### PR DESCRIPTION
Closes #1561

## 📑 Description
Now we have 2 definitions of the same function:
```
def get_incident_by_id(incident_id: UUID) -> Incident:
def get_incident_by_id(tenant_id: str, incident_id: str) -> Optional[Incident]:
```
Only 2nd definition is used. I suppose there are no much reasons to keep first one.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
