### PR TITLE
feat: Add predicted incident detail page

### DIFF
--- a/keep-ui/app/incidents/[id]/incident-alerts.tsx
+++ b/keep-ui/app/incidents/[id]/incident-alerts.tsx
@@ -28,9 +28,10 @@ import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import IncidentAlertMenu from "./incident-alert-menu";
 import IncidentPagination from "../incident-pagination";
 import React, {Dispatch, SetStateAction, useEffect, useState} from "react";
+import {IncidentDto} from "../model";
 
 interface Props {
-  incidentId: string;
+  incident: IncidentDto;
 }
 
 interface Pagination {
@@ -41,13 +42,13 @@ interface Pagination {
 
 const columnHelper = createColumnHelper<AlertDto>();
 
-export default function IncidentAlerts({ incidentId }: Props) {
+export default function IncidentAlerts({ incident }: Props) {
   const [alertsPagination, setAlertsPagination] = useState<Pagination>({
     limit: 20,
     offset: 0,
   });
 
-  const { data: alerts, isLoading } = useIncidentAlerts(incidentId, alertsPagination.limit, alertsPagination.offset);
+  const { data: alerts, isLoading } = useIncidentAlerts(incident.id, alertsPagination.limit, alertsPagination.offset);
 
   const [pagination, setTablePagination] = useState({
     pageIndex: alerts? Math.ceil(alerts.offset / alerts.limit) : 0,
@@ -69,7 +70,7 @@ export default function IncidentAlerts({ incidentId }: Props) {
       })
     }
   }, [pagination])
-  usePollIncidentAlerts(incidentId);
+  usePollIncidentAlerts(incident.id);
 
   const columns = [
     columnHelper.accessor("severity", {
@@ -128,10 +129,11 @@ export default function IncidentAlerts({ incidentId }: Props) {
       id: "remove",
       header: "",
       cell: (context) => (
-        <IncidentAlertMenu
-          alert={context.row.original}
-          incidentId={incidentId}
-        />
+        incident.is_confirmed &&
+          <IncidentAlertMenu
+            alert={context.row.original}
+            incidentId={incident.id}
+          />
       ),
     }),
   ];

--- a/keep-ui/app/incidents/[id]/incident.tsx
+++ b/keep-ui/app/incidents/[id]/incident.tsx
@@ -62,7 +62,7 @@ export default function IncidentView({ incidentId }: Props) {
                 </TabList>
                 <TabPanels>
                   <TabPanel>
-                    <IncidentAlerts incidentId={incident.id} />
+                    <IncidentAlerts incident={incident} />
                   </TabPanel>
                   <TabPanel>Coming Soon...</TabPanel>
                   <TabPanel>Coming Soon...</TabPanel>

--- a/keep-ui/app/incidents/incident-candidate-actions.tsx
+++ b/keep-ui/app/incidents/incident-candidate-actions.tsx
@@ -1,0 +1,53 @@
+import {getApiURL} from "../../utils/apiUrl";
+import {toast} from "react-toastify";
+import {IncidentDto, PaginatedIncidentsDto} from "./model";
+import {Session} from "next-auth";
+
+interface Props {
+  incidentId: string;
+  mutate: () => void;
+  session: Session | null;
+}
+
+export const handleConfirmPredictedIncident = async ({incidentId, mutate, session}: Props) => {
+  const apiUrl = getApiURL();
+  const response = await fetch(
+    `${apiUrl}/incidents/${incidentId}/confirm`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session?.accessToken}`,
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  if (response.ok) {
+    await mutate();
+    toast.success("Predicted incident confirmed successfully");
+  } else {
+    toast.error(
+      "Failed to confirm predicted incident, please contact us if this issue persists."
+    );
+  }
+}
+
+export const deleteIncident = async ({incidentId, mutate, session}: Props) => {
+  const apiUrl = getApiURL();
+  if (confirm("Are you sure you want to delete this incident?")) {
+    const response = await fetch(`${apiUrl}/incidents/${incidentId}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${session?.accessToken}`,
+      },
+    })
+
+    if (response.ok) {
+        await mutate();
+        toast.success("Incident deleted successfully");
+        return true
+      } else {
+        toast.error("Failed to delete incident, contact us if this persists");
+        return false
+      }
+  }
+};

--- a/keep-ui/app/incidents/incident-table-component.tsx
+++ b/keep-ui/app/incidents/incident-table-component.tsx
@@ -1,0 +1,65 @@
+import {Table, TableBody, TableCell, TableHead, TableHeaderCell, TableRow} from "@tremor/react";
+import { flexRender, Table as ReactTable } from "@tanstack/react-table";
+import React from "react";
+import { IncidentDto } from "./model";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  table: ReactTable<IncidentDto>;
+}
+
+export const IncidentTableComponent = (props: Props) => {
+
+  const { table } = props;
+
+  const router = useRouter();
+
+  return (
+    <Table className="mt-4">
+      <TableHead>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <TableRow
+            className="border-b border-tremor-border dark:border-dark-tremor-border"
+            key={headerGroup.id}
+          >
+            {headerGroup.headers.map((header) => {
+              return (
+                <TableHeaderCell
+                  className="text-tremor-content-strong dark:text-dark-tremor-content-strong"
+                  key={header.id}
+                >
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext()
+                  )}
+                </TableHeaderCell>
+              );
+            })}
+          </TableRow>
+        ))}
+      </TableHead>
+      <TableBody>
+        {table.getRowModel().rows.map((row) => (
+          <>
+            <TableRow
+              className="even:bg-tremor-background-muted even:dark:bg-dark-tremor-background-muted hover:bg-slate-100 cursor-pointer"
+              key={row.id}
+              onClick={() => {
+                router.push(`/incidents/${row.original.id}`);
+              }}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <TableCell key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TableCell>
+              ))}
+            </TableRow>
+          </>
+        ))}
+      </TableBody>
+    </Table>
+  )
+
+}
+
+export default IncidentTableComponent;

--- a/keep-ui/app/incidents/incidents-table.tsx
+++ b/keep-ui/app/incidents/incidents-table.tsx
@@ -1,30 +1,22 @@
 import {
   Button,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeaderCell,
-  TableRow,
   Badge,
 } from "@tremor/react";
 import {
   DisplayColumnDef,
   ExpandedState,
   createColumnHelper,
-  flexRender,
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
 import { MdRemoveCircle, MdModeEdit } from "react-icons/md";
 import { useSession } from "next-auth/react";
-import { getApiURL } from "utils/apiUrl";
-import { toast } from "react-toastify";
 import {IncidentDto, PaginatedIncidentsDto} from "./model";
 import React, {Dispatch, SetStateAction, useEffect, useState} from "react";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
 import IncidentPagination from "./incident-pagination";
+import IncidentTableComponent from "./incident-table-component";
+import {deleteIncident} from "./incident-candidate-actions";
 
 const columnHelper = createColumnHelper<IncidentDto>();
 
@@ -41,7 +33,6 @@ export default function IncidentsTable({
   setPagination,
   editCallback,
 }: Props) {
-  const router = useRouter();
   const { data: session } = useSession();
   const [expanded, setExpanded] = useState<ExpandedState>({});
   const [pagination, setTablePagination] = useState({
@@ -151,10 +142,10 @@ export default function IncidentsTable({
             size="xs"
             variant="secondary"
             icon={MdRemoveCircle}
-            onClick={(e: React.MouseEvent) => {
+            onClick={async (e: React.MouseEvent) => {
               e.preventDefault();
               e.stopPropagation();
-              deleteIncident(context.row.original.id!);
+              await deleteIncident({incidentId: context.row.original.id!, mutate, session});
             }}
           />
         </div>
@@ -173,70 +164,9 @@ export default function IncidentsTable({
     onExpandedChange: setExpanded,
   });
 
-  const deleteIncident = (incidentId: string) => {
-    const apiUrl = getApiURL();
-    if (confirm("Are you sure you want to delete this incident?")) {
-      fetch(`${apiUrl}/incidents/${incidentId}`, {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${session?.accessToken}`,
-        },
-      }).then((response) => {
-        if (response.ok) {
-          mutate();
-          toast.success("Incident deleted successfully");
-        } else {
-          toast.error("Failed to delete incident, contact us if this persists");
-        }
-      });
-    }
-  };
-
   return (
     <div>
-      <Table className="mt-4">
-        <TableHead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow
-              className="border-b border-tremor-border dark:border-dark-tremor-border"
-              key={headerGroup.id}
-            >
-              {headerGroup.headers.map((header) => {
-                return (
-                  <TableHeaderCell
-                    className="text-tremor-content-strong dark:text-dark-tremor-content-strong"
-                    key={header.id}
-                  >
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext()
-                    )}
-                  </TableHeaderCell>
-                );
-              })}
-            </TableRow>
-          ))}
-        </TableHead>
-        <TableBody>
-          {table.getRowModel().rows.map((row) => (
-            <>
-              <TableRow
-                className="even:bg-tremor-background-muted even:dark:bg-dark-tremor-background-muted hover:bg-slate-100 cursor-pointer"
-                key={row.id}
-                onClick={() => {
-                  router.push(`/incidents/${row.original.id}`);
-                }}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
-              </TableRow>
-            </>
-          ))}
-        </TableBody>
-      </Table>
+      <IncidentTableComponent table={table} />
       <div className="mt-4 mb-8">
         <IncidentPagination table={table}  isRefreshAllowed={true}/>
       </div>

--- a/keep-ui/app/incidents/model.ts
+++ b/keep-ui/app/incidents/model.ts
@@ -12,6 +12,8 @@ export interface IncidentDto {
   start_time?: Date;
   end_time?: Date;
   creation_time: Date;
+  is_confirmed: boolean;
+  is_predicted: boolean;
 }
 
 export interface PaginatedIncidentsDto {

--- a/keep/api/models/alert.py
+++ b/keep/api/models/alert.py
@@ -363,6 +363,7 @@ class IncidentDto(IncidentDtoIn):
     services: list[str]
 
     is_predicted: bool
+    is_confirmed: bool
 
     generated_summary: str | None
 
@@ -388,6 +389,7 @@ class IncidentDto(IncidentDtoIn):
             name=db_incident.name,
             description=db_incident.description,
             is_predicted=db_incident.is_predicted,
+            is_confirmed=db_incident.is_confirmed,
             creation_time=db_incident.creation_time,
             start_time=db_incident.start_time,
             end_time=db_incident.end_time,


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1572 

## 📑 Description
We need the ability to review the details of the predicted incident to make better decisions. This PR reuses the Incident details page, allowing us to see the details of Predicted Incidents and confirm/remove them right from this page.

<img width="980" alt="image" src="https://github.com/user-attachments/assets/9cbcf3bd-5211-4436-bffe-0479b9b5d032">


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Reduce code duplication for incidents
