### PR TITLE
fix: replace usage of imported AlertDto in migration

### DIFF
--- a/keep/api/models/db/migrations/versions/2024-07-25-17-13_67f1efb93c99.py
+++ b/keep/api/models/db/migrations/versions/2024-07-25-17-13_67f1efb93c99.py
@@ -8,9 +8,9 @@ Create Date: 2024-07-25 17:13:04.428633
 
 import sqlalchemy as sa
 from alembic import op
+from pydantic import BaseModel
 from sqlalchemy.orm import Session, joinedload
 
-from keep.api.models.alert import AlertDto
 from keep.api.models.db.alert import Incident
 
 # revision identifiers, used by Alembic.
@@ -20,12 +20,17 @@ branch_labels = None
 depends_on = None
 
 
+class AlertDtoLocal(BaseModel):
+    service: str | None = None
+    source: list[str] | None = []
+
+
 def populate_db(session):
 
     incidents = session.query(Incident).options(joinedload(Incident.alerts)).all()
 
     for incident in incidents:
-        alerts_dto = [AlertDto(**alert.event) for alert in incident.alerts]
+        alerts_dto = [AlertDtoLocal(**alert.event) for alert in incident.alerts]
 
         incident.sources = list(
             set([source for alert_dto in alerts_dto for source in alert_dto.source])


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1592

## 📑 Description
<!-- Add a brief description of the pr -->
 Replace usage of imported AlertDto in migration "fields for prepopulated data from alerts" with the local simplified model.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
