### PR TITLE
fix: Incident severity is int, not string

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -2273,7 +2273,7 @@ def add_alerts_to_incident_by_incident_id(
         incident.start_time = started_at
         incident.last_seen_time = last_seen_at
 
-        incident.severity = alerts_data_for_incident["max_severity"].value
+        incident.severity = alerts_data_for_incident["max_severity"].order
 
         session.add(incident)
         session.commit()

--- a/keep/api/models/db/migrations/versions/2024-08-14-18-30_87594ea6d308.py
+++ b/keep/api/models/db/migrations/versions/2024-08-14-18-30_87594ea6d308.py
@@ -50,8 +50,8 @@ def upgrade() -> None:
             )
         )
 
-    op.drop_table("alerttogroup")
-    op.drop_table("group")
+    # op.drop_table("alerttogroup")
+    # op.drop_table("group")
 
     with op.batch_alter_table("alerttoincident", schema=None) as batch_op:
         batch_op.add_column(sa.Column("timestamp", sa.DateTime(), nullable=False,


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1501 