### PR TITLE
feat: Remove alert groups mentions from the documentation

### DIFF
--- a/docs/api-ref/groups/get-groups.mdx
+++ b/docs/api-ref/groups/get-groups.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /groups/
----

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -267,12 +267,6 @@
           ]
         },
         {
-          "group": "Groups",
-          "pages": [
-            "api-ref/groups/get-groups"
-          ]
-        },
-        {
           "group": "Whoami",
           "pages": [
             "api-ref/whoami/get-tenant-id"

--- a/docs/overview/ruleengine.mdx
+++ b/docs/overview/ruleengine.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Alert grouping"
+title: "Alerts correlations"
 ---
 
-The Keep Rule Engine is a versatile tool for grouping and consolidating alerts.
+The Keep Rule Engine is a versatile tool for grouping and consolidating alerts into incidents or incident-candidates.
 This guide explains the core concepts, usage, and best practices for effectively utilizing the rule engine.
 
 <Note>Access the Rule Engine UI through the Keep platform by navigating to the Rule Builder section.</Note>
 
 ## Core Concepts
-- **Rule definition**: A rule in Keep is a set of conditions that, when met, creates an alert group.
+- **Rule definition**: A rule in Keep is a set of conditions that, when met, creates an incident or incident-candidate.
 - **Alert attributes**: These are characteristics or data points of an alert, such as source, severity, or any attribute an alert might have.
 - **Conditions and logic**: Rules are built by defining conditions based on alert attributes, using logical operators (like AND/OR) to combine multiple conditions.
 
@@ -20,8 +20,9 @@ Creating a rule involves defining the conditions under which an alert should be 
  - **Name the rule**: Assign a descriptive name that reflects its purpose.
  - **Set conditions**: Use alert attributes to create conditions. For example, a rule might specify that an alert with a severity of 'critical' and a source of 'Prometheus' should be categorized as 'High Priority'.
  - **Logical grouping**: Combine conditions using logical operators to form comprehensive rules.
+ - **Manual approve**: Create Incident-candidate or full-fledged incident.
 
 ## Examples
 - **Metric-based alerts**: Construct a rule to pinpoint alerts associated with specific metrics, such as high CPU usage on servers. This can be achieved by grouping alerts that share a common attribute, like a 'CPU usage' tag, ensuring you quickly identify and address performance issues.
-- **Feature-related alerts**: Establish rules to organize alerts by specific features or services. For instance, you can group alerts based on a 'service' or 'URL' tag. This approach is particularly useful for tracking and managing alerts related to distinct functionalities or components within your application.
-- **Team-based alert management**: Implement rules to categorize alerts according to team responsibilities. This might involve grouping alerts based on the systems or services a particular team oversees. Such a strategy ensures that alerts are promptly directed to the appropriate team, enhancing response times and efficiency.
+- **Feature-related alerts**: Establish rules to create incident by specific features or services. For instance, you can start incident based on a 'service' or 'URL' tag. This approach is particularly useful for tracking and managing alerts related to distinct functionalities or components within your application.
+- **Team-based alert management**: Implement rules to create incidents according to team responsibilities. This might involve grouping based on the systems or services a particular team oversees. Such a strategy ensures that alerts are promptly directed to the appropriate team, enhancing response times and efficiency.


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1662

## 📑 Description
We don't have alert groups anymore. Correlation rules now create Incidents, and this PR updates documentation 

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
