### PR TITLE
feat: Rules' groups are now combined with || instead of &&

### DIFF
--- a/keep-ui/app/rules/CorrelationSidebar/index.tsx
+++ b/keep-ui/app/rules/CorrelationSidebar/index.tsx
@@ -12,7 +12,7 @@ export const DEFAULT_CORRELATION_FORM_VALUES: CorrelationForm = {
   groupedAttributes: [],
   requireApprove: false,
   query: {
-    combinator: "and",
+    combinator: "or",
     rules: [
       {
         combinator: "and",

--- a/keep/rulesengine/rulesengine.py
+++ b/keep/rulesengine/rulesengine.py
@@ -66,6 +66,8 @@ class RulesEngine:
         # CEL rules looks like '(source == "sentry") && (source == "grafana" && severity == "critical")'
         # and we need to extract the subrules
         sub_rules = expression.split(") && (")
+        if len(sub_rules) == 1:
+            return sub_rules
         # the first and the last rules will have a ( or ) at the beginning or the end
         # e.g. for the example of:
         #           (source == "sentry") && (source == "grafana" && severity == "critical")

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -44,7 +44,7 @@ def test_sanity(db_session):
             "params": {},
         },
         timeframe=600,
-        definition_cel='(source == "sentry") && (source == "grafana" && severity == "critical")',
+        definition_cel='(source == "sentry") || (source == "grafana" && severity == "critical")',
         created_by="test@keephq.dev",
     )
     rules = get_rules_db(SINGLE_TENANT_UUID)
@@ -63,7 +63,7 @@ def test_sanity(db_session):
     alerts[0].event_id = alert.id
     results = rules_engine.run_rules(alerts)
     # check that there are results
-    assert results is not None
+    assert len(results) > 0
 
 
 def test_sanity_2(db_session):
@@ -109,7 +109,7 @@ def test_sanity_2(db_session):
     alerts[0].event_id = alert.id
     results = rules_engine.run_rules(alerts)
     # check that there are results
-    assert results is not None
+    assert len(results) > 0
 
 
 def test_sanity_3(db_session):
@@ -156,7 +156,7 @@ def test_sanity_3(db_session):
     alerts[0].event_id = alert.id
     results = rules_engine.run_rules(alerts)
     # check that there are results
-    assert results is not None
+    assert len(results) > 0
 
 
 def test_sanity_4(db_session):


### PR DESCRIPTION


<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1700 

## 📑 Description
<!-- Add a brief description of the pr -->
To allow users to create rules with OR (alerts where `name contains GPU` or `name contains disk`) with grouping rules, we need to combine groups with OR instead of AND 


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
