### PR TITLE
chore(tests): remove duplicated unit test

### DIFF
--- a/tests/test_iohandler.py
+++ b/tests/test_iohandler.py
@@ -605,15 +605,6 @@ def test_no_function_calls(context_manager):
     assert len(functions) == 0, "Should find no functions"
 
 
-def test_keep_in_string_not_as_function_call(context_manager):
-    iohandler = IOHandler(context_manager)
-    template = "Here is a sentence with keep. not as a function call: 'Let's keep. moving forward.'"
-    functions = iohandler.extract_keep_functions(template)
-    assert (
-        len(functions) == 0
-    ), "Should find no functions when 'keep.' is part of a string."
-
-
 def test_malformed_function_calls(context_manager):
     iohandler = IOHandler(context_manager)
     template = "Here is a malformed function call keep.(without closing parenthesis."


### PR DESCRIPTION
Closes #1991

## 📑 Description
I noticed that the `tests/test_iohandler.py` test suite contains a duplicate unit test of `test_keep_in_string_not_as_function_call` (line  [591](https://github.com/keephq/keep/blob/330eac5af16b50a619d4839beaa55bd7dd55fe3e/tests/test_iohandler.py#L591) and line [608 ](https://github.com/keephq/keep/blob/330eac5af16b50a619d4839beaa55bd7dd55fe3e/tests/test_iohandler.py#L608)) with same logic. This PR removes one of the unit tests.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
