### PR TITLE
fix(ui): remove hiding navbar on MB Air-screen-size fixes

### DIFF
--- a/keep-ui/app/incidents/incidents-table.tsx
+++ b/keep-ui/app/incidents/incidents-table.tsx
@@ -118,7 +118,7 @@ export default function IncidentsTable({
       id: "name",
       header: "Name",
       cell: ({ row }) => (
-        <div className="text-wrap">
+        <div className="text-pretty min-w-40">
           {row.original.user_generated_name || row.original.ai_generated_name}
         </div>
       ),
@@ -127,7 +127,7 @@ export default function IncidentsTable({
       id: "user_summary",
       header: "Summary",
       cell: ({ row }) => (
-        <div className="text-wrap">{row.original.user_summary}</div>
+        <div className="text-pretty min-w-96">{row.original.user_summary}</div>
       ),
     }),
     columnHelper.display({

--- a/keep-ui/components/navbar/Navbar.css
+++ b/keep-ui/components/navbar/Navbar.css
@@ -1,0 +1,3 @@
+.scrollable-menu-shadow {
+  box-shadow: inset 0 -10px 10px -10px rgba(0, 0, 0, 0.1);
+}

--- a/keep-ui/components/navbar/Navbar.tsx
+++ b/keep-ui/components/navbar/Navbar.tsx
@@ -9,6 +9,7 @@ import { MinimizeMenuButton } from "components/navbar/MinimizeMenuButton";
 import { authOptions } from "pages/api/auth/[...nextauth]";
 import { DashboardLinks } from "@/components/navbar/DashboardLinks";
 import { IncidentsLinks } from "@/components/navbar/IncidentLinks";
+import "./Navbar.css";
 
 export default async function NavbarInner() {
   const session = await getServerSession(authOptions);
@@ -18,13 +19,13 @@ export default async function NavbarInner() {
       <InitPostHog />
       <Menu>
         <Search />
-        <div className="pt-6 space-y-4 flex-1 overflow-auto">
+        <div className="pt-6 space-y-4 flex-1 overflow-auto scrollable-menu-shadow">
           <IncidentsLinks session={session} />
           <AlertsLinks session={session} />
           <NoiseReductionLinks session={session} />
           <DashboardLinks session={session} />
         </div>
-        <UserInfo session={session} />
+        <UserInfo session={session}/>
       </Menu>
       <MinimizeMenuButton />
     </>


### PR DESCRIPTION
Stop hiding menu for small screen owners 😅:
Before:
<img width="271" alt="Screenshot 2024-09-29 at 13 33 57" src="https://github.com/user-attachments/assets/5f7d7615-c181-4be9-96ed-086150aaed69">
After: 
<img width="266" alt="Screenshot 2024-09-29 at 13 14 58" src="https://github.com/user-attachments/assets/e5d2e8bb-c5bd-445f-8acf-d53813556530">

+ readable incident page
Before:
<img width="852" alt="Screenshot 2024-09-29 at 13 35 33" src="https://github.com/user-attachments/assets/1087d10b-1b8d-4893-87a2-243ae6f98520">

After:
<img width="734" alt="Screenshot 2024-09-29 at 13 35 00" src="https://github.com/user-attachments/assets/373cb5b3-10d6-4afc-9791-bbca7c9a43f5">


Closes https://github.com/keephq/keep/issues/2032