### PR TITLE
fix: duplicate incident workflow table keys

### DIFF
--- a/keep-ui/app/incidents/[id]/incident-workflow-table.tsx
+++ b/keep-ui/app/incidents/[id]/incident-workflow-table.tsx
@@ -154,7 +154,7 @@ export default function IncidentWorkflowTable({ incident }: Props) {
       },
     }),
     columnHelper.display({
-      id: "triggered_by",
+      id: "triggered_by_details",
       header: "Trigger Details",
       cell: ({ row }) => {
         const triggered_by = row.original.triggered_by;


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2062 
