### PR TITLE
chore(docs): add `poetry shell` before CLI

### DIFF
--- a/docs/development/getting-started.mdx
+++ b/docs/development/getting-started.mdx
@@ -30,6 +30,12 @@ Install Keep CLI
 poetry install
 ```
 
+To access the Keep CLI activate the environment, and access from shell.
+
+```shell
+poetry shell
+```
+
 From now on, Keep should be installed locally and accessible from your CLI, test it by executing:
 
 ```


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2081 

## 📑 Description
I have observed that the documentation on development, fails to perfectly describe when the cli in development is accessable. It mentions how to install the dependencies, but does not describe how to access the shell.

The documentation shall mention poetry shell to activate the shell and access the keep cli.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [*] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
