### PR TITLE
docs(STRESS.md): grammatical errors

### DIFF
--- a/STRESS.md
+++ b/STRESS.md
@@ -35,7 +35,7 @@ kubectl -n keep exec -it keep-database-659c69689-vxhkz  -- bash -c "mysql -u roo
 
 # No Load
 ## 500k alerts - 1Gi/250m cpu: get_last_alerts 2 minutes and 30 seconds
-- Keep Backend Workers get a timeout after one minute (500's for preset and alert endpoints)
+- Keep Backend Workers get a timeout after one minute (status code 500 for preset and alert endpoints)
 ## 500k alerts - 2Gi/500m cpu:
 - default mysql: get_last_alerts 1 minutes and 30 seconds
 - innodb_buffer_pool_size = 4294967296: 25 seconds, 3 seconds after cache

--- a/STRESS.md
+++ b/STRESS.md
@@ -35,7 +35,7 @@ kubectl -n keep exec -it keep-database-659c69689-vxhkz  -- bash -c "mysql -u roo
 
 # No Load
 ## 500k alerts - 1Gi/250m cpu: get_last_alerts 2 minutes and 30 seconds
-- Keep Backend Workers get a timeout after one minute (status code 500 for preset and alert endpoints)
+Keep Backend Workers get a timeout after one minutes (status code 500's for preset and alert endpoints)
 ## 500k alerts - 2Gi/500m cpu:
 - default mysql: get_last_alerts 1 minutes and 30 seconds
 - innodb_buffer_pool_size = 4294967296: 25 seconds, 3 seconds after cache

--- a/STRESS.md
+++ b/STRESS.md
@@ -35,7 +35,7 @@ kubectl -n keep exec -it keep-database-659c69689-vxhkz  -- bash -c "mysql -u roo
 
 # No Load
 ## 500k alerts - 1Gi/250m cpu: get_last_alerts 2 minutes and 30 seconds
-Keep Backend Workers get a timeout after one minute (status code 500's for preset and alert endpoints)
+Keep Backend Workers get a timeout after one minute (status code 500 for preset and alert endpoints)
 ## 500k alerts - 2Gi/500m cpu:
 - default mysql: get_last_alerts 1 minutes and 30 seconds
 - innodb_buffer_pool_size = 4294967296: 25 seconds, 3 seconds after cache

--- a/STRESS.md
+++ b/STRESS.md
@@ -35,7 +35,7 @@ kubectl -n keep exec -it keep-database-659c69689-vxhkz  -- bash -c "mysql -u roo
 
 # No Load
 ## 500k alerts - 1Gi/250m cpu: get_last_alerts 2 minutes and 30 seconds
-Keep Backend Workers get a timeout after one minutes (status code 500's for preset and alert endpoints)
+Keep Backend Workers get a timeout after one minute (status code 500's for preset and alert endpoints)
 ## 500k alerts - 2Gi/500m cpu:
 - default mysql: get_last_alerts 1 minutes and 30 seconds
 - innodb_buffer_pool_size = 4294967296: 25 seconds, 3 seconds after cache

--- a/STRESS.md
+++ b/STRESS.md
@@ -1,7 +1,7 @@
 
 # UNDER CONSTRUCTION
 
-# First, create a kubernetes cluster
+# First, create a Kubernetes cluster
 
 
 # Install Keep
@@ -35,7 +35,7 @@ kubectl -n keep exec -it keep-database-659c69689-vxhkz  -- bash -c "mysql -u roo
 
 # No Load
 ## 500k alerts - 1Gi/250m cpu: get_last_alerts 2 minutes and 30 seconds
-- Keep Backend Workers get timeout after a one minutes (500's for preset and alert endpoints)
+- Keep Backend Workers get a timeout after one minute (500's for preset and alert endpoints)
 ## 500k alerts - 2Gi/500m cpu:
 - default mysql: get_last_alerts 1 minutes and 30 seconds
 - innodb_buffer_pool_size = 4294967296: 25 seconds, 3 seconds after cache


### PR DESCRIPTION
Close #2097 

Fix grammatical errors in STRESS.md


Description:

I found a grammatical error in the STRESS.md of the project. This PR fixes the error to improve the overall readability and clarity of the documentation.


Changes:
Corrected grammatical error in line 38
Updated line 38  to reflect the correct grammar
Reasoning: The original text contained a grammatical error that could cause confusion for readers. This fix ensures that the documentation is accurate and easy to understand.