### PR TITLE
feat: Implement auto resolution rules for incident correlations

### DIFF
--- a/keep-ui/app/rules/CorrelationSidebar/CorrelationForm.tsx
+++ b/keep-ui/app/rules/CorrelationSidebar/CorrelationForm.tsx
@@ -4,7 +4,9 @@ import {
   MultiSelectItem,
   NumberInput,
   Select,
-  SelectItem, Switch, Text,
+  SelectItem,
+  Switch,
+  Text,
   TextInput,
 } from "@tremor/react";
 import { Controller, get, useFormContext } from "react-hook-form";
@@ -37,7 +39,6 @@ export const CorrelationForm = ({
   return (
     <div className="flex flex-col gap-y-4 flex-1">
       <fieldset className="grid grid-cols-2">
-
         <label className="text-tremor-default mr-10 font-medium text-tremor-content-strong">
           Correlation name
           <TextInput
@@ -45,7 +46,7 @@ export const CorrelationForm = ({
             placeholder="Choose name"
             className="mt-2"
             {...register("name", {
-              required: {message: "Name is required", value: true},
+              required: { message: "Name is required", value: true },
             })}
             error={!!get(errors, "name.message")}
             errorMessage={get(errors, "name.message")}
@@ -53,7 +54,6 @@ export const CorrelationForm = ({
         </label>
 
         <span className="grid grid-cols-2 gap-x-2">
-
           <legend className="text-tremor-default font-medium text-tremor-content-strong flex items-center col-span-2">
             Append to the same Incident if delay between alerts is below{" "}
             <Button
@@ -67,17 +67,16 @@ export const CorrelationForm = ({
             />
           </legend>
 
-
           <NumberInput
             defaultValue={5}
             min={1}
             className="mt-2"
-            {...register("timeAmount", {validate: (value) => value > 0})}
+            {...register("timeAmount", { validate: (value) => value > 0 })}
           />
           <Controller
             control={control}
             name="timeUnit"
-            render={({field: {value, onChange}}) => (
+            render={({ field: { value, onChange } }) => (
               <Select value={value} onValueChange={onChange} className="mt-2">
                 <SelectItem value="seconds">Seconds</SelectItem>
                 <SelectItem value="minutes">Minutes</SelectItem>
@@ -88,45 +87,69 @@ export const CorrelationForm = ({
           />
         </span>
       </fieldset>
-      <div>
-        <label
-          className="flex items-center text-tremor-default font-medium text-tremor-content-strong"
-          htmlFor="groupedAttributes"
-        >
-          Select attribute(s) to group by{" "}
-          {keys.length < 1 && (
-            <Button
-              className="cursor-default ml-2"
-              type="button"
-              tooltip="Keep will use these attributes to split between incidents. For example, with attribute host, Keep will correlate alert with hostX and alert with host hostY to different incidents. You cannot calculate attributes to group by without alerts"
-              icon={QuestionMarkCircleIcon}
-              size="xs"
-              variant="light"
-              color="slate"
-            />
-          )}
-        </label>
-        <Controller
-          control={control}
-          name="groupedAttributes"
-          render={({ field: { value, onChange } }) => (
-            <MultiSelect
-              className="mt-2"
-              value={value}
-              onValueChange={onChange}
-              disabled={isLoading || !keys.length}
-            >
-              {keys.map((alertKey) => (
-                <MultiSelectItem key={alertKey} value={alertKey}>
-                  {alertKey}
-                </MultiSelectItem>
-              ))}
-            </MultiSelect>
-          )}
-        />
-      </div>
-      <div className="flex items-center space-x-2">
+      <fieldset className="grid grid-cols-2">
+        <div className="mr-10">
+          <label
+            className="flex items-center text-tremor-default font-medium text-tremor-content-strong"
+            htmlFor="groupedAttributes"
+          >
+            Select attribute(s) to group by{" "}
+            {keys.length < 1 && (
+              <Button
+                className="cursor-default ml-2"
+                type="button"
+                tooltip="Keep will use these attributes to split between incidents. For example, with attribute host, Keep will correlate alert with hostX and alert with host hostY to different incidents. You cannot calculate attributes to group by without alerts"
+                icon={QuestionMarkCircleIcon}
+                size="xs"
+                variant="light"
+                color="slate"
+              />
+            )}
+          </label>
+          <Controller
+            control={control}
+            name="groupedAttributes"
+            render={({ field: { value, onChange } }) => (
+              <MultiSelect
+                className="mt-2"
+                value={value}
+                onValueChange={onChange}
+                disabled={isLoading || !keys.length}
+              >
+                {keys.map((alertKey) => (
+                  <MultiSelectItem key={alertKey} value={alertKey}>
+                    {alertKey}
+                  </MultiSelectItem>
+                ))}
+              </MultiSelect>
+            )}
+          />
+        </div>
 
+        <div>
+          <label
+            className="flex items-center text-tremor-default font-medium text-tremor-content-strong"
+            htmlFor="resolveOn"
+          >
+            Resolve on{" "}
+          </label>
+
+          <Controller
+            control={control}
+            name="resolveOn"
+            render={({ field: { value, onChange } }) => (
+              <Select value={value} onValueChange={onChange} className="mt-2">
+                <SelectItem value="never">No auto-resolution</SelectItem>
+                <SelectItem value="all">All alerts resolved</SelectItem>
+                <SelectItem value="first">First alert resolved</SelectItem>
+                <SelectItem value="last">Last alert resolved</SelectItem>
+              </Select>
+            )}
+          />
+        </div>
+      </fieldset>
+
+      <div className="flex items-center space-x-2">
         <Controller
           control={control}
           name="requireApprove"

--- a/keep-ui/app/rules/CorrelationSidebar/CorrelationSidebarBody.tsx
+++ b/keep-ui/app/rules/CorrelationSidebar/CorrelationSidebarBody.tsx
@@ -12,9 +12,9 @@ import { useRules } from "utils/hooks/useRules";
 import { CorrelationForm as CorrelationFormType } from ".";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSearchAlerts } from "utils/hooks/useSearchAlerts";
-import {AlertsFoundBadge} from "./AlertsFoundBadge";
+import { AlertsFoundBadge } from "./AlertsFoundBadge";
 
-export const TIMEFRAME_UNITS_TO_SECONDS= {
+export const TIMEFRAME_UNITS_TO_SECONDS = {
   seconds: (amount: number) => amount,
   minutes: (amount: number) => 60 * amount,
   hours: (amount: number) => 3600 * amount,
@@ -36,9 +36,11 @@ export const CorrelationSidebarBody = ({
     defaultValues: defaultValue,
     mode: "onChange",
   });
-  const timeframeInSeconds = methods.watch("timeUnit") ? TIMEFRAME_UNITS_TO_SECONDS[methods.watch("timeUnit")](
-    +methods.watch("timeAmount")
-  ) : 0;
+  const timeframeInSeconds = methods.watch("timeUnit")
+    ? TIMEFRAME_UNITS_TO_SECONDS[methods.watch("timeUnit")](
+        +methods.watch("timeAmount")
+      )
+    : 0;
 
   const { mutate } = useRules();
   const { data: session } = useSession();
@@ -66,7 +68,9 @@ export const CorrelationSidebarBody = ({
       timeUnit,
       description,
       groupedAttributes,
-      requireApprove } = correlationFormData;
+      requireApprove,
+      resolveOn,
+    } = correlationFormData;
 
     if (session) {
       const response = await fetch(
@@ -85,7 +89,8 @@ export const CorrelationSidebarBody = ({
             timeframeInSeconds,
             timeUnit: timeUnit,
             groupingCriteria: alertsFound.length ? groupedAttributes : [],
-            requireApprove: requireApprove
+            requireApprove: requireApprove,
+            resolveOn: resolveOn,
           }),
         }
       );
@@ -131,13 +136,23 @@ export const CorrelationSidebarBody = ({
           <div className="grid grid-cols-3 gap-x-10 flex-1">
             <CorrelationGroups />
 
-            <div className="flex flex-col items-center justify-between gap-5 py-5" id="total-results">
+            <div
+              className="flex flex-col items-center justify-between gap-5 py-5"
+              id="total-results"
+            >
               <div className="grow justify-center flex">
                 {alertsFound.length > 0 && (
-                  <AlertsFoundBadge alertsFound={alertsFound} isLoading={false} vertical={true}/>
+                  <AlertsFoundBadge
+                    alertsFound={alertsFound}
+                    isLoading={false}
+                    vertical={true}
+                  />
                 )}
               </div>
-              <span className="text-xs">Rules will be applied only to new alerts. Historical data will be ignored</span>
+              <span className="text-xs">
+                Rules will be applied only to new alerts. Historical data will
+                be ignored
+              </span>
               <div className="flex justify-end w-full">
                 <CorrelationSubmission
                   toggle={toggle}
@@ -145,9 +160,7 @@ export const CorrelationSidebarBody = ({
                 />
               </div>
             </div>
-
           </div>
-
         </form>
       </FormProvider>
     </div>

--- a/keep-ui/app/rules/CorrelationSidebar/index.tsx
+++ b/keep-ui/app/rules/CorrelationSidebar/index.tsx
@@ -11,6 +11,7 @@ export const DEFAULT_CORRELATION_FORM_VALUES: CorrelationForm = {
   timeUnit: "hours",
   groupedAttributes: [],
   requireApprove: false,
+  resolveOn: "never",
   query: {
     combinator: "or",
     rules: [
@@ -33,6 +34,7 @@ export type CorrelationForm = {
   timeUnit: "minutes" | "seconds" | "hours" | "days";
   groupedAttributes: string[];
   requireApprove: boolean;
+  resolveOn: "all" | "first" | "last" | "never";
   query: RuleGroupType;
 };
 

--- a/keep-ui/app/rules/CorrelationTable.tsx
+++ b/keep-ui/app/rules/CorrelationTable.tsx
@@ -76,6 +76,7 @@ export const CorrelationTable = ({ rules }: CorrelationTableProps) => {
         timeUnit: timeunit,
         groupedAttributes: selectedRule.grouping_criteria,
         requireApprove: selectedRule.require_approve,
+        resolveOn: selectedRule.resolve_on,
         query: queryInGroup,
         incidents: selectedRule.incidents,
       };

--- a/keep-ui/utils/hooks/useRules.ts
+++ b/keep-ui/utils/hooks/useRules.ts
@@ -19,8 +19,9 @@ export type Rule = {
   updated_by: string | null;
   update_time: string | null;
   require_approve: boolean;
+  resolve_on: "all" | "first" | "last" | "never";
   distribution: { [group: string]: { [timestamp: string]: number } };
-  incidents: number
+  incidents: number;
 };
 
 export const useRules = (options?: SWRConfiguration) => {

--- a/keep/api/models/db/migrations/versions/2024-10-05-18-37_017d759805d9.py
+++ b/keep/api/models/db/migrations/versions/2024-10-05-18-37_017d759805d9.py
@@ -1,0 +1,31 @@
+"""Add resolve_on action to Rule
+
+Revision ID: 017d759805d9
+Revises: 01ebe17218c0
+Create Date: 2024-10-05 18:37:45.152090
+
+"""
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "017d759805d9"
+down_revision = "01ebe17218c0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+
+    with op.batch_alter_table("rule", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("resolve_on", sqlmodel.sql.sqltypes.AutoString(), nullable=False,
+                      default="never", server_default="never")
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("rule", schema=None) as batch_op:
+        batch_op.drop_column("resolve_on")

--- a/keep/api/models/db/rule.py
+++ b/keep/api/models/db/rule.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import Enum
 from uuid import UUID, uuid4
 
 from sqlmodel import JSON, Column, Field, SQLModel
@@ -6,6 +7,12 @@ from sqlmodel import JSON, Column, Field, SQLModel
 # Currently a rule_definition is a list of SQL expressions
 # We use querybuilder for that
 
+class ResolveOn(Enum):
+    # the alert was triggered
+    FIRST = "first_resolved"
+    LAST = "last_resolved"
+    ALL = "all_resolved"
+    NEVER = "never"
 
 # TODOs/Pitfalls down the road which we hopefully need to address in the future:
 # 1. nested attibtues (event.foo.bar = 1)
@@ -33,3 +40,4 @@ class Rule(SQLModel, table=True):
     # e.g. The {{ labels.queue }} is more than third full on {{ num_of_alerts }} queue managers
     item_description: str = None
     require_approve: bool = False
+    resolve_on: str = ResolveOn.NEVER.value

--- a/tests/test_rules_api.py
+++ b/tests/test_rules_api.py
@@ -162,6 +162,7 @@ def test_update_rule_api(db_session, client, test_app):
         "timeframeInSeconds": 300,
         "timeUnit": "seconds",
         "requireApprove": False,
+        "resolveOn": "all",
     }
 
     response = client.put(


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2087

## 📑 Description
<!-- Add a brief description of the pr -->
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/2b8a7404-e548-40dc-ab63-ef42959e76a5">

Now, when provider sends alert with the same fingerprint multiple times with different statuses, user can configure when automatically resolve the Incident: when `all` associated alerts are resolved, when `first` or `last` alert is resolved or `never`. `Never` by default

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
