### PR TITLE
fix: enrichments regex operation

### DIFF
--- a/keep/api/bl/enrichments_bl.py
+++ b/keep/api/bl/enrichments_bl.py
@@ -343,7 +343,7 @@ class EnrichmentsBl:
     def _is_match(value, pattern):
         if value is None or pattern is None:
             return False
-        return re.match(pattern, value) is not None
+        return re.search(pattern, value) is not None
 
     def _check_matcher(self, alert: AlertDto, row: dict, matcher: str) -> bool:
         """

--- a/keep/api/bl/enrichments_bl.py
+++ b/keep/api/bl/enrichments_bl.py
@@ -126,7 +126,7 @@ class EnrichmentsBl:
                         extra={"rule_id": rule.id},
                     )
                     continue
-            match_result = re.match(rule.regex, attribute_value)
+            match_result = re.search(rule.regex, attribute_value)
             if match_result:
                 match_dict = match_result.groupdict()
 

--- a/tests/test_enrichments.py
+++ b/tests/test_enrichments.py
@@ -194,9 +194,9 @@ def test_run_extraction_rules_handle_source_special_case(mock_session):
 
     # We'll mock chevron to return the exact content of 'source' to simulate the template rendering
     with patch("chevron.render", return_value="incorrect_format"):
-        # We need to mock 're.match' to return a match object with a groupdict that includes 'source'
+        # We need to mock 're.search' to return a match object with a groupdict that includes 'source'
         with patch(
-            "re.match",
+            "re.search",
             return_value=Mock(groupdict=lambda: {"source": "incorrect_format"}),
         ):
             enriched_event = enrichment_bl.run_extraction_rules(event)


### PR DESCRIPTION
close #2139
## 📑 Description
```
re.match() checks for a match only at the beginning of the string
re.search() checks for a match anywhere in the string (this is what Perl does by default)
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
https://docs.python.org/3/library/re.html#re.match
https://docs.python.org/3/library/re.html#re.search
