### PR TITLE
fix: More verbose exception for provider docs validator

### DIFF
--- a/scripts/docs_get_providers_list.py
+++ b/scripts/docs_get_providers_list.py
@@ -26,7 +26,7 @@ NON_DOCUMENTED_PROVIDERS = [
     "bash",
     "keep",
     "bigquery",
-    # "parseable",
+    "parseable",
 ] # known not documented providers https://github.com/keephq/keep/issues/2033
 
 

--- a/scripts/docs_get_providers_list.py
+++ b/scripts/docs_get_providers_list.py
@@ -26,8 +26,7 @@ NON_DOCUMENTED_PROVIDERS = [
     "bash",
     "keep",
     "bigquery",
-    "parseable",
-    "smtp",
+    # "parseable",
 ] # known not documented providers https://github.com/keephq/keep/issues/2033
 
 
@@ -58,11 +57,15 @@ def validate_all_providers_are_documented(documented_providers):
     for provider in ProvidersFactory.get_all_providers():
         provider_name = provider.display_name.lower()
         if provider_name not in documented_providers and provider_name not in NON_DOCUMENTED_PROVIDERS:
-            print(
-                f"""Provider {provider_name} is not documented in the docs/providers/documentation folder,
-please document it and run the scripts/docs_get_providers_list.py --validate script again."""
-            )
-            raise Exception(f"Provider {provider_name} is not documented.")
+            raise Exception(f"""Provider "{provider_name}" is not documented in the docs/providers/documentation folder,
+please document it and run the scripts/docs_get_providers_list.py --validate script again.
+
+Provider's PROVIDER_DISPLAY_NAME should match the title in the documentation file: {{PROVIDER_DISPLAY_NAME}}-provider.mdx.
+
+{provider_name}-provider.mdx not found.
+
+Documented providers: {documented_providers}
+Excluded list: {NON_DOCUMENTED_PROVIDERS}""")
 
 def main():
     """


### PR DESCRIPTION
```
Exception: Provider "parseable" is not documented in the docs/providers/documentation folder,
please document it and run the scripts/docs_get_providers_list.py --validate script again.

Provider's PROVIDER_DISPLAY_NAME should match the title in the documentation file: {PROVIDER_DISPLAY_NAME}-provider.mdx.

parseable-provider.mdx not found.

Documented providers: ['azure aks', 'appdynamics', 'axiom', 'azure monitor', 'centreon', 'clickhouse', 'cloudwatch', 'console', 'coralogix', 'datadog', 'discord', 'elastic', 'gcp monitoring', 'github workflows', 'gitlab', 'gitlab pipelines', 'google chat', 'grafana', 'grafana incident', 'grafana oncall', 'http', 'ilert', 'incident.io', 'incident manager', 'jira on-prem', 'jira cloud', 'kibana', 'kubernetes', 'linear', 'linearb', 'mailchimp', 'mailgun', 'mattermost', 'microsoft planner', 'mongodb', 'mysql', 'netdata', 'new relic', 'ntfy.sh', 'openobserve', 'openshift', 'opsgenie', 'pagerduty', 'pagertree', 'pingdom', 'postgresql', 'pushover', 'quickchart', 'redmine', 'resend', 'rollbar', 'sendgrid', 'sentry', 'signalfx', 'signl4', 'site24x7', 'slack', 'smtp', 'snowflake', 'splunk', 'squadcast', 'ssh', 'statuscake', 'sumologic', 'teams', 'telegram', 'template', 'trello', 'twilio', 'uptimekuma', 'victoriametrics', 'webhook', 'websocket', 'zabbix', 'zenduty']
Excluded list: ['service now', 'python', 'prometheus
```

Closes https://github.com/keephq/keep/issues/2174