### PR TITLE
fix: copy/paste error with AlertStatus enum usage

### DIFF
--- a/keep/providers/netdata_provider/netdata_provider.py
+++ b/keep/providers/netdata_provider/netdata_provider.py
@@ -72,10 +72,10 @@ To send alerts from Netdata to Keep, Use the following webhook url to configure 
             ),
             status=(
                 NetdataProvider.STATUS_MAP.get(
-                    event["status"]["text"], AlertStatus.INFO
+                    event["status"]["text"], AlertStatus.FIRING
                 )
                 if "status" in event
-                else AlertStatus.INFO
+                else AlertStatus.FIRING
             ),
             alert=event["alert"] if "alert" in event else None,
             url=(


### PR DESCRIPTION
## 📑 Description

Copy/Paste error fixed in netdata provider

attempt of ingesting events ended up with:

```
File "/venv/lib/python3.11/site-packages/keep/api/tasks/process_event_task.py", line 528, in process_event
event = provider_class.format_alert(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/venv/lib/python3.11/site-packages/keep/providers/base/base_provider.py", line 342, in format_alert
formatted_alert = cls._format_alert(event, provider_instance)                     
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
File "/venv/lib/python3.11/site-packages/keep/providers/netdata_provider/netdata_provider.py", line 75, in _format_alert   
event[\"status\"][\"text\"], AlertStatus.INFO
                             ^^^^^^^^^^^^^^^^  
File "/usr/local/lib/python3.11/enum.py", line 784, in __getattr__  
    raise AttributeError(name) from None
    AttributeError: INFO", 
```

looks like `.INFO` is from another enum (`AlertSeverity`) and was just pasted/mistyped

## ✅ Checks
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information

/close #2268
