### PR TITLE
docs: Fix typos on multiple pages of Keep Docs Site

### DIFF
--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -69,7 +69,7 @@ Resource provisioning settings control how Keep sets up initial resources. This 
 <Info>
 Authentication configuration determines how Keep verifies user identities and manages access control. These settings are essential for securing your Keep instance and integrating with various authentication providers.
 </Info>
-<Tip>For specifc authentication type configuration, please see [authentication docs](/deployment/authentication/overview).</Tip>
+<Tip>For specific authentication type configuration, please see [authentication docs](/deployment/authentication/overview).</Tip>
 
 
 | Env var | Purpose | Required | Default Value | Valid options |

--- a/docs/deployment/ecs.mdx
+++ b/docs/deployment/ecs.mdx
@@ -102,7 +102,7 @@ sidebarTitle: "AWS ECS"
             - Configuration Type: Configure at task definition creation
             - Volume type: EFS
             - Storage configurations:
-                - File system ID: Select an exisiting EFS filesystem or create a new one
+                - File system ID: Select an existing EFS filesystem or create a new one
                 - Root Directory: /
                 ![Volume Configuration](/images/ecs-task-def-backend5.png)
             - Container mount points:

--- a/docs/deployment/stress-testing.mdx
+++ b/docs/deployment/stress-testing.mdx
@@ -27,7 +27,7 @@ The primary parameters that affect the specification requirements for Keep are:
 3. **Number of Workflows**: How many automation run as a result of alert.
 
 ### Main Components:
-- **Keep Backend** - API and buisness logic. A container that serves FastAPI on top of gunicorn.
+- **Keep Backend** - API and business logic. A container that serves FastAPI on top of gunicorn.
 - **Keep Frontend** - Web app. A container that serves the react app.
 - **Database** - Stores the alerts and any other operational data.
 - **Elasticsearch** (opt out by default) - Stores alerts as document for better search performance.

--- a/docs/overview/comparisons.mdx
+++ b/docs/overview/comparisons.mdx
@@ -17,7 +17,7 @@ Keep is different because it’s able to correlate alerts between different obse
 |                                       | Keep                                                           | Alternative                  |
 | ------------------------------------- | -------------------------------------------------------------- | ---------------------------- |
 | Aggregates alerts from one platform | ✅                                                           | ✅                            |
-| Aggregates alerts from mutliple platforms | ✅                                                             | ❌                            |
+| Aggregates alerts from multiple platforms | ✅                                                             | ❌                            |
 | Correlates alerts between multiple sources | ✅                                                    | ❌                            |
 | Alerts enrichment                     | ✅                                                             | ❌                            |
 | Open source                           | ✅                                                             | ❌                            |

--- a/docs/overview/deduplication.mdx
+++ b/docs/overview/deduplication.mdx
@@ -20,7 +20,7 @@ Alert deduplication is a crucial feature in Keep that helps reduce noise and str
 Partial deduplication allows you to specify certain fields (fingerprint fields) that are used to identify similar alerts. Alerts with matching values in these specified fields are considered duplicates and are grouped together. This method is flexible and allows for fine-tuned control over how alerts are deduplicated.
 
 Every provider integrated with Keep comes with pre-built partial deduplication rule tailored to that provider's specific alert format and common use cases.
-The default fingerprint fields defined using `FINGERPRINT_FIELDS` attributes in the provider code (e.g. [datadog provider](https://github.com/keephq/keep/blob/main/keep/providers/datadog_provider/datadog_provider.py#L188) or [gcp monitoring provder](https://github.com/keephq/keep/blob/main/keep/providers/gcpmonitoring_provider/gcpmonitoring_provider.py#L52)).
+The default fingerprint fields defined using `FINGERPRINT_FIELDS` attributes in the provider code (e.g. [datadog provider](https://github.com/keephq/keep/blob/main/keep/providers/datadog_provider/datadog_provider.py#L188) or [gcp monitoring provider](https://github.com/keephq/keep/blob/main/keep/providers/gcpmonitoring_provider/gcpmonitoring_provider.py#L52)).
 
 ### Full Deduplication
 When full deduplication is enabled, Keep will also discard exact same events (excluding ignore fields). This mode considers all fields of an alert when determining duplicates, except for explicitly ignored fields.


### PR DESCRIPTION
Closes #2289

## 📑 Description

This PR fixes typos on the following pages of the Keep Docs site.

### [Configuration Page](https://docs.keephq.dev/deployment/configuration#authentication)

![Screenshot 2024-10-24 202952 (1)](https://github.com/user-attachments/assets/7a05ec39-0fca-45e6-959c-07643961f0e8)

### [Specifications Page](https://docs.keephq.dev/deployment/stress-testing#main-components)

![Screenshot 2024-10-24 203449 (1)](https://github.com/user-attachments/assets/10e4a1f1-f250-45e9-8e74-ef3c34700aec)

### [AWS ECS Page](https://docs.keephq.dev/deployment/ecs)

![Screenshot 2024-10-24 203827 (1)](https://github.com/user-attachments/assets/34c27471-a10e-4ca6-b28f-57148557889b)

### [Comparison Page](https://docs.keephq.dev/overview/comparisons#keep-vs-aiops-in-observability-elastic-splunk-etc)

![Screenshot 2024-10-24 204010 (1)](https://github.com/user-attachments/assets/f6fd43a6-57ab-462e-a1fa-1e05cf7a2de1)

### [Alert Deduplication Page](https://docs.keephq.dev/overview/deduplication#partial-deduplication)

![Screenshot 2024-10-24 204235 (1)](https://github.com/user-attachments/assets/be198482-ab5e-454b-a79f-634d1aaca1b3)

## ✅ Checks
- [x] This PR follows the Keep Contributing Guidelines.
