### PR TITLE
fix: alert enriching is always disposable (no matter query params)

### DIFF
--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -447,8 +447,12 @@ def enrich_alert(
     authenticated_entity: AuthenticatedEntity = Depends(
         IdentityManagerFactory.get_auth_verifier(["write:alert"])
     ),
+    dispose_on_new_alert: Optional[bool] = Query(False, description="Dispose on new alert"),
 ) -> dict[str, str]:
-    return _enrich_alert(enrich_data, authenticated_entity=authenticated_entity)
+    return _enrich_alert(enrich_data, 
+                         authenticated_entity=authenticated_entity, 
+                         dispose_on_new_alert=dispose_on_new_alert,
+    )
 
 
 def _enrich_alert(
@@ -457,9 +461,7 @@ def _enrich_alert(
     authenticated_entity: AuthenticatedEntity = Depends(
         IdentityManagerFactory.get_auth_verifier(["write:alert"])
     ),
-    dispose_on_new_alert: Optional[bool] = Query(
-        False, description="Dispose on new alert"
-    ),
+    dispose_on_new_alert: Optional[bool] = False,
 ) -> dict[str, str]:
     tenant_id = authenticated_entity.tenant_id
     logger.info(

--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -465,7 +465,6 @@ def enrich_alert(
 
 def _enrich_alert(
     enrich_data: EnrichAlertRequestBody,
-    pusher_client: Pusher | None = get_pusher_client(),
     authenticated_entity: AuthenticatedEntity = Depends(
         IdentityManagerFactory.get_auth_verifier(["write:alert"])
     ),
@@ -479,7 +478,6 @@ def _enrich_alert(
             "tenant_id": tenant_id,
         },
     )
-
     try:
         enrichement_bl = EnrichmentsBl(tenant_id)
         # Shahar: TODO, change to the specific action type, good enough for now
@@ -540,6 +538,7 @@ def _enrich_alert(
             logger.exception("Failed to push alert to elasticsearch")
             pass
         # use pusher to push the enriched alert to the client
+        pusher_client = get_pusher_client()
         if pusher_client:
             logger.info("Telling client to poll alerts")
             try:

--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -4,7 +4,7 @@ import hmac
 import json
 import logging
 import os
-from typing import Optional, List
+from typing import List, Optional
 
 import celpy
 from arq import ArqRedis
@@ -25,7 +25,12 @@ from keep.api.bl.enrichments_bl import EnrichmentsBl
 from keep.api.consts import KEEP_ARQ_QUEUE_BASIC
 from keep.api.core.config import config
 from keep.api.core.db import get_alert_audit as get_alert_audit_db
-from keep.api.core.db import get_alerts_by_fingerprint, get_enrichment, get_last_alerts, get_alerts_metrics_by_provider
+from keep.api.core.db import (
+    get_alerts_by_fingerprint,
+    get_alerts_metrics_by_provider,
+    get_enrichment,
+    get_last_alerts,
+)
 from keep.api.core.dependencies import extract_generic_body, get_pusher_client
 from keep.api.core.elastic import ElasticClient
 from keep.api.models.alert import (
@@ -37,15 +42,15 @@ from keep.api.models.alert import (
 from keep.api.models.alert_audit import AlertAuditDto
 from keep.api.models.db.alert import AlertActionType
 from keep.api.models.search_alert import SearchAlertsRequest
+from keep.api.models.time_stamp import TimeStampFilter
 from keep.api.tasks.process_event_task import process_event
 from keep.api.utils.email_utils import EmailTemplates, send_email
 from keep.api.utils.enrichment_helpers import convert_db_alerts_to_dto_alerts
+from keep.api.utils.time_stamp_helpers import get_time_stamp_filter
 from keep.identitymanager.authenticatedentity import AuthenticatedEntity
 from keep.identitymanager.identitymanagerfactory import IdentityManagerFactory
 from keep.providers.providers_factory import ProvidersFactory
 from keep.searchengine.searchengine import SearchEngine
-from keep.api.utils.time_stamp_helpers import get_time_stamp_filter
-from keep.api.models.time_stamp import TimeStampFilter
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -447,17 +452,20 @@ def enrich_alert(
     authenticated_entity: AuthenticatedEntity = Depends(
         IdentityManagerFactory.get_auth_verifier(["write:alert"])
     ),
-    dispose_on_new_alert: Optional[bool] = Query(False, description="Dispose on new alert"),
+    dispose_on_new_alert: Optional[bool] = Query(
+        False, description="Dispose on new alert"
+    ),
 ) -> dict[str, str]:
-    return _enrich_alert(enrich_data, 
-                         authenticated_entity=authenticated_entity, 
-                         dispose_on_new_alert=dispose_on_new_alert,
+    return _enrich_alert(
+        enrich_data,
+        authenticated_entity=authenticated_entity,
+        dispose_on_new_alert=dispose_on_new_alert,
     )
 
 
 def _enrich_alert(
     enrich_data: EnrichAlertRequestBody,
-    pusher_client: Pusher = Depends(get_pusher_client),
+    pusher_client: Pusher | None = get_pusher_client(),
     authenticated_entity: AuthenticatedEntity = Depends(
         IdentityManagerFactory.get_auth_verifier(["write:alert"])
     ),
@@ -772,17 +780,15 @@ def get_alert_quality(
 ):
     logger.info(
         "Fetching alert quality metrics per provider",
-        extra={
-            "tenant_id": authenticated_entity.tenant_id,
-            "fields": fields
-        },
-        
+        extra={"tenant_id": authenticated_entity.tenant_id, "fields": fields},
     )
     start_date = time_stamp.lower_timestamp if time_stamp else None
     end_date = time_stamp.upper_timestamp if time_stamp else None
     db_alerts_quality = get_alerts_metrics_by_provider(
-        tenant_id=authenticated_entity.tenant_id, start_date=start_date, end_date=end_date,
-        fields=fields
+        tenant_id=authenticated_entity.tenant_id,
+        start_date=start_date,
+        end_date=end_date,
+        fields=fields,
     )
-    
+
     return db_alerts_quality

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keep"
-version = "0.27.5"
+version = "0.27.6"
 description = "Alerting. for developers, by developers."
 authors = ["Keep Alerting LTD"]
 readme = "README.md"


### PR DESCRIPTION
## 📑 Description

/close #2292

In `_enrich_alert` function, you have the following parameter:
```python
dispose_on_new_alert: Optional[bool] = Query(False, description="Dispose on new alert")
```

Here, you're using `Query`, which is designed to be used in FastAPI endpoint functions to declare query parameters. When you use `Query`, FastAPI expects to parse this parameter from the incoming HTTP request.

However, `_enrich_alert` is not an endpoint function; it's a helper function that's being called directly from another function (`enrich_alert`). Seems like FastAPI's dependency injection system isn't in play for `_enrich_alert`, and `dispose_on_new_alert` is not being set from the HTTP request query parameters. Instead, **it's getting assigned the Query object itself as the default value**.  Since `dispose_on_new_alert` is set to the `Query` object, it becomes truthy in a boolean context. Therefore, when execution reach `if dispose_on_new_alert` condition in `_enrich_alert` it evaluates as `True`.

In logs it looks like this:

```bash
"Request started: POST /alerts/enrich",  # NO ?dispose_on_new_alert=true here
"Enriching alert", 
"Enriching disposable enrichments",  # yet notes are treated as disposable
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

