### PR TITLE
docs: Fix typos on certain pages of Keep Docs Site

### DIFF
--- a/docs/overview/examples.mdx
+++ b/docs/overview/examples.mdx
@@ -6,10 +6,10 @@ title: "Examples"
 
 
 ## Create an incident only if the customer is on Enterprise tier
-In this example we will utilze:
+In this example we will utilize:
 
 1. Datadog for monitoring
-2. OpsGenie for incident managment
+2. OpsGenie for incident management
 3. A postgres database that stores the customer tier.
 
 This example consists of two steps:
@@ -45,7 +45,7 @@ alert:
         type: opsgenie
         config: " {{ providers.opsgenie-prod }} "
         with:
-          message: "A new alert on enteprise customer ( {{ steps.check-if-customer-is-enterprise.results[1] }} )"
+          message: "A new alert on enterprise customer ( {{ steps.check-if-customer-is-enterprise.results[1] }} )"
 ```
 
 ## Send a slack message for every Cloudwatch alarm

--- a/docs/overview/introduction.mdx
+++ b/docs/overview/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-description: "Keep is an open-source alert management and automation tool that provides everything you need to collect, enrich and manange alerts effectively."
+description: "Keep is an open-source alert management and automation tool that provides everything you need to collect, enrich and manage alerts effectively."
 ---
 <Note> You can start using Keep by logging in to the [platform](https://platform.keephq.dev).</Note>
 

--- a/docs/overview/keyconcepts.mdx
+++ b/docs/overview/keyconcepts.mdx
@@ -23,7 +23,7 @@ A Provider can either push alerts into Keep, or Keep can pull alerts from the Pr
 #### Push alerts to Keep (Manual)
 You can configure your alert source to push alerts into Keep.
 
-For example, consider Promethues. If you want to push alerts from Promethues to Keep, you'll need to configure Promethues Alertmanager to send the alerts to
+For example, consider Prometheus. If you want to push alerts from Prometheus to Keep, you'll need to configure Prometheus Alertmanager to send the alerts to
 'https://api.keephq.dev/alerts/event/prometheus' using API key authentication. Each Provider implements Push mechanism and is documented under the specific Provider page.
 
 #### Push alerts to Keep (Automatic)

--- a/docs/providers/adding-a-new-provider.mdx
+++ b/docs/providers/adding-a-new-provider.mdx
@@ -2,7 +2,7 @@
 title: "Adding a new Provider"
 sidebarTitle: "Adding a New Provider"
 ---
-<Info>Under contstruction</Info>
+<Info>Under construction</Info>
 
 ### Basics
 
@@ -446,7 +446,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
     @staticmethod
     def parse_event_raw_body(raw_body: bytes) -> bytes:
         """
-        Parse the raw body of an event and create an ingestable dict from it.
+        Parse the raw body of an event and create an ingestible dict from it.
 
         For instance, in parseable, the "event" is just a string
         > b'Alert: Server side error triggered on teststream1\nMessage: server reporting status as 500\nFailing Condition: status column equal to abcd, 2 times'
@@ -459,7 +459,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
             raw_body (bytes): The raw body of the incoming event (/event endpoint in alerts.py)
 
         Returns:
-            dict: Ingestable event
+            dict: Ingestible event
         """
         return raw_body
 

--- a/docs/providers/documentation/auth0-provider.mdx
+++ b/docs/providers/documentation/auth0-provider.mdx
@@ -51,6 +51,6 @@ workflow:
           audience: "https://api.example.com"
           grant_type: "client_credentials"
 
-##Usefull Links
+## Useful Links
 -[Auth0 API Documentation](https://auth0.com/docs/api)
 -[Auth0 as an authentication method for keep](https://docs.keephq.dev/deployment/authentication/auth0-auth)


### PR DESCRIPTION
Fixes #2297 

## 📑 Description

This PR fixes typos on the following pages of the Keep Docs site.

-  **[Auth0 Page](https://docs.keephq.dev/providers/documentation/auth0-provider)**
-  **[Adding a new Provider Page](https://docs.keephq.dev/providers/adding-a-new-provider)**
-  **[Key concepts Page](https://docs.keephq.dev/overview/keyconcepts)**
-  **[Introduction Page](https://docs.keephq.dev/overview/introduction)**
-  **[Examples Page](https://docs.keephq.dev/overview/examples)**

## ✅ Checks
- [x] This PR follows the Keep Contributing Guidelines.