### PR TITLE
Introducing Keep Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@
     <a href="https://codecov.io/gh/keephq/keep" >
         <img src="https://codecov.io/gh/keephq/keep/branch/main/graph/badge.svg?token=2VT6XYMRGS"/>
     </a>
-    <a href="https://gurubase.io/g/keep">
-        <img src="https://img.shields.io/badge/Gurubase-Ask%20Keep%20Guru-006BFF" alt="Gurubase" />
-    </a>
 </div>
 <p align="center">
     <a href="#why-keep">Why Keep?</a>
@@ -34,6 +31,8 @@
     <a href="https://github.com/keephq/keep/issues/new?assignees=&labels=bug&template=bug_report.md&title=">Report Bug</a>
     ·
     <a href="https://slack.keephq.dev">Slack Community</a>
+    ·
+    <a href="https://gurubase.io/g/keep">Ask Keep Guru</a>
 </p>
 
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
     <a href="https://codecov.io/gh/keephq/keep" >
         <img src="https://codecov.io/gh/keephq/keep/branch/main/graph/badge.svg?token=2VT6XYMRGS"/>
     </a>
+    <a href="https://gurubase.io/g/keep">
+        <img src="https://img.shields.io/badge/Gurubase-Ask%20Keep%20Guru-006BFF" alt="Gurubase" />
+    </a>
 </div>
 <p align="center">
     <a href="#why-keep">Why Keep?</a>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Keep Guru](https://gurubase.io/g/keep) to Gurubase. Keep Guru uses the data from this repo and data from the [docs](https://docs.keephq.dev) to answer questions by leveraging the LLM.

In this PR, I showcased the "Keep Guru", which highlights that Keep now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Keep Guru in Gurubase, just let me know that's totally fine.
