### PR TITLE
fix: oauth2 not working due to providers caching

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -34,8 +34,6 @@ ENV VIRTUAL_ENV="/venv"
 ENV EE_PATH="ee"
 COPY --from=builder /venv /venv
 COPY --from=builder /app/examples /examples
-# Build the providers cache
-RUN keep provider build_cache
 # as per Openshift guidelines, https://docs.openshift.com/container-platform/4.11/openshift_images/create-images.html#use-uid_create-images
 RUN chgrp -R 0 /app && chmod -R g=u /app && \
     chown -R keep:keep /app && \

--- a/keep/entrypoint.sh
+++ b/keep/entrypoint.sh
@@ -11,5 +11,8 @@ SCRIPT_DIR=$(dirname "$0")
 
 python "$SCRIPT_DIR/server_jobs_bg.py" &
 
+# Build the providers cache
+keep provider build_cache
+
 # Execute the CMD provided in the Dockerfile or as arguments
 exec "$@"


### PR DESCRIPTION
Build providers cache on startup and not on build time (no env variables then). Adds a few seconds to start time.