### PR TITLE
fix: revert validation for Slack provider to work with oauth

### DIFF
--- a/keep/parser/parser.py
+++ b/keep/parser/parser.py
@@ -144,7 +144,7 @@ class Parser:
         self._load_providers_config(
             tenant_id, context_manager, workflow, providers_file, workflow_providers
         )
-        # Parsethe actions (from workflow, actions yaml and database)
+        # Parse the actions (from workflow, actions yaml and database)
         self._load_actions_config(
             tenant_id, context_manager, workflow, actions_file, workflow_actions
         )

--- a/keep/providers/slack_provider/slack_provider.py
+++ b/keep/providers/slack_provider/slack_provider.py
@@ -13,20 +13,19 @@ from keep.contextmanager.contextmanager import ContextManager
 from keep.exceptions.provider_exception import ProviderException
 from keep.providers.base.base_provider import BaseProvider
 from keep.providers.models.provider_config import ProviderConfig
-from keep.validation.fields import HttpsUrl
 
 
 @pydantic.dataclasses.dataclass
 class SlackProviderAuthConfig:
     """Slack authentication configuration."""
 
-    webhook_url: HttpsUrl = dataclasses.field(
+    webhook_url: str = dataclasses.field(
         metadata={
             "required": True,
             "description": "Slack Webhook Url",
-            "validation": "https_url",
             "sensitive": True,
         },
+        default="",
     )
     access_token: str = dataclasses.field(
         metadata={


### PR DESCRIPTION
Slack does not work with OAuth anymore because of the new validation method, reverting https://github.com/keephq/keep/pull/2430 for slack