### PR TITLE
feat(api): change calculation variable for pull data from providers

### DIFF
--- a/keep/api/consts.py
+++ b/keep/api/consts.py
@@ -6,8 +6,8 @@ from keep.api.models.db.preset import PresetDto, StaticPresetsId
 
 load_dotenv(find_dotenv())
 RUNNING_IN_CLOUD_RUN = os.environ.get("K_SERVICE") is not None
-PROVIDER_PULL_INTERVAL_DAYS = int(
-    os.environ.get("KEEP_PULL_INTERVAL", 7)
+PROVIDER_PULL_INTERVAL_MINUTE = int(
+    os.environ.get("KEEP_PULL_INTERVAL", 10080)
 )  # maximum once a week
 STATIC_PRESETS = {
     "feed": PresetDto(

--- a/keep/api/routes/preset.py
+++ b/keep/api/routes/preset.py
@@ -14,7 +14,7 @@ from fastapi import (
 from pydantic import BaseModel
 from sqlmodel import Session, select
 
-from keep.api.consts import PROVIDER_PULL_INTERVAL_DAYS, STATIC_PRESETS
+from keep.api.consts import PROVIDER_PULL_INTERVAL_MINUTE, STATIC_PRESETS
 from keep.api.core.db import get_db_preset_by_name
 from keep.api.core.db import get_presets as get_presets_db
 from keep.api.core.db import (
@@ -87,13 +87,13 @@ def pull_data_from_providers(
 
         if provider.last_pull_time is not None:
             now = datetime.now()
-            days_passed = (now - provider.last_pull_time).days
-            if days_passed <= PROVIDER_PULL_INTERVAL_DAYS:
+            minutes_passed = (now - provider.last_pull_time).total_seconds() / 60
+            if minutes_passed <= PROVIDER_PULL_INTERVAL_MINUTE:
                 logger.info(
                     "Skipping provider data pulling since not enough time has passed",
                     extra={
                         **extra,
-                        "days_passed": days_passed,
+                        "minutes_passed": minutes_passed,
                         "provider_last_pull_time": str(provider.last_pull_time),
                     },
                 )


### PR DESCRIPTION
## 📑 Description

At the moment, keep prefers to work with webhook from source systems. But my company prefers to initiate a request from keep (for example, Oracle Enterprise Management). In view of this, it is problematic to have a limitation in a variable "KEEP_PULL_INTERVAL", which represents days. As more flexibility, it would be better to give users the ability to configure the pulling time themselves (for example, in minutes). Of course, ideally for the pull data option, it is best to have such a variable in the provider itself, but as an intermediate flexible solution, I suggest considering giving users the freedom to configure data collection from sources themselves.

## ✅ Checks
- [ ] All the tests have passed

close #2975 
