### PR TITLE
fix: event as list[AlertDTO]  not included in the condition

### DIFF
--- a/keep/api/tasks/process_event_task.py
+++ b/keep/api/tasks/process_event_task.py
@@ -597,12 +597,26 @@ def process_event(
                 except Exception:
                     provider_class = ProvidersFactory.get_provider_class("keep")
 
-                event = provider_class.format_alert(
-                    tenant_id=tenant_id,
-                    event=event,
-                    provider_id=provider_id,
-                    provider_type=provider_type,
-                )
+                if isinstance(event, list):
+                    event_list = []
+                    for event_item in event:
+                        if not isinstance(event_item, AlertDto):
+                            event_list.append(provider_class.format_alert(
+                                tenant_id=tenant_id,
+                                event=event_item,
+                                provider_id=provider_id,
+                                provider_type=provider_type,
+                            ))
+                        else:
+                            event_list.append(event_item)
+                    event = event_list
+                else:
+                    event = provider_class.format_alert(
+                        tenant_id=tenant_id,
+                        event=event,
+                        provider_id=provider_id,
+                        provider_type=provider_type,
+                    )
                 # SHAHAR: for aws cloudwatch, we get a subscription notification message that we should skip
                 #         todo: move it to be generic
                 if event is None and provider_type == "cloudwatch":


### PR DESCRIPTION
close #2974 

## 📑 Description
in one of the conditions of the process_event function there is a flaw in processing event as a list. 2 months ago there was no such problem, but now when I upgraded the version of keep I found that zabbix provider started getting an error. while studying the issue (2 days) I finally understood what was the problem. The point is that in one of the conditions there is an attempt to convert dict into some formatted model, but the check condition checks list as well, without even trying to understand what is inside. The base_provider function requires implementing _format_alert, where event=dict. This means that you cannot pass list, or even list[alertDTO]. The change ensures that the _format_alert call is excluded if it is not dict.


# base_provider
```python
@staticmethod
    def _format_alert(
        event: dict | list[dict], provider_instance: "BaseProvider" = None
    ) -> AlertDto | list[AlertDto]:
```


## ✅ Checks
- [х] All the tests have passed
