### PR TITLE
fix: Filter out deleted and resolved incidents in navbar links.

### DIFF
--- a/keep-ui/components/navbar/IncidentLinks.tsx
+++ b/keep-ui/components/navbar/IncidentLinks.tsx
@@ -19,7 +19,7 @@ export const IncidentsLinks = ({ session }: IncidentsLinksProps) => {
     25,
     0,
     { id: "creation_time", desc: false },
-    '',
+    '!(status in [\'deleted\', \'resolved\'])',
     {}
   );
   usePollIncidents(mutate);

--- a/keep/api/models/db/migrations/versions/2025-02-05-15-46_e343054ae740.py
+++ b/keep/api/models/db/migrations/versions/2025-02-05-15-46_e343054ae740.py
@@ -6,7 +6,6 @@ Create Date: 2025-02-05 15:46:25.933229
 
 """
 
-import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import text
 from sqlalchemy.orm import Session


### PR DESCRIPTION
Updated the IncidentLinks component to exclude incidents with 'deleted' or 'resolved' statuses from the navbar list. This ensures only relevant incidents are displayed to the user.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3322

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
