### PR TITLE
docs(site24x7): add remark of using correct account uri

### DIFF
--- a/docs/providers/documentation/site24x7-provider.mdx
+++ b/docs/providers/documentation/site24x7-provider.mdx
@@ -75,8 +75,10 @@ To use the Site24x7 Provider, initialize it with the necessary authentication cr
 ---
 ## Notes
 
+- You must use your domain-specific Zoho Accounts URL to generate refresh tokens, otherwise you will receive an `invalid_client` error. See [Data center for Zoho Account](https://help.zoho.com/portal/en/kb/accounts/manage-your-zoho-account/articles/data-center-for-zoho-account).
 - Ensure that the necessary scopes **Site24x7.Admin.Read, Site24x7.Admin.Create, Site24x7.Operations.Read** are included when generating the grant token, as they dictate the API functionalities accessible via the provider.
 - Zoho API Console [Link](https://api-console.zoho.com)
+
 
 ## Webhook Integration Modifications
 
@@ -94,3 +96,4 @@ The webhook can be accessed via the "Alarms" section in the Site24x7 console.
 - [Zoho OAuth Documentation](https://www.zoho.com/accounts/protocol/oauth/web-apps.html)
 - [Site 24x7 Authentication Guide](https://www.site24x7.com/help/api/#authentication)
 - [Third Party and Webhook Integrations](https://www.site24x7.com/help/api/#third-party-integrations)
+- [List of Zoho Account datacenters](https://help.zoho.com/portal/en/kb/accounts/manage-your-zoho-account/articles/data-center-for-zoho-account)


### PR DESCRIPTION
close #3369 
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Adds a remark to the Site24x7 docs to ensure you use the correct Zoho account URI for generating the refresh token.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
