### PR TITLE
chore: loosen validation on host url of grafana-incident

### DIFF
--- a/keep/providers/grafana_incident_provider/grafana_incident_provider.py
+++ b/keep/providers/grafana_incident_provider/grafana_incident_provider.py
@@ -12,7 +12,6 @@ from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
 from keep.contextmanager.contextmanager import ContextManager
 from keep.providers.base.base_provider import BaseProvider
 from keep.providers.models.provider_config import ProviderConfig, ProviderScope
-from keep.validation.fields import HttpsUrl
 
 
 @pydantic.dataclasses.dataclass
@@ -21,12 +20,13 @@ class GrafanaIncidentProviderAuthConfig:
     GrafanaIncidentProviderAuthConfig is a class that allows to authenticate in Grafana Incident.
     """
 
-    host_url: HttpsUrl = dataclasses.field(
+    host_url: pydantic.AnyHttpUrl = dataclasses.field(
         metadata={
             "required": True,
             "description": "Grafana Host URL",
+            "hint": "e.g. https://keephq.grafana.net",
             "sensitive": False,
-            "validation": "https_url",
+            "validation": "any_http_url",
         },
     )
 


### PR DESCRIPTION
close #3382
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
<!-- Add a brief description of the pr -->
This _loosens_ the validation of the `Host` field on the Grafana Incident provider, matching that of the normal Grafana provider. 
While it is good to use HTTPS where possible, for certain use-cases it might not be possible/desirable (e.g. linking to services on K8s that use their ingress to do SSL termination).

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
