### PR TITLE
Feature: Added PresetLinkButton to GridItem

### DIFF
--- a/keep-ui/app/(keep)/dashboard/GridItem.tsx
+++ b/keep-ui/app/(keep)/dashboard/GridItem.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { AreaChart, Card } from "@tremor/react";
 import MenuButton from "./MenuButton";
+import PresetLinkButton from "./PresetLinkButton";
 import { WidgetData, WidgetType } from "./types";
 import AlertQuality from "@/app/(keep)/alerts/alert-quality-table";
 import { useSearchParams } from "next/navigation";
@@ -94,25 +95,30 @@ const GridItem: React.FC<GridItemProps> = ({
     >
       <div className="flex flex-col h-full">
         <div
-          className={`flex-none flex items-center justify-between p-2 ${
-            item.preset ? "h-1/5" : item.metric ? "h-1/5 mb-3" : "h-[10%]"
-          }`}
+          className={`flex-none flex items-center justify-between p-2 ${item.preset ? "h-1/5" : item.metric ? "h-1/5 mb-3" : "h-[10%]"
+            }`}
         >
           {/* For table view we need intract with table filter and pagination.so we aare dragging the widget here */}
           <span
-            className={`text-lg font-semibold truncate ${
-              item.preset ? "" : "grid-item__widget"
-            }`}
+            className={`text-lg font-semibold truncate ${item.preset ? "" : "grid-item__widget"
+              }`}
           >
             {item.name}
           </span>
-          <MenuButton
-            onEdit={handleEdit}
-            onDelete={() => onDelete(item.i)}
-            onSave={() => {
-              onSave(getUpdateItem());
-            }}
-          />
+          <div className="flex flex-col mt-7">
+            {item.preset &&
+              <PresetLinkButton
+                routePath={`/alerts/${item.preset?.name}`}>
+              </PresetLinkButton>
+            }
+            <MenuButton
+              onEdit={handleEdit}
+              onDelete={() => onDelete(item.i)}
+              onSave={() => {
+                onSave(getUpdateItem());
+              }}
+            />
+          </div>
         </div>
         {item.preset && (
           //We can remove drag and drop style and make it same as table view. if we want to maintain consistency.

--- a/keep-ui/app/(keep)/dashboard/MenuButton.tsx
+++ b/keep-ui/app/(keep)/dashboard/MenuButton.tsx
@@ -25,7 +25,7 @@ const MenuButton: React.FC<MenuButtonProps> = ({
       <Menu as="div" className="relative inline-block text-left z-10">
         <div>
           <Menu.Button
-            className="inline-flex w-full justify-center rounded-md text-sm mt-2"
+            className="inline-flex w-full justify-center rounded-md text-sm"
             onClick={stopPropagation}
           >
             <Icon

--- a/keep-ui/app/(keep)/dashboard/PresetLinkButton.tsx
+++ b/keep-ui/app/(keep)/dashboard/PresetLinkButton.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Navigation } from 'lucide-react';
+import { useRouter } from "next/navigation";
+
+interface PresetLinkButtonProps {
+    routePath: string;
+}
+
+const PresetLinkButton: React.FC<PresetLinkButtonProps> = ({
+    routePath
+}) => {
+    const router = useRouter();
+
+    const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+        router.push(routePath);
+    };
+
+    return (
+        <div className="w-44 text-right">
+            <div className="relative inline-block text-left z-10">
+                <div>
+                    <button
+                        onClick={handleClick}
+                        className="inline-flex justify-center items-center hover:bg-gray-100 w-8 h-8"
+                    >
+                        <Navigation color='gray' />
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default PresetLinkButton;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keep"
-version = "0.36.4"
+version = "0.36.5"
 description = "Alerting. for developers, by developers."
 authors = ["Keep Alerting LTD"]
 packages = [{include = "keep"}]


### PR DESCRIPTION

Closes #3413

## 📑 Description
Added a button to the preset widget in the Dasboards page that routes to the linked preset when clicked

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
