### PR TITLE
feat: modity incident summary data to show the text as it was added

### DIFF
--- a/keep-ui/app/(keep)/incidents/[id]/incident-overview.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/incident-overview.tsx
@@ -8,9 +8,7 @@ import React, { useState } from "react";
 import { useIncident, useIncidentAlerts } from "@/utils/hooks/useIncidents";
 import { Disclosure } from "@headlessui/react";
 import { IoChevronDown } from "react-icons/io5";
-import remarkRehype from "remark-rehype";
-import rehypeRaw from "rehype-raw";
-import Markdown from "react-markdown";
+import DOMpurify from 'isomorphic-dompurify';
 import { Badge, Callout } from "@tremor/react";
 import { Button, DynamicImageProviderIcon, Link } from "@/components/ui";
 import { IncidentChangeStatusSelect } from "@/features/change-incident-status";
@@ -94,9 +92,12 @@ function Summary({
   };
 
   const formatedSummary = (
-    <Markdown remarkPlugins={[remarkRehype]} rehypePlugins={[rehypeRaw]}>
-      {summary ?? generatedSummary}
-    </Markdown>
+    <div 
+      className="prose max-w-none [&_pre]:!p-2 [&_pre]:!my-2 [&_code]:!text-sm [&_pre]:!bg-gray-800 [&_pre]:!text-gray-100 [&_pre]:!rounded [&_pre]:!border [&_pre]:!border-gray-700"
+      dangerouslySetInnerHTML={{ 
+        __html: DOMpurify.sanitize(summary ?? generatedSummary)
+      }} 
+    />
   );
 
   if (collapsable) {

--- a/keep-ui/package.json
+++ b/keep-ui/package.json
@@ -55,6 +55,7 @@
     "eslint-utils": "^3.0.0",
     "eslint-visitor-keys": "^3.4.1",
     "https-proxy-agent": "^7.0.5",
+    "isomorphic-dompurify": "^2.21.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

/claim #3353


<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3353 

## 📑 Description
<!-- Add a brief description of the pr -->
I have changed the component from Markdown to div which uses html as react quill returns result in that format. To avoid attacks, I have also sanitized the input before rendering it.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

<img width="1338" alt="image" src="https://github.com/user-attachments/assets/f369de40-a32b-4e97-8eeb-c8e1593f75c7" />

in the screenshot I have done formatting as well as added a code line, those are reflected in summary, earlier, it was shown as only text.
