### PR TITLE
fix: JSON loading in migration script

### DIFF
--- a/keep/api/models/db/migrations/versions/2025-02-11-12-59_21d314490e6a.py
+++ b/keep/api/models/db/migrations/versions/2025-02-11-12-59_21d314490e6a.py
@@ -98,7 +98,8 @@ def upgrade() -> None:
     result = connection.execute(sa.text("SELECT id, matchers FROM mappingrule"))
     for row in result:
         old_matchers = row.matchers
-        old_matchers = json.loads(old_matchers)
+        if isinstance(old_matchers, str):
+            old_matchers = json.loads(old_matchers)
         new_matchers = []
         for matcher in old_matchers:
             m = matcher.split("&&") if isinstance(matcher, str) else matcher


### PR DESCRIPTION
Ensure `json.loads` is only called on string types to prevent type errors during migration. This update adds a type check for better robustness and handles non-string matcher inputs correctly.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3473 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
