### PR TITLE
fix: Add pulling availability support for providers

### DIFF
--- a/keep-ui/app/(keep)/providers/provider-form.tsx
+++ b/keep-ui/app/(keep)/providers/provider-form.tsx
@@ -574,24 +574,27 @@ const ProviderForm = ({
                     tooltip={`Whether to install Keep as a webhook integration in ${provider.type}. This allows Keep to asynchronously receive alerts from ${provider.type}. Please note that this will install a new integration in ${provider.type} and slightly modify your monitors/notification policy to include Keep.`}
                   />
                 </label>
-                <input
-                  type="checkbox"
-                  id="pulling_enabled"
-                  name="pulling_enabled"
-                  className="mr-2.5"
-                  onChange={handlePullingEnabledChange}
-                  checked={Boolean(formValues["pulling_enabled"])}
-                />
-                <label htmlFor="pulling_enabled" className="flex items-center">
-                  <Text className="capitalize">Pulling Enabled</Text>
-                  <Icon
-                    icon={QuestionMarkCircleIcon}
-                    variant="simple"
-                    color="gray"
-                    size="sm"
-                    tooltip={`Whether Keep should try to pull alerts automatically from the provider once in a while`}
+                {provider.pulling_available && <>
+                    <input
+                    type="checkbox"
+                    id="pulling_enabled"
+                    name="pulling_enabled"
+                    className="mr-2.5"
+                    onChange={handlePullingEnabledChange}
+                    checked={Boolean(formValues["pulling_enabled"])}
                   />
-                </label>
+                  <label htmlFor="pulling_enabled" className="flex items-center">
+                    <Text className="capitalize">Pulling Enabled</Text>
+                    <Icon
+                      icon={QuestionMarkCircleIcon}
+                      variant="simple"
+                      color="gray"
+                      size="sm"
+                      tooltip={`Whether Keep should try to pull alerts automatically from the provider once in a while`}
+                    />
+                  </label>
+                </>
+              }
               </div>
               {isLocalhost && (
                 <span className="text-sm">
@@ -619,6 +622,38 @@ const ProviderForm = ({
               )}
             </div>
           )}
+
+        {!isHealthCheck &&
+          !provider.can_setup_webhook &&
+          !installedProvidersMode && provider.pulling_available && (
+            <div
+              className={`${
+                isLocalhost ? "bg-gray-100 p-2 rounded-tremor-default" : ""
+              }`}
+            >
+              <div className="flex items-center">
+                    <input
+                    type="checkbox"
+                    id="pulling_enabled"
+                    name="pulling_enabled"
+                    className="mr-2.5"
+                    onChange={handlePullingEnabledChange}
+                    checked={Boolean(formValues["pulling_enabled"])}
+                  />
+                  <label htmlFor="pulling_enabled" className="flex items-center">
+                    <Text className="capitalize">Pulling Enabled</Text>
+                    <Icon
+                      icon={QuestionMarkCircleIcon}
+                      variant="simple"
+                      color="gray"
+                      size="sm"
+                      tooltip={`Whether Keep should try to pull alerts automatically from the provider once in a while`}
+                    />
+                  </label>
+              </div>
+            </div>
+          )}
+
       </div>
 
       {!isHealthCheck &&

--- a/keep-ui/app/(keep)/providers/providers.tsx
+++ b/keep-ui/app/(keep)/providers/providers.tsx
@@ -123,6 +123,7 @@ export interface Provider {
   methods?: ProviderMethod[];
   tags: TProviderLabels[];
   last_pull_time?: Date;
+  pulling_available: boolean;
   pulling_enabled: boolean;
   alertsDistribution?: AlertDistritbuionData[];
   alertExample?: { [key: string]: string };
@@ -147,6 +148,7 @@ export const defaultProvider: Provider = {
   type: "",
   tags: [],
   validatedScopes: {},
+  pulling_available: false,
   pulling_enabled: true,
   categories: ["Others"],
   coming_soon: false,

--- a/keep/api/models/provider.py
+++ b/keep/api/models/provider.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from keep.providers.models.provider_config import ProviderScope
 from keep.providers.models.provider_method import ProviderMethodDTO
@@ -15,7 +15,7 @@ class Provider(BaseModel):
     id: str | None = None
     display_name: str
     type: str
-    config: dict[str, dict] = {}
+    config: dict[str, dict] = Field(default_factory=dict)
     details: dict[str, dict] | None = None
     can_notify: bool
     # TODO: consider making it strongly typed for UI validations
@@ -34,11 +34,12 @@ class Provider(BaseModel):
     webhook_required: bool = False
     provider_description: str | None = None
     oauth2_url: str | None = None
-    scopes: list[ProviderScope] = []
-    validatedScopes: dict[str, bool | str] | None = {}
-    methods: list[ProviderMethodDTO] = []
+    scopes: list[ProviderScope] = Field(default_factory=list)
+    validatedScopes: dict[str, bool | str] | None = Field(default_factory=dict)
+    methods: list[ProviderMethodDTO] = Field(default_factory=list)
     installed_by: str | None = None
     installation_time: datetime | None = None
+    pulling_available: bool = False
     pulling_enabled: bool = True
     last_pull_time: datetime | None = None
     docs: str | None = None
@@ -46,8 +47,8 @@ class Provider(BaseModel):
         Literal[
             "alert", "ticketing", "messaging", "data", "queue", "topology", "incident"
         ]
-    ] = []
-    categories: list[str] = ["Others"]
+    ] = Field(default_factory=list)
+    categories: list[str] = Field(default_factory=lambda: ["Others"])
     coming_soon: bool = False
     alertsDistribution: dict[str, int] | None = None
     alertExample: dict | None = None

--- a/keep/providers/providers_factory.py
+++ b/keep/providers/providers_factory.py
@@ -353,8 +353,14 @@ class ProvidersFactory:
                 )
                 oauth2_url = provider_class.__dict__.get("OAUTH2_URL")
                 docs = provider_class.__doc__
+
+                can_fetch_alerts = (
+                    issubclass(provider_class, BaseProvider)
+                    and provider_class.__dict__.get("_get_alerts") is not None
+                )
                 can_fetch_topology = issubclass(provider_class, BaseTopologyProvider)
                 can_fetch_incidents = issubclass(provider_class, BaseIncidentProvider)
+                pulling_available = can_fetch_alerts or can_fetch_topology or can_fetch_incidents
 
                 provider_tags = set(provider_class.PROVIDER_TAGS)
                 if can_fetch_topology:
@@ -423,6 +429,9 @@ class ProvidersFactory:
                         categories=provider_class.PROVIDER_CATEGORY,
                         coming_soon=provider_class.PROVIDER_COMING_SOON,
                         health=provider_class.has_health_report(),
+                        pulling_available=pulling_available,
+                        # pulling can't be enabled if it's not available
+                        pulling_enabled=pulling_available,
                     )
                 )
             except ModuleNotFoundError:


### PR DESCRIPTION
Integrated logic and UI updates to distinguish if a provider supports pulling alerts. Introduced the `pulling_available` flag for providers, ensuring the "Pulling Enabled" checkbox only appears when applicable. Updated models, factory, and form components to reflect this functionality.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3243 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
