### PR TITLE
fix: Add optional 'predicted' filter support in useIncidents hook

### DIFF
--- a/keep-ui/app/(keep)/alerts/alert-associate-incident-modal.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-associate-incident-modal.tsx
@@ -28,7 +28,7 @@ const AlertAssociateIncidentModal = ({
 }: AlertAssociateIncidentModalProps) => {
   const [createIncident, setCreateIncident] = useState(false);
 
-  const { data: incidents, isLoading, mutate } = useIncidents(true, 100);
+  const { data: incidents, isLoading, mutate } = useIncidents(true, null, 100);
   usePollIncidents(mutate);
 
   const [selectedIncident, setSelectedIncident] = useState<

--- a/keep-ui/app/(keep)/alerts/alert-create-incident-ai-modal.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-create-incident-ai-modal.tsx
@@ -50,6 +50,7 @@ const CreateIncidentWithAIModal = ({
   const router = useRouter();
   const { mutate: mutateIncidents } = useIncidents(
     true,
+    null,
     20,
     0,
     { id: "creation_time", desc: true },

--- a/keep-ui/app/(keep)/alerts/alert-table-facet-value.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-table-facet-value.tsx
@@ -28,6 +28,7 @@ export const FacetValue: React.FC<FacetValueProps> = ({
 }) => {
   const { data: incidents } = useIncidents(
     true,
+    null,
     100,
     undefined,
     undefined,

--- a/keep-ui/components/navbar/IncidentLinks.tsx
+++ b/keep-ui/components/navbar/IncidentLinks.tsx
@@ -16,6 +16,7 @@ export const IncidentsLinks = ({ session }: IncidentsLinksProps) => {
   const isNOCRole = session?.userRole === "noc";
   const { data: incidents, mutate } = useIncidents(
     true,
+    null,
     25,
     0,
     { id: "creation_time", desc: false },

--- a/keep-ui/features/incident-list/ui/incident-list.tsx
+++ b/keep-ui/features/incident-list/ui/incident-list.tsx
@@ -62,6 +62,7 @@ export function IncidentList({
     error: incidentsError,
   } = useIncidents(
     true,
+    null,
     incidentsPagination.limit,
     incidentsPagination.offset,
     incidentsSorting[0],
@@ -74,7 +75,7 @@ export function IncidentList({
   );
 
   const { data: predictedIncidents, isLoading: isPredictedLoading } =
-    useIncidents(false);
+    useIncidents(false, true);
   const { incidentChangeToken } = usePollIncidents(mutateIncidents);
 
   const [incidentToEdit, setIncidentToEdit] = useState<IncidentDto | null>(

--- a/keep-ui/features/same-incidents-in-the-past/ui/change-same-incident-in-the-past-form.tsx
+++ b/keep-ui/features/same-incidents-in-the-past/ui/change-same-incident-in-the-past-form.tsx
@@ -19,7 +19,7 @@ export function ChangeSameIncidentInThePastForm({
   handleClose,
   linkedIncident,
 }: ChangeSameIncidentInThePastFormProps) {
-  const { data: incidents, isLoading } = useIncidents(true, 100);
+  const { data: incidents, isLoading } = useIncidents(true, null, 100);
 
   const [selectedIncident, setSelectedIncident] = useState<string | undefined>(
     linkedIncident?.id

--- a/keep-ui/features/split-incident-alerts/ui/split-incident-alerts-modal.tsx
+++ b/keep-ui/features/split-incident-alerts/ui/split-incident-alerts-modal.tsx
@@ -26,7 +26,7 @@ export function SplitIncidentAlertsModal({
 }: Props) {
   const { data: sourceIncident, isLoading: isSourceIncidentLoading } =
     useIncident(sourceIncidentId);
-  const { data: incidents, isLoading, mutate, error } = useIncidents(true, 100);
+  const { data: incidents, isLoading, mutate, error } = useIncidents(true, null, 100);
   usePollIncidents(mutate);
 
   const [destinationIncidentId, setDestinationIncidentId] = useState<string>();

--- a/keep-ui/utils/hooks/useIncidents.ts
+++ b/keep-ui/utils/hooks/useIncidents.ts
@@ -26,6 +26,7 @@ export interface Filters {
 
 export const useIncidents = (
   confirmed: boolean = true,
+  predicted: boolean | null = null,
   limit: number = 25,
   offset: number = 0,
   sorting: { id: string; desc: boolean } = { id: "creation_time", desc: false },
@@ -39,6 +40,9 @@ export const useIncidents = (
   const filtersParams = new URLSearchParams();
 
   filtersParams.set("confirmed", confirmed.toString());
+  if (predicted !== undefined && predicted !== null) {
+    filtersParams.set("predicted", predicted.toString());
+  }
 
   if (limit !== undefined) {
     filtersParams.set("limit", limit.toString());

--- a/keep/api/routes/incidents.py
+++ b/keep/api/routes/incidents.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from arq import ArqRedis
 from fastapi import (
@@ -123,6 +123,7 @@ def get_incidents_meta(
 )
 def get_all_incidents(
     confirmed: bool = True,
+    predicted: Optional[bool] = None,
     limit: int = 25,
     offset: int = 0,
     sorting: IncidentSorting = IncidentSorting.creation_time,
@@ -175,6 +176,7 @@ def get_all_incidents(
         incidents, total_count = get_last_incidents_by_cel(
             tenant_id=tenant_id,
             is_confirmed=confirmed,
+            is_predicted=predicted,
             limit=limit,
             offset=offset,
             sorting=sorting,


### PR DESCRIPTION
Updated the `useIncidents` hook and related API to include an optional `predicted` filter for improved incident querying capabilities. Adjusted all relevant components to pass the new parameter where applicable, ensuring consistent functionality across the application.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3504 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
