### PR TITLE
fix: Refactor incident resolution to remove rule dependency

### DIFF
--- a/keep/rulesengine/rulesengine.py
+++ b/keep/rulesengine/rulesengine.py
@@ -157,7 +157,7 @@ class RulesEngine:
                             send_created_event = incident.is_confirmed
 
                         incident = self._resolve_incident_if_require(
-                            rule, incident, session
+                            incident, session
                         )
                         session.add(incident)
                         session.commit()
@@ -339,24 +339,24 @@ class RulesEngine:
 
     @staticmethod
     def _resolve_incident_if_require(
-        rule: Rule, incident: Incident, session: Session
+        incident: Incident, session: Session
     ) -> Incident:
 
         should_resolve = False
 
-        if rule.resolve_on == ResolveOn.ALL.value and is_all_alerts_resolved(
+        if incident.resolve_on == ResolveOn.ALL.value and is_all_alerts_resolved(
             incident=incident, session=session
         ):
             should_resolve = True
 
         elif (
-            rule.resolve_on == ResolveOn.FIRST.value
+            incident.resolve_on == ResolveOn.FIRST.value
             and is_first_incident_alert_resolved(incident, session=session)
         ):
             should_resolve = True
 
         elif (
-            rule.resolve_on == ResolveOn.LAST.value
+            incident.resolve_on == ResolveOn.LAST.value
             and is_last_incident_alert_resolved(incident, session=session)
         ):
             should_resolve = True


### PR DESCRIPTION
Replaced rule-based logic with incident-based logic for determining resolution, removing the `rule` parameter from the `_resolve_incident_if_require` method. This improves code clarity and aligns resolution checks directly with the incident object.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3508

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
