### PR TITLE
fix: 500 on incident status change

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -4589,9 +4589,8 @@ def change_incident_status_by_id(
                 end_time=end_time,
             )
         )
-        updated = session.execute(stmt)
+        session.exec(stmt)
         session.commit()
-        return updated.rowcount > 0
 
 
 def get_workflow_executions_for_incident_or_alert(

--- a/keep/api/routes/incidents.py
+++ b/keep/api/routes/incidents.py
@@ -771,15 +771,9 @@ def change_incident_status(
         end_time = (
             datetime.utcnow() if change.status == IncidentStatus.RESOLVED else None
         )
-        result = change_incident_status_by_id(
+        change_incident_status_by_id(
             tenant_id, incident_id, change.status, end_time
         )
-        if not result:
-            raise HTTPException(
-                status_code=500, detail="Error changing incident status"
-            )
-        # TODO: same this change to audit table with the comment
-
         if change.status == IncidentStatus.RESOLVED:
             for alert in incident._alerts:
                 _enrich_alert(


### PR DESCRIPTION
For PostgreSQL: rowcount will be 0 because PostgreSQL doesn't count rows where no actual change was needed.

So, changing status to the same status for the incident caused 500 on PG. Removed the rowcount check because no need.

close https://github.com/keephq/keep/issues/3512