### PR TITLE
fix: allow up to 3 lines in alert description

### DIFF
--- a/keep-ui/app/(keep)/alerts/alert-table-utils.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-table-utils.tsx
@@ -307,7 +307,9 @@ export const useAlertTableCols = (
       minSize: 100,
       cell: (context) => (
         <div title={context.getValue()}>
-          <div className="truncate">{context.getValue()}</div>
+          <div className="truncate line-clamp-3 whitespace-pre-wrap">
+            {context.getValue()}
+          </div>
         </div>
       ),
     }),


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3522 

## Before
<img width="1131" alt="Screenshot 2025-02-17 at 18 40 57" src="https://github.com/user-attachments/assets/d6a5c659-fffb-4aea-9fc3-03dee6dc2da6" />

## After
<img width="1032" alt="Screenshot 2025-02-17 at 18 56 43 1" src="https://github.com/user-attachments/assets/2801504c-159a-46b4-bb0e-bf59a71abb05" />
