### PR TITLE
fix: Refactor ViewAlertModal to remove monaco-editor dependency

### DIFF
--- a/keep-ui/app/(keep)/alerts/ViewAlertModal.tsx
+++ b/keep-ui/app/(keep)/alerts/ViewAlertModal.tsx
@@ -7,7 +7,6 @@ import React, { useState, useRef, useEffect } from "react";
 import { useApi } from "@/shared/lib/hooks/useApi";
 import { showErrorToast } from "@/shared/ui";
 import Editor, { Monaco } from "@monaco-editor/react";
-import * as monaco from "monaco-editor";
 
 interface ViewAlertModalProps {
   alert: AlertDto | null | undefined;
@@ -23,7 +22,7 @@ export const ViewAlertModal: React.FC<ViewAlertModalProps> = ({
   const isOpen = !!alert;
   const [showHighlightedOnly, setShowHighlightedOnly] = useState(false);
   const api = useApi();
-  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const editorRef = useRef(null);
   const decorationsRef = useRef<string[]>([]);
 
   const unEnrichAlert = async (key: string) => {
@@ -43,13 +42,13 @@ export const ViewAlertModal: React.FC<ViewAlertModalProps> = ({
   };
 
   const handleEditorDidMount = (
-    editor: monaco.editor.IStandaloneCodeEditor,
+    editor: any,
     monacoInstance: Monaco
   ) => {
     editorRef.current = editor;
 
     // Add click handler
-    editor.onMouseDown((e) => {
+    editor.onMouseDown((e: any) => {
       if (!alert?.enriched_fields) return;
 
       const position = e.target.position;
@@ -94,13 +93,13 @@ export const ViewAlertModal: React.FC<ViewAlertModalProps> = ({
     }
   }, [showHighlightedOnly]);
 
-  const updateDecorations = (editor: monaco.editor.IStandaloneCodeEditor) => {
+  const updateDecorations = (editor: any) => {
     if (!alert?.enriched_fields || !editor) return;
 
     const model = editor.getModel();
     if (!model) return;
 
-    const decorations: monaco.editor.IModelDeltaDecoration[] = [];
+    const decorations: any[] = [];
 
     // For each enriched field, find its position and create a decoration
     alert.enriched_fields.forEach((field) => {
@@ -113,14 +112,13 @@ export const ViewAlertModal: React.FC<ViewAlertModalProps> = ({
         true
       );
 
-      matches.forEach((match) => {
+      matches.forEach((match: any) => {
         decorations.push({
           range: match.range,
           options: {
             inlineClassName: "enriched-field",
             hoverMessage: { value: "Click to un-enrich" },
-            stickiness:
-              monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+            stickiness: 1,
           },
         });
       });
@@ -132,7 +130,7 @@ export const ViewAlertModal: React.FC<ViewAlertModalProps> = ({
     );
   };
 
-  const editorOptions: monaco.editor.IStandaloneEditorConstructionOptions = {
+  const editorOptions: any = {
     readOnly: true,
     minimap: { enabled: false },
     lineNumbers: "on",


### PR DESCRIPTION
Replace direct references to monaco-editor's types with generic `any` types to decouple the component from the monaco-editor package. This simplifies the code by reducing dependency-specific bindings, but may slightly reduce type safety.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3538 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
