### PR TITLE
fix: Refactor dismissed enrichments to handle SUPPRESSED status

### DIFF
--- a/keep/api/models/alert.py
+++ b/keep/api/models/alert.py
@@ -339,8 +339,8 @@ class AlertDto(BaseModel):
         # if dismissed, change status to SUPPRESSED
         # note this is happen AFTER validate_dismissed which already consider
         #   dismissed + dismissUntil
-        if values.get("dismissed"):
-            values["status"] = AlertStatus.SUPPRESSED
+        # if values.get("dismissed"):
+        #     values["status"] = AlertStatus.SUPPRESSED
         return values
 
     class Config:

--- a/keep/api/models/db/migrations/versions/2025-02-18-18-09_876a424d8f06.py
+++ b/keep/api/models/db/migrations/versions/2025-02-18-18-09_876a424d8f06.py
@@ -6,13 +6,9 @@ Create Date: 2025-02-18 18:09:40.656808
 
 """
 
-import sqlalchemy as sa
-import sqlalchemy_utils
-import sqlmodel
 from alembic import op
-from sqlalchemy import select, func, and_, null
+from sqlalchemy import and_, null
 from sqlalchemy.orm.attributes import flag_modified
-# from sqlalchemy.orm import Session
 from sqlmodel import Session
 
 from keep.api.core.db_utils import get_json_extract_field

--- a/keep/api/models/db/migrations/versions/2025-02-18-18-09_876a424d8f06.py
+++ b/keep/api/models/db/migrations/versions/2025-02-18-18-09_876a424d8f06.py
@@ -1,0 +1,52 @@
+"""Extend dismissed enrichments with SUPPRESSED status
+
+Revision ID: 876a424d8f06
+Revises: 8176d7153747
+Create Date: 2025-02-18 18:09:40.656808
+
+"""
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+import sqlmodel
+from alembic import op
+from sqlalchemy import select, func, and_, null
+from sqlalchemy.orm.attributes import flag_modified
+# from sqlalchemy.orm import Session
+from sqlmodel import Session
+
+from keep.api.core.db_utils import get_json_extract_field
+from keep.api.models.alert import AlertStatus
+from keep.api.models.db.alert import AlertEnrichment, Alert
+
+# revision identifiers, used by Alembic.
+revision = "876a424d8f06"
+down_revision = "8176d7153747"
+branch_labels = None
+depends_on = None
+
+def populate_db():
+    session = Session(op.get_bind())
+
+    dismissed_field = get_json_extract_field(session, AlertEnrichment.enrichments, "dismissed")
+    status_field = get_json_extract_field(session, AlertEnrichment.enrichments, "status")
+
+    enrichments = session.query(AlertEnrichment).filter(
+        and_(
+            dismissed_field.in_(['true', 'True']),
+            status_field.is_(null())
+        )
+    ).all()
+
+    for enrichment in enrichments:
+        enrichment.enrichments['status'] = AlertStatus.SUPPRESSED.value
+        flag_modified(enrichment, "enrichments")
+        session.add(enrichment)
+    session.commit()
+
+def upgrade() -> None:
+    populate_db()
+
+
+def downgrade() -> None:
+    pass

--- a/keep/api/models/db/migrations/versions/2025-02-18-18-09_876a424d8f06.py
+++ b/keep/api/models/db/migrations/versions/2025-02-18-18-09_876a424d8f06.py
@@ -13,7 +13,7 @@ from sqlmodel import Session
 
 from keep.api.core.db_utils import get_json_extract_field
 from keep.api.models.alert import AlertStatus
-from keep.api.models.db.alert import AlertEnrichment, Alert
+from keep.api.models.db.alert import AlertEnrichment
 
 # revision identifiers, used by Alembic.
 revision = "876a424d8f06"

--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -44,7 +44,7 @@ from keep.api.models.alert import (
     DeleteRequestBody,
     EnrichAlertRequestBody,
     IncidentStatus,
-    UnEnrichAlertRequestBody,
+    UnEnrichAlertRequestBody, AlertStatus,
 )
 from keep.api.models.alert_audit import AlertAuditDto
 from keep.api.models.db.alert import ActionType
@@ -721,6 +721,18 @@ def enrich_alert(
     ),
     session: Session = Depends(get_session),
 ) -> dict[str, str]:
+    if "dismissed" in enrich_data.enrichments and enrich_data.enrichments["dismissed"].lower() == "true":
+        enrich_data.enrichments["status"] = AlertStatus.SUPPRESSED.value
+
+    tenant_id = authenticated_entity.tenant_id
+    logger.info(
+        "Enriching alert",
+        extra={
+            "fingerprint": enrich_data.fingerprint,
+            "tenant_id": tenant_id,
+        }
+    )
+
     return _enrich_alert(
         enrich_data,
         authenticated_entity=authenticated_entity,


### PR DESCRIPTION
Commented out direct status update in alert model and adapted enrichment logic to ensure dismissed alerts are tagged with SUPPRESSED status. Added a database migration to retroactively update enrichment statuses and modified the enrichment route to handle this condition dynamically.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3530

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
