### PR TITLE
fix: Force update for same_incident_in_the_past_id in incidents

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -3592,6 +3592,10 @@ def update_incident_from_dto_by_id(
                     if value is not None:
                         setattr(incident, key, value)
 
+        # Force update same_incident_in_the_past_id
+        if "same_incident_in_the_past_id" in updated_data:
+            incident.same_incident_in_the_past_id = updated_data["same_incident_in_the_past_id"]
+
         if generated_by_ai:
             incident.generated_summary = updated_incident_dto.user_summary
         else:


### PR DESCRIPTION
Ensure proper assignment of same_incident_in_the_past_id when present in updated data. This guarantees that the field is correctly updated during incident modifications.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3560 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
