### PR TITLE
chore: several improvements based on feedback

### DIFF
--- a/keep-ui/app/(keep)/alerts/alert-associate-incident-modal.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-associate-incident-modal.tsx
@@ -9,9 +9,13 @@ import {
 } from "../../../utils/hooks/useIncidents";
 import Loading from "@/app/(keep)/loading";
 import { AlertDto } from "@/entities/alerts/model";
-import { getIncidentName } from "@/entities/incidents/lib/utils";
+import {
+  getIncidentName,
+  getIncidentNameWithCreationTime,
+} from "@/entities/incidents/lib/utils";
 import { useApi } from "@/shared/lib/hooks/useApi";
 import { Select, showErrorToast } from "@/shared/ui";
+import { IncidentDto, Status } from "@/entities/incidents/model";
 
 interface AlertAssociateIncidentModalProps {
   isOpen: boolean;
@@ -77,6 +81,13 @@ const AlertAssociateIncidentModal = ({
     [associateAlertsHandler, handleClose, hideCreateIncidentForm]
   );
 
+  const filterIncidents = (incident: IncidentDto) => {
+    return (
+      incident.status === Status.Firing ||
+      incident.status === Status.Acknowledged
+    );
+  };
+
   // reset modal state after closing
   useEffect(() => {
     if (!isOpen) {
@@ -127,9 +138,9 @@ const AlertAssociateIncidentModal = ({
           onChange={(selectedOption) =>
             setSelectedIncident(selectedOption?.value)
           }
-          options={incidents.items?.map((incident) => ({
+          options={incidents.items?.filter(filterIncidents).map((incident) => ({
             value: incident.id,
-            label: getIncidentName(incident),
+            label: getIncidentNameWithCreationTime(incident),
           }))}
         />
         <Divider />

--- a/keep-ui/app/(keep)/alerts/alert-grouped-row.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-grouped-row.tsx
@@ -37,10 +37,6 @@ export const GroupedRow = ({
       ? row.getValue(groupingColumnId)
       : "Unknown Group";
 
-    const groupColumnIndex = row
-      .getVisibleCells()
-      .findIndex((cell) => cell.column.id === groupingColumnId);
-
     return (
       <>
         {/* Group Header Row */}
@@ -140,7 +136,7 @@ export const GroupedRow = ({
               className,
               rowBgColor,
               "group-hover:bg-orange-100",
-              isLastViewed && "bg-gray-50"
+              isLastViewed && "bg-orange-50"
             )}
             style={style}
           >

--- a/keep-ui/app/(keep)/alerts/alert-grouped-row.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-grouped-row.tsx
@@ -1,7 +1,7 @@
-import { TableBody, TableRow, TableCell } from "@tremor/react";
+import { TableBody, TableRow, TableCell, Icon } from "@tremor/react";
 import { AlertDto, Severity } from "@/entities/alerts/model";
 import { Table, flexRender, Row } from "@tanstack/react-table";
-import { ChevronDownIcon } from "@heroicons/react/24/outline";
+import { ChevronDownIcon, EyeIcon } from "@heroicons/react/24/outline";
 import clsx from "clsx";
 import { useState } from "react";
 import {
@@ -9,12 +9,16 @@ import {
   UISeverity,
   getCommonPinningStylesAndClassNames,
 } from "@/shared/ui";
+import { ViewedAlert } from "./alert-table";
+import { format } from "date-fns";
 
 interface GroupedRowProps {
   row: Row<AlertDto>;
   table: Table<AlertDto>;
   theme: Record<string, string>;
   onRowClick?: (e: React.MouseEvent, alert: AlertDto) => void;
+  viewedAlerts: ViewedAlert[];
+  lastViewedAlert: string | null;
 }
 
 export const GroupedRow = ({
@@ -22,6 +26,8 @@ export const GroupedRow = ({
   table,
   theme,
   onRowClick,
+  viewedAlerts,
+  lastViewedAlert,
 }: GroupedRowProps) => {
   const [isExpanded, setIsExpanded] = useState(true);
 
@@ -109,6 +115,10 @@ export const GroupedRow = ({
   // Regular non-grouped row
   const severity = row.original.severity || "info";
   const rowBgColor = theme[severity] || "bg-white";
+  const isLastViewed = row.original.fingerprint === lastViewedAlert;
+  const viewedAlert = viewedAlerts?.find(
+    (a) => a.fingerprint === row.original.fingerprint
+  );
   return (
     <TableRow
       id={`alert-row-${row.original.fingerprint}`}
@@ -129,11 +139,23 @@ export const GroupedRow = ({
               cell.column.columnDef.meta?.tdClassName,
               className,
               rowBgColor,
-              "group-hover:bg-orange-100"
+              "group-hover:bg-orange-100",
+              isLastViewed && "bg-gray-50"
             )}
             style={style}
           >
-            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            <div className="flex items-center gap-2">
+              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              {viewedAlert && cell.column.id === "alertMenu" && (
+                <Icon
+                  icon={EyeIcon}
+                  tooltip={`Viewed ${format(
+                    new Date(viewedAlert.viewedAt),
+                    "MMM d, yyyy HH:mm"
+                  )}`}
+                />
+              )}
+            </div>
           </TableCell>
         );
       })}

--- a/keep-ui/app/(keep)/alerts/alert-grouped-row.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-grouped-row.tsx
@@ -140,18 +140,7 @@ export const GroupedRow = ({
             )}
             style={style}
           >
-            <div className="flex items-center gap-2">
-              {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              {viewedAlert && cell.column.id === "alertMenu" && (
-                <Icon
-                  icon={EyeIcon}
-                  tooltip={`Viewed ${format(
-                    new Date(viewedAlert.viewedAt),
-                    "MMM d, yyyy HH:mm"
-                  )}`}
-                />
-              )}
-            </div>
+            {flexRender(cell.column.columnDef.cell, cell.getContext())}
           </TableCell>
         );
       })}

--- a/keep-ui/app/(keep)/alerts/alert-grouped-row.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-grouped-row.tsx
@@ -140,7 +140,21 @@ export const GroupedRow = ({
             )}
             style={style}
           >
-            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            {viewedAlert && cell.column.id === "alertMenu" ? (
+              <div className="flex items-center gap-2">
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+
+                <Icon
+                  icon={EyeIcon}
+                  tooltip={`Viewed ${format(
+                    new Date(viewedAlert.viewedAt),
+                    "MMM d, yyyy HH:mm"
+                  )}`}
+                />
+              </div>
+            ) : (
+              flexRender(cell.column.columnDef.cell, cell.getContext())
+            )}
           </TableCell>
         );
       })}

--- a/keep-ui/app/(keep)/alerts/alert-table-server-side.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-table-server-side.tsx
@@ -46,15 +46,13 @@ import { Icon } from "@tremor/react";
 import { BellIcon, BellSlashIcon } from "@heroicons/react/24/outline";
 import AlertPaginationServerSide from "./alert-pagination-server-side";
 import { FacetDto } from "@/features/filter";
-import {
-  GroupingState,
-  getGroupedRowModel,
-  getExpandedRowModel,
-} from "@tanstack/react-table";
+import { GroupingState, getGroupedRowModel } from "@tanstack/react-table";
 import { TimeFrame } from "@/components/ui/DateRangePicker";
 import { AlertsQuery } from "@/utils/hooks/useAlerts";
 import { v4 as uuidV4 } from "uuid";
 import { FacetsConfig } from "@/features/filter/models";
+import { ViewedAlert } from "./alert-table";
+
 const AssigneeLabel = ({ email }: { email: string }) => {
   const user = useUser(email);
   return user ? user.name : email;
@@ -168,6 +166,12 @@ export function AlertTableServerSide({
     pageIndex: 0,
     pageSize: 20,
   });
+
+  const [viewedAlerts, setViewedAlerts] = useLocalStorage<ViewedAlert[]>(
+    `viewed-alerts-${presetName}`,
+    []
+  );
+  const [lastViewedAlert, setLastViewedAlert] = useState<string | null>(null);
 
   useEffect(() => {
     const filterArray = [];
@@ -306,6 +310,22 @@ export function AlertTableServerSide({
     if (presetName === "alert-history") {
       return;
     }
+
+    // Update viewed alerts
+    setViewedAlerts((prev) => {
+      const newViewedAlerts = prev.filter(
+        (a) => a.fingerprint !== alert.fingerprint
+      );
+      return [
+        ...newViewedAlerts,
+        {
+          fingerprint: alert.fingerprint,
+          viewedAt: new Date().toISOString(),
+        },
+      ];
+    });
+
+    setLastViewedAlert(alert.fingerprint);
     setSelectedAlert(alert);
     setIsSidebarOpen(true);
   };
@@ -528,6 +548,8 @@ export function AlertTableServerSide({
                       showFilterEmptyState={showFilterEmptyState}
                       showSearchEmptyState={showSearchEmptyState}
                       theme={theme}
+                      viewedAlerts={viewedAlerts}
+                      lastViewedAlert={lastViewedAlert}
                       onRowClick={handleRowClick}
                       presetName={presetName}
                     />

--- a/keep-ui/app/(keep)/alerts/alerts-table-body.tsx
+++ b/keep-ui/app/(keep)/alerts/alerts-table-body.tsx
@@ -1,4 +1,4 @@
-import { TableBody, TableRow, TableCell, Icon } from "@tremor/react";
+import { TableBody, TableRow, TableCell } from "@tremor/react";
 import { AlertDto } from "@/entities/alerts/model";
 import Skeleton from "react-loading-skeleton";
 import "react-loading-skeleton/dist/skeleton.css";
@@ -6,13 +6,8 @@ import { Table } from "@tanstack/react-table";
 import React, { useState } from "react";
 import PushAlertToServerModal from "./alert-push-alert-to-server-modal";
 import { EmptyStateCard } from "@/components/ui/EmptyStateCard";
-import {
-  MagnifyingGlassIcon,
-  FunnelIcon,
-  EyeIcon,
-} from "@heroicons/react/24/outline";
+import { MagnifyingGlassIcon, FunnelIcon } from "@heroicons/react/24/outline";
 import { GroupedRow } from "./alert-grouped-row";
-import { format } from "date-fns";
 import { ViewedAlert } from "./alert-table";
 
 interface Props {

--- a/keep-ui/app/(keep)/alerts/alerts-table-body.tsx
+++ b/keep-ui/app/(keep)/alerts/alerts-table-body.tsx
@@ -1,4 +1,4 @@
-import { TableBody, TableRow, TableCell } from "@tremor/react";
+import { TableBody, TableRow, TableCell, Icon } from "@tremor/react";
 import { AlertDto } from "@/entities/alerts/model";
 import Skeleton from "react-loading-skeleton";
 import "react-loading-skeleton/dist/skeleton.css";
@@ -6,8 +6,14 @@ import { Table } from "@tanstack/react-table";
 import React, { useState } from "react";
 import PushAlertToServerModal from "./alert-push-alert-to-server-modal";
 import { EmptyStateCard } from "@/components/ui/EmptyStateCard";
-import { MagnifyingGlassIcon, FunnelIcon } from "@heroicons/react/24/outline";
+import {
+  MagnifyingGlassIcon,
+  FunnelIcon,
+  EyeIcon,
+} from "@heroicons/react/24/outline";
 import { GroupedRow } from "./alert-grouped-row";
+import { format } from "date-fns";
+import { ViewedAlert } from "./alert-table";
 
 interface Props {
   table: Table<AlertDto>;
@@ -18,6 +24,8 @@ interface Props {
   theme: { [key: string]: string };
   onRowClick: (alert: AlertDto) => void;
   presetName: string;
+  viewedAlerts: ViewedAlert[];
+  lastViewedAlert: string | null;
 }
 
 export function AlertsTableBody({
@@ -29,6 +37,8 @@ export function AlertsTableBody({
   presetName,
   showFilterEmptyState,
   showSearchEmptyState,
+  viewedAlerts,
+  lastViewedAlert,
 }: Props) {
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -148,6 +158,8 @@ export function AlertsTableBody({
           table={table}
           theme={theme}
           onRowClick={handleRowClick}
+          viewedAlerts={viewedAlerts}
+          lastViewedAlert={lastViewedAlert}
         />
       ))}
     </TableBody>

--- a/keep-ui/app/(keep)/incidents/[id]/activity/ui/IncidentActivityComment.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/activity/ui/IncidentActivityComment.tsx
@@ -19,7 +19,7 @@ export function IncidentActivityComment({
 
   const onSubmit = useCallback(async () => {
     try {
-      const response = await api.post(`/incidents/${incident.id}/comment`, {
+      await api.post(`/incidents/${incident.id}/comment`, {
         status: incident.status,
         comment,
       });

--- a/keep-ui/app/(keep)/incidents/[id]/activity/ui/IncidentActivityItem.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/activity/ui/IncidentActivityItem.tsx
@@ -2,16 +2,21 @@ import AlertSeverity from "@/app/(keep)/alerts/alert-severity";
 import { AlertDto } from "@/entities/alerts/model";
 import TimeAgo from "react-timeago";
 
+// TODO: REFACTOR THIS TO SUPPORT ANY ACTIVITY TYPE, IT'S A MESS!
+
 export function IncidentActivityItem({ activity }: { activity: any }) {
   const title =
     typeof activity.initiator === "string"
       ? activity.initiator
       : activity.initiator?.name;
   const subTitle =
-    typeof activity.initiator === "string"
+    activity.type === "comment"
       ? " Added a comment. "
-      : (activity.initiator?.status === "firing" ? " triggered" : " resolved") +
-        ". ";
+      : activity.type === "statuschange"
+      ? " Incident status changed. "
+      : activity.initiator?.status === "firing"
+      ? " triggered"
+      : " resolved" + ". ";
   return (
     <div className="relative h-full w-full flex flex-col">
       <div className="flex items-center gap-2">

--- a/keep-ui/app/(keep)/incidents/[id]/timeline/incident-timeline.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/timeline/incident-timeline.tsx
@@ -59,9 +59,7 @@ const AlertEventInfo: React.FC<{ event: AuditEvent; alert: AlertDto }> = ({
 }) => {
   return (
     <div className="h-full p-4 bg-gray-100 border-l">
-      <h2 className="font-semibold mb-2">
-        {alert.name} ({alert.fingerprint})
-      </h2>
+      <h2 className="font-semibold mb-2">{alert.name}</h2>
       <p className="mb-2 text-md">{alert.description}</p>
       <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
         <p className="text-gray-400">Date:</p>

--- a/keep-ui/app/(keep)/workflows/manual-run-workflow-modal.tsx
+++ b/keep-ui/app/(keep)/workflows/manual-run-workflow-modal.tsx
@@ -48,11 +48,24 @@ export default function ManualRunWorkflowModal({
         }
       );
 
-      // Workflow started successfully
-      toast.success("Workflow started successfully", { position: "top-left" });
       const { workflow_execution_id } = responseData;
-      router.push(
-        `/workflows/${selectedWorkflowId}/runs/${workflow_execution_id}`
+      const executionUrl = `/workflows/${selectedWorkflowId}/runs/${workflow_execution_id}`;
+
+      toast.success(
+        <div>
+          Workflow started successfully.{" "}
+          <a
+            href={executionUrl}
+            className="text-orange-500 hover:text-orange-600 underline"
+            onClick={(e) => {
+              e.preventDefault();
+              router.push(executionUrl);
+            }}
+          >
+            View execution
+          </a>
+        </div>,
+        { position: "top-right" }
       );
     } catch (error) {
       showErrorToast(error, "Failed to start workflow");

--- a/keep-ui/entities/incidents/lib/utils.ts
+++ b/keep-ui/entities/incidents/lib/utils.ts
@@ -1,5 +1,9 @@
 import { IncidentDto } from "@/entities/incidents/model";
-import {ExclamationCircleIcon, ExclamationTriangleIcon, InformationCircleIcon} from "@heroicons/react/20/solid";
+import {
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InformationCircleIcon,
+} from "@heroicons/react/20/solid";
 
 export function getIncidentName(incident: IncidentDto) {
   return (
@@ -7,8 +11,13 @@ export function getIncidentName(incident: IncidentDto) {
   );
 }
 
+export function getIncidentNameWithCreationTime(incident: IncidentDto) {
+  return `${incident.user_generated_name || incident.ai_generated_name || incident.id} (${incident.creation_time})`;
+}
 
-export function getIncidentSeverityIconAndColor(severity: IncidentDto["severity"]) {
+export function getIncidentSeverityIconAndColor(
+  severity: IncidentDto["severity"]
+) {
   let icon: any;
   let color: any;
 
@@ -38,5 +47,5 @@ export function getIncidentSeverityIconAndColor(severity: IncidentDto["severity"
       color = "blue";
       break;
   }
-  return {icon, color}
+  return { icon, color };
 }

--- a/keep-ui/entities/incidents/model/useIncidentActions.tsx
+++ b/keep-ui/entities/incidents/model/useIncidentActions.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { toast } from "react-toastify";
 import { useSWRConfig } from "swr";
-import {IncidentDto, Severity, Status} from "./models";
+import { IncidentDto, Severity, Status } from "./models";
 import { useApi } from "@/shared/lib/hooks/useApi";
 import { showErrorToast } from "@/shared/ui";
 
@@ -212,12 +212,13 @@ export function useIncidentActions(): UseIncidentActionsValue {
 
         toast.success("Incident status changed successfully!");
         mutateIncidentsList();
+        mutateIncident(incidentId);
         return result;
       } catch (error) {
         showErrorToast(error, "Failed to change incident status");
       }
     },
-    [api, mutateIncidentsList]
+    [api, mutateIncident, mutateIncidentsList]
   );
 
   const changeSeverity = useCallback(

--- a/keep/api/models/db/alert.py
+++ b/keep/api/models/db/alert.py
@@ -500,3 +500,4 @@ class ActionType(enum.Enum):
     MAINTENANCE = "Alert is in maintenance window"
     INCIDENT_COMMENT = "A comment was added to the incident"
     INCIDENT_ENRICH = "Incident enriched"
+    INCIDENT_STATUS_CHANGE = "Incident status changed"

--- a/keep/api/routes/incidents.py
+++ b/keep/api/routes/incidents.py
@@ -789,6 +789,8 @@ def change_incident_status(
                     authenticated_entity=authenticated_entity,
                 )
         incident.end_time = end_time
+        incident.assignee = authenticated_entity.email
+        incident.status = change.status
         add_audit(
             tenant_id,
             str(incident_id),
@@ -796,8 +798,6 @@ def change_incident_status(
             ActionType.INCIDENT_STATUS_CHANGE,
             f"Incident status changed from {incident.status} to {change.status} by {authenticated_entity.email}",
         )
-        incident.assignee = authenticated_entity.email
-        incident.status = change.status
 
     new_incident_dto = IncidentDto.from_db_incident(incident)
 

--- a/keep/api/routes/incidents.py
+++ b/keep/api/routes/incidents.py
@@ -789,6 +789,14 @@ def change_incident_status(
                     authenticated_entity=authenticated_entity,
                 )
         incident.end_time = end_time
+        add_audit(
+            tenant_id,
+            str(incident_id),
+            authenticated_entity.email,
+            ActionType.INCIDENT_STATUS_CHANGE.value,
+            f"Incident status changed from {incident.status} to {change.status} by {authenticated_entity.email}",
+        )
+        incident.assignee = authenticated_entity.email
         incident.status = change.status
 
     new_incident_dto = IncidentDto.from_db_incident(incident)

--- a/keep/api/routes/incidents.py
+++ b/keep/api/routes/incidents.py
@@ -793,7 +793,7 @@ def change_incident_status(
             tenant_id,
             str(incident_id),
             authenticated_entity.email,
-            ActionType.INCIDENT_STATUS_CHANGE.value,
+            ActionType.INCIDENT_STATUS_CHANGE,
             f"Incident status changed from {incident.status} to {change.status} by {authenticated_entity.email}",
         )
         incident.assignee = authenticated_entity.email


### PR DESCRIPTION
close #3549 
close #3548 

- Fixed incident status change to acknowledge to ack alerts too
- Looking at some alert will show an icon that this alert was viewed before and highlight the last alert that was looked at
![CleanShot 2025-02-19 at 16 30 50](https://github.com/user-attachments/assets/348b3f39-55fc-44dd-bc05-d9204e3dde86)
- Alert self-assign changes the alert status to acknowledged
- Incident status change audit message
- Incident status change assignes changing user
- Removed fingerprint from AlertEventInfo
- Workflow execution doesn't take you to the execution but proposes in Toast
![CleanShot 2025-02-19 at 16 36 32](https://github.com/user-attachments/assets/eb27b2b9-8440-4212-a4aa-2ef6e1902c80)
- Filter resolved and deleted incidents with alert association modal 
