### PR TITLE
feat: AWS EC2 IAM

### DIFF
--- a/keep/providers/amazonsqs_provider/amazonsqs_provider.py
+++ b/keep/providers/amazonsqs_provider/amazonsqs_provider.py
@@ -27,15 +27,15 @@ class AmazonsqsProviderAuthConfig:
 
     access_key_id: str = dataclasses.field(
         metadata={
-            "required": True,
-            "description": "Access Key Id",
+            "required": False,
+            "description": "Access Key Id (Leave empty if using IAM role at EC2)",
             "hint": "Access Key ID",
         },
     )
     secret_access_key: str = dataclasses.field(
         metadata={
-            "required": True,
-            "description": "Secret access key",
+            "required": False,
+            "description": "Secret access key (Leave empty if using IAM role at EC2)",
             "hint": "Secret access key",
             "sensitive": True,
         },

--- a/keep/providers/cloudwatch_provider/cloudwatch_provider.py
+++ b/keep/providers/cloudwatch_provider/cloudwatch_provider.py
@@ -24,12 +24,16 @@ from keep.providers.models.provider_config import ProviderConfig, ProviderScope
 @pydantic.dataclasses.dataclass
 class CloudwatchProviderAuthConfig:
     access_key: str = dataclasses.field(
-        metadata={"required": True, "description": "AWS access key", "sensitive": True}
+        metadata={
+            "required": False,
+            "description": "AWS access key (Leave empty if using IAM role at EC2)",
+            "sensitive": True,
+        }
     )
     access_key_secret: str = dataclasses.field(
         metadata={
-            "required": True,
-            "description": "AWS access key secret",
+            "required": False,
+            "description": "AWS access key secret (Leave empty if using IAM role at EC2)",
             "sensitive": True,
         }
     )

--- a/keep/providers/eks_provider/eks_provider.py
+++ b/keep/providers/eks_provider/eks_provider.py
@@ -22,13 +22,13 @@ class EksProviderAuthConfig:
     """EKS authentication configuration."""
 
     access_key: str = dataclasses.field(
-        metadata={"required": True, "description": "AWS access key", "sensitive": True}
+        metadata={"required": False, "description": "AWS access key (Leave empty if using IAM role at EC2)", "sensitive": True}
     )
 
     secret_access_key: str = dataclasses.field(
         metadata={
-            "required": True,
-            "description": "AWS secret access key",
+            "required": False,
+            "description": "AWS secret access key (Leave empty if using IAM role at EC2)",
             "sensitive": True,
         }
     )

--- a/keep/providers/incidentmanager_provider/incidentmanager_provider.py
+++ b/keep/providers/incidentmanager_provider/incidentmanager_provider.py
@@ -21,12 +21,16 @@ from keep.providers.models.provider_config import ProviderConfig, ProviderScope
 @pydantic.dataclasses.dataclass
 class IncidentmanagerProviderAuthConfig:
     access_key: str = dataclasses.field(
-        metadata={"required": True, "description": "AWS access key", "sensitive": True}
+        metadata={
+            "required": False,
+            "description": "AWS access key (Leave empty if using IAM role at EC2)",
+            "sensitive": True,
+        }
     )
     access_key_secret: str = dataclasses.field(
         metadata={
-            "required": True,
-            "description": "AWS access key secret",
+            "required": False,
+            "description": "AWS access key secret (Leave empty if using IAM role at EC2)",
             "sensitive": True,
         }
     )

--- a/keep/providers/s3_provider/s3_provider.py
+++ b/keep/providers/s3_provider/s3_provider.py
@@ -15,8 +15,8 @@ from keep.providers.base.base_provider import BaseProvider
 class S3ProviderAuthConfig:
     access_key: str = dataclasses.field(
         metadata={
-            "required": True,
-            "description": "S3 Access Token",
+            "required": False,
+            "description": "S3 Access Token (Leave empty if using IAM role at EC2)",
             "sensitive": True,
         },
         default=None,
@@ -24,8 +24,8 @@ class S3ProviderAuthConfig:
 
     secret_access_key: str = dataclasses.field(
         metadata={
-            "required": True,
-            "description": "S3 Secret Access Token",
+            "required": False,
+            "description": "S3 Secret Access Token (Leave empty if using IAM role at EC2)",
             "sensitive": True,
         },
         default=None,
@@ -40,9 +40,7 @@ class S3Provider(BaseProvider):
         pass
 
     def validate_config(self):
-        self.authentication_config = S3ProviderAuthConfig(
-            **self.config.authentication
-        )
+        self.authentication_config = S3ProviderAuthConfig(**self.config.authentication)
         if (
             self.authentication_config.access_key is None
             or self.authentication_config.secret_access_key is None
@@ -87,7 +85,7 @@ class S3Provider(BaseProvider):
             if any(key.endswith(ext) for ext in valid_extensions):
                 try:
                     response = s3_client.get_object(Bucket=bucket, Key=key)
-                    files.append(response.get("Body").read().decode('utf-8'))
+                    files.append(response.get("Body").read().decode("utf-8"))
                     print(files)
                 except Exception as e:
                     self.logger.exception(


### PR DESCRIPTION
Leverage EC2 attached IAM for AWS integration. Following this instruction:

First, create an IAM policy:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:GetObject",
                "s3:PutObject",
                "s3:ListBucket",
                "s3:DeleteObject"
            ],
            "Resource": [
                "arn:aws:s3:::non-public-keep",
                "arn:aws:s3:::non-public-keep/*"
            ]
        }
    ]
}
```
Steps to create and attach the role:

Go to IAM in AWS Console
Click "Roles" → "Create role"
Select "AWS service" as trusted entity
Choose "EC2" as use case
Attach the policy above (you'll need to create it first)
Name the role (e.g., "EC2-S3-NonPublicKeep-Access")

To attach the role to your EC2 instance:

Go to EC2 in AWS Console
Select your instance
Click "Actions" → "Security" → "Modify IAM role"
Select the role you created
Click "Save"

To verify it works, you can test with this Python code on your EC2:
```
import boto3

s3 = boto3.client('s3', region_name='eu-north-1')

# List objects in bucket
response = s3.list_objects_v2(Bucket='non-public-keep')
for obj in response.get('Contents', []):
    print(obj['Key'])
```