### PR TITLE
feat: Add date range filter to incident list

### DIFF
--- a/keep-ui/features/incident-list/ui/incident-list.tsx
+++ b/keep-ui/features/incident-list/ui/incident-list.tsx
@@ -347,6 +347,7 @@ export function IncidentList({
                   className="mt-14"
                   entityName={"incidents"}
                   facetsConfig={facetsConfig}
+                  facetOptionsCel={mainCelQuery}
                   usePropertyPathsSuggestions={true}
                   clearFiltersToken={clearFiltersToken}
                   initialFacetsData={initialFacetsData}

--- a/keep-ui/features/incident-list/ui/incident-list.tsx
+++ b/keep-ui/features/incident-list/ui/incident-list.tsx
@@ -30,6 +30,11 @@ import {
 import { IncidentsNotFoundPlaceholder } from "./incidents-not-found";
 import { v4 as uuidV4 } from "uuid";
 import { FacetsConfig } from "@/features/filter/models";
+import EnhancedDateRangePicker, {
+  TimeFrame,
+} from "@/components/ui/DateRangePicker";
+import { useLocalStorage } from "@/utils/hooks/useLocalStorage";
+import { AlertsQuery } from "@/utils/hooks/useAlerts";
 
 const AssigneeLabel = ({ email }: { email: string }) => {
   const user = useUser(email);
@@ -58,6 +63,12 @@ export function IncidentList({
   ]);
 
   const [filterCel, setFilterCel] = useState<string>("");
+  const [dateRangeCel, setDateRangeCel] = useState<string>("");
+
+  const mainCelQuery = useMemo(() => {
+    const filterArray = [dateRangeCel, filterCel];
+    return filterArray.filter(Boolean).join(" && ");
+  }, [filterCel, dateRangeCel]);
 
   const {
     data: incidents,
@@ -70,7 +81,7 @@ export function IncidentList({
     incidentsPagination.limit,
     incidentsPagination.offset,
     incidentsSorting[0],
-    filterCel,
+    mainCelQuery,
     {
       revalidateOnFocus: false,
       revalidateOnMount: !initialData,
@@ -97,6 +108,26 @@ export function IncidentList({
   useEffect(() => {
     setFilterRevalidationToken(incidentChangeToken);
   }, [incidentChangeToken]);
+
+  const [dateRange, setDateRange] = useState<TimeFrame>({
+    start: null,
+    end: null,
+    paused: true,
+  });
+
+  useEffect(() => {
+    const filterArray: string[] = [];
+
+    if (dateRange?.start) {
+      filterArray.push(`creation_time >= '${dateRange.start.toISOString()}'`);
+    }
+
+    if (dateRange?.paused && dateRange?.end) {
+      filterArray.push(`creation_time <= '${dateRange.end.toISOString()}'`);
+    }
+
+    setDateRangeCel(filterArray.filter(Boolean).join(" && "));
+  }, [dateRange]);
 
   const handleCloseForm = () => {
     setIsFormOpen(false);
@@ -205,6 +236,19 @@ export function IncidentList({
     };
   }, []);
 
+  const handleClearFilters = () => {
+    setDateRange({
+      start: null,
+      end: null,
+      paused: true,
+    });
+    setIncidentsPagination({
+      limit: 20,
+      offset: 0,
+    });
+    setClearFiltersToken(uuidV4());
+  };
+
   function renderIncidents() {
     if (incidents && incidents.items.length > 0) {
       return (
@@ -218,12 +262,10 @@ export function IncidentList({
       );
     }
 
-    if (filterCel && incidents?.items.length === 0) {
+    if (mainCelQuery && incidents?.items.length === 0) {
       return (
         <Card className="flex-grow ">
-          <IncidentsNotFoundPlaceholder
-            onClearFilters={() => setClearFiltersToken(uuidV4())}
-          />
+          <IncidentsNotFoundPlaceholder onClearFilters={handleClearFilters} />
         </Card>
       );
     }
@@ -238,6 +280,24 @@ export function IncidentList({
 
   const uncheckedFacetOptionsByDefault: Record<string, string[]> = {
     Status: ["resolved", "deleted"],
+  };
+
+  const renderDateTimePicker = () => {
+    return (
+      <div className="flex justify-end">
+        <EnhancedDateRangePicker
+          timeFrame={dateRange}
+          setTimeFrame={(timeFrame) => setDateRange(timeFrame)}
+          timeframeRefreshInterval={2000}
+          hasPlay={false}
+          pausedByDefault={true}
+          hasRewind={false}
+          hasForward={false}
+          hasZoomOut={false}
+          enableYearNavigation
+        />
+      </div>
+    );
   };
 
   return (
@@ -297,6 +357,7 @@ export function IncidentList({
                   revalidationToken={filterRevalidationToken}
                 />
                 <div className="flex flex-col gap-5 flex-1 min-w-0">
+                  {renderDateTimePicker()}
                   {renderIncidents()}
                 </div>
               </div>

--- a/keep-ui/features/incident-list/ui/incident-list.tsx
+++ b/keep-ui/features/incident-list/ui/incident-list.tsx
@@ -347,7 +347,7 @@ export function IncidentList({
                   className="mt-14"
                   entityName={"incidents"}
                   facetsConfig={facetsConfig}
-                  facetOptionsCel={mainCelQuery}
+                  facetOptionsCel={dateRangeCel}
                   usePropertyPathsSuggestions={true}
                   clearFiltersToken={clearFiltersToken}
                   initialFacetsData={initialFacetsData}

--- a/keep-ui/features/incident-list/ui/incidents-table.tsx
+++ b/keep-ui/features/incident-list/ui/incidents-table.tsx
@@ -7,6 +7,7 @@ import {
   SortingState,
   getSortedRowModel,
   ColumnDef,
+  Table,
 } from "@tanstack/react-table";
 import type {
   IncidentDto,
@@ -40,6 +41,12 @@ import {
 } from "@/shared/ui";
 import { UserStatefulAvatar } from "@/entities/users/ui";
 import { DynamicImageProviderIcon } from "@/components/ui";
+import { TitleAndFilters } from "@/app/(keep)/alerts/TitleAndFilters";
+import { useLocalStorage } from "@/utils/hooks/useLocalStorage";
+import { severityMapping } from "@/entities/alerts/model";
+import EnhancedDateRangePicker, {
+  TimeFrame,
+} from "@/components/ui/DateRangePicker";
 
 function SelectedRowActions({
   selectedRowIds,
@@ -267,7 +274,7 @@ export default function IncidentsTable({
     }),
   ] as ColumnDef<IncidentDto>[];
 
-  const table = useReactTable({
+  const table: Table<IncidentDto> = useReactTable({
     columns,
     data: incidents.items,
     state: {


### PR DESCRIPTION
Introduce a date range picker for the incident list, allowing users to filter incidents by creation time. Refactor filtering logic to include the new date range and integrate it with existing filters. Add a clear filter handler to reset all filters, including the date range.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3553 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
