### PR TITLE
fix: Make `description` and `repository` not-nullable.

### DIFF
--- a/keep/api/models/db/migrations/versions/2025-02-25-14-20_a82154690f35.py
+++ b/keep/api/models/db/migrations/versions/2025-02-25-14-20_a82154690f35.py
@@ -28,11 +28,11 @@ def upgrade() -> None:
     prepare_data()
 
     with op.batch_alter_table("topologyapplication", schema=None) as batch_op:
-        batch_op.alter_column("description", existing_type=sa.VARCHAR(), nullable=False)
-        batch_op.alter_column("repository", existing_type=sa.VARCHAR(), nullable=False)
+        batch_op.alter_column("description", existing_type=sa.VARCHAR(255), nullable=False)
+        batch_op.alter_column("repository", existing_type=sa.VARCHAR(255), nullable=False)
 
 
 def downgrade() -> None:
     with op.batch_alter_table("topologyapplication", schema=None) as batch_op:
-        batch_op.alter_column("repository", existing_type=sa.VARCHAR(), nullable=True)
-        batch_op.alter_column("description", existing_type=sa.VARCHAR(), nullable=True)
+        batch_op.alter_column("repository", existing_type=sa.VARCHAR(255), nullable=True)
+        batch_op.alter_column("description", existing_type=sa.VARCHAR(255), nullable=True)

--- a/keep/api/models/db/migrations/versions/2025-02-25-14-20_a82154690f35.py
+++ b/keep/api/models/db/migrations/versions/2025-02-25-14-20_a82154690f35.py
@@ -1,0 +1,38 @@
+"""TopologyApplication repository default_value
+
+Revision ID: a82154690f35
+Revises: ea25d9402518
+Create Date: 2025-02-25 14:20:04.175052
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+# revision identifiers, used by Alembic.
+revision = "a82154690f35"
+down_revision = "ea25d9402518"
+branch_labels = None
+depends_on = None
+
+def prepare_data():
+    session = Session(op.get_bind())
+
+    session.execute(text("UPDATE topologyapplication set description = '' where description is null"))
+    session.execute(text("UPDATE topologyapplication set repository = '' where repository is null"))
+
+
+def upgrade() -> None:
+    prepare_data()
+
+    with op.batch_alter_table("topologyapplication", schema=None) as batch_op:
+        batch_op.alter_column("description", existing_type=sa.VARCHAR(), nullable=False)
+        batch_op.alter_column("repository", existing_type=sa.VARCHAR(), nullable=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("topologyapplication", schema=None) as batch_op:
+        batch_op.alter_column("repository", existing_type=sa.VARCHAR(), nullable=True)
+        batch_op.alter_column("description", existing_type=sa.VARCHAR(), nullable=True)

--- a/keep/api/models/db/topology.py
+++ b/keep/api/models/db/topology.py
@@ -16,8 +16,8 @@ class TopologyApplication(SQLModel, table=True):
     id: UUID = Field(default_factory=uuid4, primary_key=True)
     tenant_id: str = Field(sa_column=Column(ForeignKey("tenant.id")))
     name: str
-    description: Optional[str] = None
-    repository: Optional[str] = None
+    description: str = Field(default_factory=str)
+    repository: str = Field(default_factory=str)
     services: List["TopologyService"] = Relationship(
         back_populates="applications", link_model=TopologyServiceApplication
     )
@@ -159,8 +159,8 @@ class TopologyServiceDtoIn(BaseModel, extra="ignore"):
 class TopologyApplicationDtoIn(BaseModel, extra="ignore"):
     id: Optional[UUID] = None
     name: str
-    description: Optional[str] = None
-    repository: Optional[str] = None
+    description: str = ""
+    repository: str = ""
     services: List[TopologyServiceDtoIn] = []
 
 


### PR DESCRIPTION
Ensure `description` and `repository` in `TopologyApplication` are non-nullable in the database and models by setting default values for missing entries. Updated migration script and adjusted model definitions accordingly.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3668

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
