### PR TITLE
fix: Add cleanup function for tenant data before topology import

### DIFF
--- a/keep-ui/app/(keep)/topology/ui/map/topology-map.tsx
+++ b/keep-ui/app/(keep)/topology/ui/map/topology-map.tsx
@@ -186,7 +186,7 @@ export function TopologyMap({
     {
       label: "Import",
       icon: ArrowUpTrayIcon,
-      onClick: () => document.getElementById("fileInput")?.click(),
+      onClick: () => window.confirm("Current topology will be completely replaced. Do you want to continue?")? document.getElementById("fileInput")?.click() : null,
     },
     {
       label: "Export",

--- a/keep/api/models/db/topology.py
+++ b/keep/api/models/db/topology.py
@@ -11,6 +11,13 @@ class TopologyServiceApplication(SQLModel, table=True):
     service_id: int = Field(foreign_key="topologyservice.id", primary_key=True)
     application_id: UUID = Field(foreign_key="topologyapplication.id", primary_key=True)
 
+    service: "TopologyService" = Relationship(
+        sa_relationship_kwargs={"primaryjoin": "TopologyService.id == TopologyServiceApplication.service_id"},
+    )
+    application: "TopologyApplication" = Relationship(
+        sa_relationship_kwargs={"primaryjoin": "TopologyApplication.id == TopologyServiceApplication.application_id"},
+    )
+
 
 class TopologyApplication(SQLModel, table=True):
     id: UUID = Field(default_factory=uuid4, primary_key=True)


### PR DESCRIPTION
Add `clean_before_import` to remove tenant-specific data before topology imports, ensuring a clean slate. Updated `import_to_db` to call this function and added corresponding tests to validate behavior.

closes keep incident: a59d7701-22a3-4262-9651-dec6021b890d

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3698 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
