### PR TITLE
fix: Handle None values for Grafana provider URLs

### DIFF
--- a/keep/providers/grafana_provider/grafana_provider.py
+++ b/keep/providers/grafana_provider/grafana_provider.py
@@ -268,10 +268,10 @@ class GrafanaProvider(BaseTopologyProvider, ProviderHealthMixin):
                 description=description,
                 source=["grafana"],
                 labels=labels,
-                url=url,
-                imageUrl=image_url,
-                dashboardUrl=dashboard_url,
-                panelUrl=panel_url,
+                url=url or None,
+                imageUrl=image_url or None,
+                dashboardUrl=dashboard_url or None,
+                panelUrl=panel_url or None,
                 valueString=valueString,
                 **extra,  # add annotations and values
             )


### PR DESCRIPTION
Added fallback to None for URL-related fields when they are undefined. This ensures safer and more consistent handling of empty or missing values.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3709
closes keep incident: 98fea67a-5a6b-44ae-afcb-4178f1842321

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
