### PR TITLE
feat: Allow deleting all timestamps when lastReceived is omitted from delete alert API

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,1 +1,7079 @@
-{"openapi": "3.0.2", "info": {"title": "Keep API", "description": "Rest API powering https://platform.keephq.dev and friends \ud83c\udfc4\u200d\u2640\ufe0f", "version": "0.24.5"}, "paths": {"/": {"get": {"summary": "Root", "description": "App desctiption and version.", "operationId": "root__get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}}}, "/providers": {"get": {"tags": ["providers"], "summary": "Get Providers", "operationId": "get_providers_providers_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/export": {"get": {"tags": ["providers"], "summary": "Get Installed Providers", "description": "export all installed providers", "operationId": "get_installed_providers_providers_export_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/{provider_type}/{provider_id}/configured-alerts": {"get": {"tags": ["providers"], "summary": "Get Alerts Configuration", "description": "Get alerts configuration from a provider", "operationId": "get_alerts_configuration_providers__provider_type___provider_id__configured_alerts_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Type"}, "name": "provider_type", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Provider Id"}, "name": "provider_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {}, "type": "array", "title": "Response Get Alerts Configuration Providers  Provider Type   Provider Id  Configured Alerts Get"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/{provider_type}/{provider_id}/logs": {"get": {"tags": ["providers"], "summary": "Get Logs", "description": "Get logs from a provider", "operationId": "get_logs_providers__provider_type___provider_id__logs_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Type"}, "name": "provider_type", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Provider Id"}, "name": "provider_id", "in": "path"}, {"required": false, "schema": {"type": "integer", "title": "Limit", "default": 5}, "name": "limit", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {}, "type": "array", "title": "Response Get Logs Providers  Provider Type   Provider Id  Logs Get"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/{provider_type}/schema": {"get": {"tags": ["providers"], "summary": "Get Alerts Schema", "description": "Get the provider's API schema used to push alerts configuration", "operationId": "get_alerts_schema_providers__provider_type__schema_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Type"}, "name": "provider_type", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"type": "object", "title": "Response Get Alerts Schema Providers  Provider Type  Schema Get"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/providers/{provider_type}/{provider_id}/alerts/count": {"get": {"tags": ["providers"], "summary": "Get Alert Count", "description": "Get number of alerts a specific provider has received (in a specific time time period or ever)", "operationId": "get_alert_count_providers__provider_type___provider_id__alerts_count_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Type"}, "name": "provider_type", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Provider Id"}, "name": "provider_id", "in": "path"}, {"required": true, "schema": {"type": "boolean", "title": "Ever"}, "name": "ever", "in": "query"}, {"required": false, "schema": {"type": "string", "format": "date-time", "title": "Start Time"}, "name": "start_time", "in": "query"}, {"required": false, "schema": {"type": "string", "format": "date-time", "title": "End Time"}, "name": "end_time", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/{provider_type}/{provider_id}/alerts": {"post": {"tags": ["providers"], "summary": "Add Alert", "description": "Push new alerts to the provider", "operationId": "add_alert_providers__provider_type___provider_id__alerts_post", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Type"}, "name": "provider_type", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Provider Id"}, "name": "provider_id", "in": "path"}, {"required": false, "schema": {"type": "string", "title": "Alert Id"}, "name": "alert_id", "in": "query"}], "requestBody": {"content": {"application/json": {"schema": {"type": "object", "title": "Alert"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/test": {"post": {"tags": ["providers"], "summary": "Test Provider", "description": "Test a provider's alert retrieval", "operationId": "test_provider_providers_test_post", "requestBody": {"content": {"application/json": {"schema": {"type": "object", "title": "Provider Info"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/{provider_type}/{provider_id}": {"delete": {"tags": ["providers"], "summary": "Delete Provider", "operationId": "delete_provider_providers__provider_type___provider_id__delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Type"}, "name": "provider_type", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Provider Id"}, "name": "provider_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/{provider_id}/scopes": {"post": {"tags": ["providers"], "summary": "Validate Provider Scopes", "description": "Validate provider scopes", "operationId": "validate_provider_scopes_providers__provider_id__scopes_post", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Id"}, "name": "provider_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"additionalProperties": {"anyOf": [{"type": "boolean"}, {"type": "string"}]}, "type": "object", "title": "Response Validate Provider Scopes Providers  Provider Id  Scopes Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/{provider_id}": {"put": {"tags": ["providers"], "summary": "Update Provider", "description": "Update provider", "operationId": "update_provider_providers__provider_id__put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Id"}, "name": "provider_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/install": {"post": {"tags": ["providers"], "summary": "Install Provider", "operationId": "install_provider_providers_install_post", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/install/oauth2/{provider_type}": {"post": {"tags": ["providers"], "summary": "Install Provider Oauth2", "operationId": "install_provider_oauth2_providers_install_oauth2__provider_type__post", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Type"}, "name": "provider_type", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"type": "object", "title": "Provider Info"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/{provider_id}/invoke/{method}": {"post": {"tags": ["providers"], "summary": "Invoke Provider Method", "description": "Invoke provider special method", "operationId": "invoke_provider_method_providers__provider_id__invoke__method__post", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Id"}, "name": "provider_id", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Method"}, "name": "method", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"type": "object", "title": "Method Params"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/install/webhook/{provider_type}/{provider_id}": {"post": {"tags": ["providers"], "summary": "Install Provider Webhook", "operationId": "install_provider_webhook_providers_install_webhook__provider_type___provider_id__post", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Type"}, "name": "provider_type", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Provider Id"}, "name": "provider_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/providers/{provider_type}/webhook": {"get": {"tags": ["providers"], "summary": "Get Webhook Settings", "operationId": "get_webhook_settings_providers__provider_type__webhook_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Type"}, "name": "provider_type", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ProviderWebhookSettings"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/actions": {"get": {"tags": ["actions"], "summary": "Get Actions", "description": "Get all actions", "operationId": "get_actions_actions_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["actions"], "summary": "Create Actions", "description": "Create new actions by uploading a file", "operationId": "create_actions_actions_post", "requestBody": {"content": {"multipart/form-data": {"schema": {"$ref": "#/components/schemas/Body_create_actions_actions_post"}}}}, "responses": {"201": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/actions/{action_id}": {"put": {"tags": ["actions"], "summary": "Put Action", "description": "Update an action", "operationId": "put_action_actions__action_id__put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Action Id"}, "name": "action_id", "in": "path"}], "requestBody": {"content": {"multipart/form-data": {"schema": {"$ref": "#/components/schemas/Body_put_action_actions__action_id__put"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["actions"], "summary": "Delete Action", "description": "Delete an action", "operationId": "delete_action_actions__action_id__delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Action Id"}, "name": "action_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/healthcheck": {"get": {"tags": ["healthcheck"], "summary": "Healthcheck", "description": "simple healthcheck endpoint", "operationId": "healthcheck_healthcheck_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"type": "object", "title": "Response Healthcheck Healthcheck Get"}}}}}}}, "/alerts": {"get": {"tags": ["alerts"], "summary": "Get All Alerts", "description": "Get last alerts occurrence", "operationId": "get_all_alerts_alerts_get", "parameters": [{"required": false, "schema": {"type": "integer", "title": "Limit", "default": 1000}, "name": "limit", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/AlertDto"}, "type": "array", "title": "Response Get All Alerts Alerts Get"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["alerts"], "summary": "Delete Alert", "description": "Delete alert by finerprint and last received time", "operationId": "delete_alert_alerts_delete", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/DeleteRequestBody"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"additionalProperties": {"type": "string"}, "type": "object", "title": "Response Delete Alert Alerts Delete"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/alerts/{fingerprint}/history": {"get": {"tags": ["alerts"], "summary": "Get Alert History", "description": "Get alert history", "operationId": "get_alert_history_alerts__fingerprint__history_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Fingerprint"}, "name": "fingerprint", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/AlertDto"}, "type": "array", "title": "Response Get Alert History Alerts  Fingerprint  History Get"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/alerts/{fingerprint}/assign/{last_received}": {"post": {"tags": ["alerts"], "summary": "Assign Alert", "description": "Assign alert to user", "operationId": "assign_alert_alerts__fingerprint__assign__last_received__post", "parameters": [{"required": true, "schema": {"type": "string", "title": "Fingerprint"}, "name": "fingerprint", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Last Received"}, "name": "last_received", "in": "path"}, {"required": false, "schema": {"type": "boolean", "title": "Unassign", "default": false}, "name": "unassign", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"additionalProperties": {"type": "string"}, "type": "object", "title": "Response Assign Alert Alerts  Fingerprint  Assign  Last Received  Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/alerts/event": {"post": {"tags": ["alerts"], "summary": "Receive Generic Event", "description": "Receive a generic alert event", "operationId": "receive_generic_event_alerts_event_post", "parameters": [{"required": false, "schema": {"type": "string", "title": "Fingerprint"}, "name": "fingerprint", "in": "query"}], "requestBody": {"content": {"application/json": {"schema": {"anyOf": [{"$ref": "#/components/schemas/AlertDto"}, {"items": {"$ref": "#/components/schemas/AlertDto"}, "type": "array"}, {"type": "object"}], "title": "Event"}}}, "required": true}, "responses": {"202": {"description": "Successful Response", "content": {"application/json": {"schema": {"anyOf": [{"$ref": "#/components/schemas/AlertDto"}, {"items": {"$ref": "#/components/schemas/AlertDto"}, "type": "array"}], "title": "Response Receive Generic Event Alerts Event Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/alerts/event/netdata": {"get": {"tags": ["alerts"], "summary": "Webhook Challenge", "description": "Helper function to complete Netdata webhook challenge", "operationId": "webhook_challenge_alerts_event_netdata_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}}}, "/alerts/event/{provider_type}": {"post": {"tags": ["alerts"], "summary": "Receive Event", "description": "Receive an alert event from a provider", "operationId": "receive_event_alerts_event__provider_type__post", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Type"}, "name": "provider_type", "in": "path"}, {"required": false, "schema": {"type": "string", "title": "Provider Id"}, "name": "provider_id", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Fingerprint"}, "name": "fingerprint", "in": "query"}], "responses": {"202": {"description": "Successful Response", "content": {"application/json": {"schema": {"additionalProperties": {"type": "string"}, "type": "object", "title": "Response Receive Event Alerts Event  Provider Type  Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/alerts/{fingerprint}": {"get": {"tags": ["alerts"], "summary": "Get Alert", "description": "Get alert by fingerprint", "operationId": "get_alert_alerts__fingerprint__get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Fingerprint"}, "name": "fingerprint", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AlertDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/alerts/enrich": {"post": {"tags": ["alerts"], "summary": "Enrich Alert", "description": "Enrich an alert", "operationId": "enrich_alert_alerts_enrich_post", "parameters": [{"description": "Dispose on new alert", "required": false, "schema": {"type": "boolean", "title": "Dispose On New Alert", "description": "Dispose on new alert", "default": false}, "name": "dispose_on_new_alert", "in": "query"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/EnrichAlertRequestBody"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"additionalProperties": {"type": "string"}, "type": "object", "title": "Response Enrich Alert Alerts Enrich Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/alerts/unenrich": {"post": {"tags": ["alerts"], "summary": "Unenrich Alert", "description": "Un-Enrich an alert", "operationId": "unenrich_alert_alerts_unenrich_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/UnEnrichAlertRequestBody"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"additionalProperties": {"type": "string"}, "type": "object", "title": "Response Unenrich Alert Alerts Unenrich Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/alerts/search": {"post": {"tags": ["alerts"], "summary": "Search Alerts", "description": "Search alerts", "operationId": "search_alerts_alerts_search_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/SearchAlertsRequest"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/AlertDto"}, "type": "array", "title": "Response Search Alerts Alerts Search Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/alerts/audit": {"post": {"tags": ["alerts"], "summary": "Get Multiple Fingerprint Alert Audit", "description": "Get alert timeline audit trail for multiple fingerprints", "operationId": "get_multiple_fingerprint_alert_audit_alerts_audit_post", "requestBody": {"content": {"application/json": {"schema": {"items": {"type": "string"}, "type": "array", "title": "Fingerprints"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/AlertAuditDto"}, "type": "array", "title": "Response Get Multiple Fingerprint Alert Audit Alerts Audit Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/alerts/{fingerprint}/audit": {"get": {"tags": ["alerts"], "summary": "Get Alert Audit", "description": "Get alert timeline audit trail", "operationId": "get_alert_audit_alerts__fingerprint__audit_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Fingerprint"}, "name": "fingerprint", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/AlertAuditDto"}, "type": "array", "title": "Response Get Alert Audit Alerts  Fingerprint  Audit Get"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/alerts/quality/metrics": {"get": {"tags": ["alerts"], "summary": "Get Alert Quality", "description": "Get alert quality", "operationId": "get_alert_quality_alerts_quality_metrics_get", "parameters": [{"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Fields", "default": []}, "name": "fields", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Time Stamp"}, "name": "time_stamp", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents": {"get": {"tags": ["incidents"], "summary": "Get All Incidents", "description": "Get last incidents", "operationId": "get_all_incidents_incidents_get", "parameters": [{"required": false, "schema": {"type": "boolean", "title": "Confirmed", "default": true}, "name": "confirmed", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Limit", "default": 25}, "name": "limit", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Offset", "default": 0}, "name": "offset", "in": "query"}, {"required": false, "schema": {"allOf": [{"$ref": "#/components/schemas/IncidentSorting"}], "default": "creation_time"}, "name": "sorting", "in": "query"}, {"required": false, "schema": {"items": {"$ref": "#/components/schemas/IncidentStatus"}, "type": "array"}, "name": "status", "in": "query"}, {"required": false, "schema": {"items": {"$ref": "#/components/schemas/IncidentSeverity"}, "type": "array"}, "name": "severity", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Assignees"}, "name": "assignees", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Sources"}, "name": "sources", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Affected Services"}, "name": "affected_services", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentsPaginatedResultsDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["incidents"], "summary": "Create Incident", "description": "Create new incident", "operationId": "create_incident_incidents_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentDtoIn"}}}, "required": true}, "responses": {"202": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents/meta": {"get": {"tags": ["incidents"], "summary": "Get Incidents Meta", "description": "Get incidents' metadata for filtering", "operationId": "get_incidents_meta_incidents_meta_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentListFilterParamsDto"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents/{incident_id}": {"get": {"tags": ["incidents"], "summary": "Get Incident", "description": "Get incident by id", "operationId": "get_incident_incidents__incident_id__get", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Incident Id"}, "name": "incident_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "put": {"tags": ["incidents"], "summary": "Update Incident", "description": "Update incident by id", "operationId": "update_incident_incidents__incident_id__put", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Incident Id"}, "name": "incident_id", "in": "path"}, {"description": "Whether the incident update request was generated by AI", "required": false, "schema": {"type": "boolean", "title": "Generatedbyai", "description": "Whether the incident update request was generated by AI", "default": false}, "name": "generatedByAi", "in": "query"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentDtoIn"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["incidents"], "summary": "Delete Incident", "description": "Delete incident by incident id", "operationId": "delete_incident_incidents__incident_id__delete", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Incident Id"}, "name": "incident_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents/merge": {"post": {"tags": ["incidents"], "summary": "Merge Incidents", "description": "Merge incidents", "operationId": "merge_incidents_incidents_merge_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/MergeIncidentsRequestDto"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/MergeIncidentsResponseDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents/{incident_id}/alerts": {"get": {"tags": ["incidents"], "summary": "Get Incident Alerts", "description": "Get incident alerts by incident incident id", "operationId": "get_incident_alerts_incidents__incident_id__alerts_get", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Incident Id"}, "name": "incident_id", "in": "path"}, {"required": false, "schema": {"type": "integer", "title": "Limit", "default": 25}, "name": "limit", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Offset", "default": 0}, "name": "offset", "in": "query"}, {"required": false, "schema": {"type": "boolean", "title": "Include Unlinked", "default": false}, "name": "include_unlinked", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AlertWithIncidentLinkMetadataPaginatedResultsDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["incidents"], "summary": "Add Alerts To Incident", "description": "Add alerts to incident", "operationId": "add_alerts_to_incident_incidents__incident_id__alerts_post", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Incident Id"}, "name": "incident_id", "in": "path"}, {"required": false, "schema": {"type": "boolean", "title": "Is Created By Ai", "default": false}, "name": "is_created_by_ai", "in": "query"}], "requestBody": {"content": {"application/json": {"schema": {"items": {"type": "string", "format": "uuid"}, "type": "array", "title": "Alert Ids"}}}, "required": true}, "responses": {"202": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/AlertDto"}, "type": "array", "title": "Response Add Alerts To Incident Incidents  Incident Id  Alerts Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["incidents"], "summary": "Delete Alerts From Incident", "description": "Delete alerts from incident", "operationId": "delete_alerts_from_incident_incidents__incident_id__alerts_delete", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Incident Id"}, "name": "incident_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"items": {"type": "string", "format": "uuid"}, "type": "array", "title": "Alert Ids"}}}, "required": true}, "responses": {"202": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/AlertDto"}, "type": "array", "title": "Response Delete Alerts From Incident Incidents  Incident Id  Alerts Delete"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents/{incident_id}/future_incidents": {"get": {"tags": ["incidents"], "summary": "Get Future Incidents For An Incident", "description": "Get same incidents linked to this one", "operationId": "get_future_incidents_for_an_incident_incidents__incident_id__future_incidents_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Incident Id"}, "name": "incident_id", "in": "path"}, {"required": false, "schema": {"type": "integer", "title": "Limit", "default": 25}, "name": "limit", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Offset", "default": 0}, "name": "offset", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentsPaginatedResultsDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents/{incident_id}/workflows": {"get": {"tags": ["incidents"], "summary": "Get Incident Workflows", "description": "Get incident workflows by incident id", "operationId": "get_incident_workflows_incidents__incident_id__workflows_get", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Incident Id"}, "name": "incident_id", "in": "path"}, {"required": false, "schema": {"type": "integer", "title": "Limit", "default": 25}, "name": "limit", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Offset", "default": 0}, "name": "offset", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WorkflowExecutionsPaginatedResultsDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents/event/{provider_type}": {"post": {"tags": ["incidents"], "summary": "Receive Event", "description": "Receive an alert event from a provider", "operationId": "receive_event_incidents_event__provider_type__post", "parameters": [{"required": true, "schema": {"type": "string", "title": "Provider Type"}, "name": "provider_type", "in": "path"}, {"required": false, "schema": {"type": "string", "title": "Provider Id"}, "name": "provider_id", "in": "query"}], "responses": {"202": {"description": "Successful Response", "content": {"application/json": {"schema": {"additionalProperties": {"type": "string"}, "type": "object", "title": "Response Receive Event Incidents Event  Provider Type  Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents/{incident_id}/status": {"post": {"tags": ["incidents"], "summary": "Change Incident Status", "description": "Change incident status", "operationId": "change_incident_status_incidents__incident_id__status_post", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Incident Id"}, "name": "incident_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentStatusChangeDto"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents/{incident_id}/comment": {"post": {"tags": ["incidents"], "summary": "Add Comment", "description": "Add incident audit activity", "operationId": "add_comment_incidents__incident_id__comment_post", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Incident Id"}, "name": "incident_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentStatusChangeDto"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AlertAudit"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents/ai/suggest": {"post": {"tags": ["incidents"], "summary": "Create With Ai", "description": "Create incident with AI", "operationId": "create_with_ai_incidents_ai_suggest_post", "requestBody": {"content": {"application/json": {"schema": {"items": {"type": "string"}, "type": "array", "title": "Alerts Fingerprints"}}}, "required": true}, "responses": {"202": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentsClusteringSuggestion"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents/ai/{suggestion_id}/commit": {"post": {"tags": ["incidents"], "summary": "Commit With Ai", "description": "Commit incidents with AI and user feedback", "operationId": "commit_with_ai_incidents_ai__suggestion_id__commit_post", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Suggestion Id"}, "name": "suggestion_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/IncidentCommit"}, "type": "array", "title": "Incidents With Feedback"}}}, "required": true}, "responses": {"202": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/IncidentDto"}, "type": "array", "title": "Response Commit With Ai Incidents Ai  Suggestion Id  Commit Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/incidents/{incident_id}/confirm": {"post": {"tags": ["incidents"], "summary": "Confirm Incident", "description": "Confirm predicted incident by id", "operationId": "confirm_incident_incidents__incident_id__confirm_post", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Incident Id"}, "name": "incident_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IncidentDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/settings/webhook": {"get": {"tags": ["settings"], "summary": "Webhook Settings", "description": "Get details about the webhook endpoint (e.g. the API url and an API key)", "operationId": "webhook_settings_settings_webhook_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WebhookSettings"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/settings/smtp": {"get": {"tags": ["settings"], "summary": "Get Smtp Settings", "description": "Get SMTP settings", "operationId": "get_smtp_settings_settings_smtp_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["settings"], "summary": "Update Smtp Settings", "description": "Install or update SMTP settings", "operationId": "update_smtp_settings_settings_smtp_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/SMTPSettings"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["settings"], "summary": "Delete Smtp Settings", "description": "Delete SMTP settings", "operationId": "delete_smtp_settings_settings_smtp_delete", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/settings/smtp/test": {"post": {"tags": ["settings"], "summary": "Test Smtp Settings", "description": "Test SMTP settings", "operationId": "test_smtp_settings_settings_smtp_test_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/SMTPSettings"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/settings/apikey": {"put": {"tags": ["settings"], "summary": "Update Api Key", "description": "Update API key secret", "operationId": "update_api_key_settings_apikey_put", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["settings"], "summary": "Create Key", "description": "Create API key", "operationId": "create_key_settings_apikey_post", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/settings/apikeys": {"get": {"tags": ["settings"], "summary": "Get Keys", "description": "Get API keys", "operationId": "get_keys_settings_apikeys_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/settings/apikey/{keyId}": {"delete": {"tags": ["settings"], "summary": "Delete Api Key", "description": "Delete API key", "operationId": "delete_api_key_settings_apikey__keyId__delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Keyid"}, "name": "keyId", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/settings/sso": {"get": {"tags": ["settings"], "summary": "Get Sso Settings", "operationId": "get_sso_settings_settings_sso_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/workflows": {"get": {"tags": ["workflows", "alerts"], "summary": "Get Workflows", "description": "Get workflows", "operationId": "get_workflows_workflows_get", "parameters": [{"required": false, "schema": {"type": "boolean", "title": "Is V2", "default": false}, "name": "is_v2", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"anyOf": [{"items": {"$ref": "#/components/schemas/WorkflowDTO"}, "type": "array"}, {"items": {"type": "object"}, "type": "array"}], "title": "Response Get Workflows Workflows Get"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["workflows", "alerts"], "summary": "Create Workflow", "description": "Create or update a workflow", "operationId": "create_workflow_workflows_post", "requestBody": {"content": {"multipart/form-data": {"schema": {"$ref": "#/components/schemas/Body_create_workflow_workflows_post"}}}, "required": true}, "responses": {"201": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WorkflowCreateOrUpdateDTO"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/workflows/export": {"get": {"tags": ["workflows", "alerts"], "summary": "Export Workflows", "description": "export all workflow Yamls", "operationId": "export_workflows_workflows_export_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"type": "string"}, "type": "array", "title": "Response Export Workflows Workflows Export Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/workflows/{workflow_id}/run": {"post": {"tags": ["workflows", "alerts"], "summary": "Run Workflow", "description": "Run a workflow", "operationId": "run_workflow_workflows__workflow_id__run_post", "parameters": [{"required": true, "schema": {"type": "string", "title": "Workflow Id"}, "name": "workflow_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"type": "object", "title": "Body"}}}}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"type": "object", "title": "Response Run Workflow Workflows  Workflow Id  Run Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/workflows/test": {"post": {"tags": ["workflows", "alerts"], "summary": "Run Workflow From Definition", "description": "Test run a workflow from a definition", "operationId": "run_workflow_from_definition_workflows_test_post", "requestBody": {"content": {"multipart/form-data": {"schema": {"$ref": "#/components/schemas/Body_run_workflow_from_definition_workflows_test_post"}}}}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"type": "object", "title": "Response Run Workflow From Definition Workflows Test Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/workflows/json": {"post": {"tags": ["workflows", "alerts"], "summary": "Create Workflow From Body", "description": "Create or update a workflow", "operationId": "create_workflow_from_body_workflows_json_post", "responses": {"201": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WorkflowCreateOrUpdateDTO"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/workflows/random-templates": {"get": {"tags": ["workflows", "alerts"], "summary": "Get Random Workflow Templates", "description": "Get random workflow templates", "operationId": "get_random_workflow_templates_workflows_random_templates_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"type": "object"}, "type": "array", "title": "Response Get Random Workflow Templates Workflows Random Templates Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/workflows/{workflow_id}": {"get": {"tags": ["workflows", "alerts"], "summary": "Get Workflow By Id", "description": "Get workflow by ID", "operationId": "get_workflow_by_id_workflows__workflow_id__get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Workflow Id"}, "name": "workflow_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "put": {"tags": ["workflows", "alerts"], "summary": "Update Workflow By Id", "description": "Update a workflow", "operationId": "update_workflow_by_id_workflows__workflow_id__put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Workflow Id"}, "name": "workflow_id", "in": "path"}], "responses": {"201": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WorkflowCreateOrUpdateDTO"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["workflows", "alerts"], "summary": "Delete Workflow By Id", "description": "Delete workflow", "operationId": "delete_workflow_by_id_workflows__workflow_id__delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Workflow Id"}, "name": "workflow_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/workflows/{workflow_id}/raw": {"get": {"tags": ["workflows", "alerts"], "summary": "Get Raw Workflow By Id", "description": "Get workflow executions by ID", "operationId": "get_raw_workflow_by_id_workflows__workflow_id__raw_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Workflow Id"}, "name": "workflow_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"type": "string", "title": "Response Get Raw Workflow By Id Workflows  Workflow Id  Raw Get"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/workflows/executions": {"get": {"tags": ["workflows", "alerts"], "summary": "Get Workflow Executions By Alert Fingerprint", "description": "Get workflow executions by alert fingerprint", "operationId": "get_workflow_executions_by_alert_fingerprint_workflows_executions_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/WorkflowToAlertExecutionDTO"}, "type": "array", "title": "Response Get Workflow Executions By Alert Fingerprint Workflows Executions Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/workflows/{workflow_id}/runs": {"get": {"tags": ["workflows", "alerts"], "summary": "Get Workflow By Id", "description": "Get workflow executions by ID", "operationId": "get_workflow_by_id_workflows__workflow_id__runs_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Workflow Id"}, "name": "workflow_id", "in": "path"}, {"required": false, "schema": {"type": "integer", "title": "Tab", "default": 1}, "name": "tab", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Limit", "default": 25}, "name": "limit", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Offset", "default": 0}, "name": "offset", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Status"}, "name": "status", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Trigger"}, "name": "trigger", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Execution Id"}, "name": "execution_id", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WorkflowExecutionsPaginatedResultsDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/workflows/{workflow_id}/runs/{workflow_execution_id}": {"get": {"tags": ["workflows", "alerts"], "summary": "Get Workflow Execution Status", "description": "Get a workflow execution status", "operationId": "get_workflow_execution_status_workflows__workflow_id__runs__workflow_execution_id__get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Workflow Execution Id"}, "name": "workflow_execution_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WorkflowExecutionDTO"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/whoami": {"get": {"tags": ["whoami"], "summary": "Get Tenant Id", "description": "Get tenant id", "operationId": "get_tenant_id_whoami_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"type": "object", "title": "Response Get Tenant Id Whoami Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/pusher/auth": {"post": {"tags": ["pusher"], "summary": "Pusher Authentication", "description": "Authenticate a user to a private channel\n\nArgs:\n    request (Request): The request object\n    tenant_id (str, optional): The tenant ID. Defaults to Depends(verify_bearer_token).\n    pusher_client (Pusher, optional): Pusher client. Defaults to Depends(get_pusher_client).\n\nRaises:\n    HTTPException: 403 if the user is not allowed to access the channel.\n\nReturns:\n    dict: The authentication response.", "operationId": "pusher_authentication_pusher_auth_post", "requestBody": {"content": {"application/x-www-form-urlencoded": {"schema": {"$ref": "#/components/schemas/Body_pusher_authentication_pusher_auth_post"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"type": "object", "title": "Response Pusher Authentication Pusher Auth Post"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/status": {"get": {"tags": ["status"], "summary": "Status", "description": "simple status endpoint", "operationId": "status_status_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"type": "object", "title": "Response Status Status Get"}}}}}}}, "/rules": {"get": {"tags": ["rules"], "summary": "Get Rules", "description": "Get Rules", "operationId": "get_rules_rules_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["rules"], "summary": "Create Rule", "description": "Create Rule", "operationId": "create_rule_rules_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/RuleCreateDto"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/rules/{rule_id}": {"put": {"tags": ["rules"], "summary": "Update Rule", "description": "Update Rule", "operationId": "update_rule_rules__rule_id__put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Rule Id"}, "name": "rule_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["rules"], "summary": "Delete Rule", "description": "Delete Rule", "operationId": "delete_rule_rules__rule_id__delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Rule Id"}, "name": "rule_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/preset": {"get": {"tags": ["preset"], "summary": "Get Presets", "description": "Get all presets for tenant", "operationId": "get_presets_preset_get", "parameters": [{"required": false, "schema": {"type": "string", "title": "Time Stamp"}, "name": "time_stamp", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/PresetDto"}, "type": "array", "title": "Response Get Presets Preset Get"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["preset"], "summary": "Create Preset", "description": "Create a preset for tenant", "operationId": "create_preset_preset_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/CreateOrUpdatePresetDto"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/PresetDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/preset/{uuid}": {"put": {"tags": ["preset"], "summary": "Update Preset", "description": "Update a preset for tenant", "operationId": "update_preset_preset__uuid__put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Uuid"}, "name": "uuid", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/CreateOrUpdatePresetDto"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/PresetDto"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["preset"], "summary": "Delete Preset", "description": "Delete a preset for tenant", "operationId": "delete_preset_preset__uuid__delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Uuid"}, "name": "uuid", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/preset/{preset_name}/alerts": {"get": {"tags": ["preset"], "summary": "Get Preset Alerts", "description": "Get the alerts of a preset", "operationId": "get_preset_alerts_preset__preset_name__alerts_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Preset Name"}, "name": "preset_name", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {}, "type": "array", "title": "Response Get Preset Alerts Preset  Preset Name  Alerts Get"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/preset/{preset_id}/tab": {"post": {"tags": ["preset"], "summary": "Create Preset Tab", "description": "Create a tab for a preset", "operationId": "create_preset_tab_preset__preset_id__tab_post", "parameters": [{"required": true, "schema": {"type": "string", "title": "Preset Id"}, "name": "preset_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/CreatePresetTab"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/preset/{preset_id}/tab/{tab_id}": {"delete": {"tags": ["preset"], "summary": "Delete Tab", "description": "Delete a tab from a preset", "operationId": "delete_tab_preset__preset_id__tab__tab_id__delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Preset Id"}, "name": "preset_id", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Tab Id"}, "name": "tab_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/mapping": {"get": {"tags": ["enrichment", "mapping"], "summary": "Get Rules", "description": "Get all mapping rules", "operationId": "get_rules_mapping_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/MappingRuleDtoOut"}, "type": "array", "title": "Response Get Rules Mapping Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["enrichment", "mapping"], "summary": "Create Rule", "description": "Create a new mapping rule", "operationId": "create_rule_mapping_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/MappingRuleDtoIn"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/MappingRule"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/mapping/{rule_id}": {"put": {"tags": ["enrichment", "mapping"], "summary": "Update Rule", "description": "Update an existing rule", "operationId": "update_rule_mapping__rule_id__put", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Rule Id"}, "name": "rule_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/MappingRuleDtoIn"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/MappingRuleDtoOut"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["enrichment", "mapping"], "summary": "Delete Rule", "description": "Delete a mapping rule", "operationId": "delete_rule_mapping__rule_id__delete", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Rule Id"}, "name": "rule_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/auth/groups": {"get": {"tags": ["auth", "groups"], "summary": "Get Groups", "description": "Get all groups", "operationId": "get_groups_auth_groups_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/Group"}, "type": "array", "title": "Response Get Groups Auth Groups Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["auth", "groups"], "summary": "Create Group", "description": "Create a group", "operationId": "create_group_auth_groups_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/CreateOrUpdateGroupRequest"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/auth/groups/{group_name}": {"put": {"tags": ["auth", "groups"], "summary": "Update Group", "description": "Update a group", "operationId": "update_group_auth_groups__group_name__put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Group Name"}, "name": "group_name", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/CreateOrUpdateGroupRequest"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["auth", "groups"], "summary": "Delete Group", "description": "Delete a group", "operationId": "delete_group_auth_groups__group_name__delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Group Name"}, "name": "group_name", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/auth/permissions": {"get": {"tags": ["auth", "permissions"], "summary": "Get Permissions", "description": "Get resources permissions", "operationId": "get_permissions_auth_permissions_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/ResourcePermission"}, "type": "array", "title": "Response Get Permissions Auth Permissions Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["auth", "permissions"], "summary": "Create Permissions", "description": "Create permissions for resources", "operationId": "create_permissions_auth_permissions_post", "requestBody": {"content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/ResourcePermission"}, "type": "array", "title": "Resource Permissions", "description": "List of resource permissions"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/auth/permissions/scopes": {"get": {"tags": ["auth", "permissions"], "summary": "Get Scopes", "description": "Get all resources types", "operationId": "get_scopes_auth_permissions_scopes_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"type": "string"}, "type": "array", "title": "Response Get Scopes Auth Permissions Scopes Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/auth/roles": {"get": {"tags": ["auth", "roles"], "summary": "Get Roles", "description": "Get roles", "operationId": "get_roles_auth_roles_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/Role"}, "type": "array", "title": "Response Get Roles Auth Roles Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["auth", "roles"], "summary": "Create Role", "description": "Create role", "operationId": "create_role_auth_roles_post", "requestBody": {"content": {"application/json": {"schema": {"allOf": [{"$ref": "#/components/schemas/CreateOrUpdateRole"}], "title": "Role", "description": "Role"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/auth/roles/{role_id}": {"put": {"tags": ["auth", "roles"], "summary": "Update Role", "description": "Update role", "operationId": "update_role_auth_roles__role_id__put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Role Id"}, "name": "role_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"allOf": [{"$ref": "#/components/schemas/CreateOrUpdateRole"}], "title": "Role", "description": "Role"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["auth", "roles"], "summary": "Delete Role", "description": "Delete role", "operationId": "delete_role_auth_roles__role_id__delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Role Id"}, "name": "role_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/auth/users": {"get": {"tags": ["auth", "users"], "summary": "Get Users", "description": "Get all users", "operationId": "get_users_auth_users_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/User"}, "type": "array", "title": "Response Get Users Auth Users Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["auth", "users"], "summary": "Create User", "description": "Create a user", "operationId": "create_user_auth_users_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/CreateUserRequest"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/auth/users/{user_email}": {"put": {"tags": ["auth", "users"], "summary": "Update User", "description": "Update a user", "operationId": "update_user_auth_users__user_email__put", "parameters": [{"required": true, "schema": {"type": "string", "title": "User Email"}, "name": "user_email", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/UpdateUserRequest"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["auth", "users"], "summary": "Delete User", "description": "Delete a user", "operationId": "delete_user_auth_users__user_email__delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "User Email"}, "name": "user_email", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/metrics": {"get": {"tags": ["metrics"], "summary": "Get Metrics", "description": "This endpoint is used by Prometheus to scrape such metrics from the application:\n- alerts_total {incident_name, incident_id} - The total number of alerts per incident.\n- open_incidents_total - The total number of open incidents.\n- workflows_executions_total {status} - The total number of workflow executions.\n\nPlease note that those metrics are per-tenant and are not designed to be used for the monitoring of the application itself.\n\nExample prometheus configuration:\n```\nscrape_configs:\n- job_name: \"scrape_keep\"\n  scrape_interval: 5m  # It's important to scrape not too often to avoid rate limiting.\n  static_configs:\n  - targets: [\"https://api.keephq.dev\"]  # Or your own domain.\n  authorization:\n    type: Bearer\n    credentials: \"{Your API Key}\"\n\n  # Optional, you can add labels to exported incidents. \n  # Label values will be equal to the last incident's alert payload value matching the label.\n  # Attention! Don't add \"flaky\" labels which could change from alert to alert within the same incident.\n  # Good labels: ['labels.department', 'labels.team'], bad labels: ['labels.severity', 'labels.pod_id']\n  # Check Keep -> Feed -> \"extraPayload\" column, it will help in writing labels.\n\n  params:\n    labels: ['labels.service', 'labels.queue']\n  # Will resuld as: \"labels_service\" and \"labels_queue\".\n```", "operationId": "get_metrics_metrics_get", "parameters": [{"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Labels"}, "name": "labels", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/extraction": {"get": {"tags": ["enrichment", "extraction"], "summary": "Get Extraction Rules", "description": "Get all extraction rules", "operationId": "get_extraction_rules_extraction_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/ExtractionRuleDtoOut"}, "type": "array", "title": "Response Get Extraction Rules Extraction Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["enrichment", "extraction"], "summary": "Create Extraction Rule", "description": "Create a new extraction rule", "operationId": "create_extraction_rule_extraction_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/ExtractionRuleDtoBase"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ExtractionRuleDtoOut"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/extraction/{rule_id}": {"put": {"tags": ["enrichment", "extraction"], "summary": "Update Extraction Rule", "description": "Update an existing extraction rule", "operationId": "update_extraction_rule_extraction__rule_id__put", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Rule Id"}, "name": "rule_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/ExtractionRuleDtoBase"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ExtractionRuleDtoOut"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["enrichment", "extraction"], "summary": "Delete Extraction Rule", "description": "Delete an extraction rule", "operationId": "delete_extraction_rule_extraction__rule_id__delete", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Rule Id"}, "name": "rule_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/dashboard": {"get": {"tags": ["dashboard"], "summary": "Read Dashboards", "operationId": "read_dashboards_dashboard_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/DashboardResponseDTO"}, "type": "array", "title": "Response Read Dashboards Dashboard Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["dashboard"], "summary": "Create Dashboard", "operationId": "create_dashboard_dashboard_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/DashboardCreateDTO"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/DashboardResponseDTO"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/dashboard/{dashboard_id}": {"put": {"tags": ["dashboard"], "summary": "Update Dashboard", "operationId": "update_dashboard_dashboard__dashboard_id__put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Dashboard Id"}, "name": "dashboard_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/DashboardUpdateDTO"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/DashboardResponseDTO"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["dashboard"], "summary": "Delete Dashboard", "operationId": "delete_dashboard_dashboard__dashboard_id__delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Dashboard Id"}, "name": "dashboard_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/dashboard/metric-widgets": {"get": {"tags": ["dashboard"], "summary": "Get Metric Widgets", "operationId": "get_metric_widgets_dashboard_metric_widgets_get", "parameters": [{"required": false, "schema": {"type": "boolean", "title": "Mttr", "default": true}, "name": "mttr", "in": "query"}, {"required": false, "schema": {"type": "boolean", "title": "Apd", "default": true}, "name": "apd", "in": "query"}, {"required": false, "schema": {"type": "boolean", "title": "Ipd", "default": true}, "name": "ipd", "in": "query"}, {"required": false, "schema": {"type": "boolean", "title": "Wpd", "default": true}, "name": "wpd", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Time Stamp"}, "name": "time_stamp", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/tags": {"get": {"tags": ["tags"], "summary": "Get Tags", "description": "get tags", "operationId": "get_tags_tags_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"type": "object"}, "type": "array", "title": "Response Get Tags Tags Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/maintenance": {"get": {"tags": ["maintenance"], "summary": "Get Maintenance Rules", "description": "Get all maintenance rules", "operationId": "get_maintenance_rules_maintenance_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/MaintenanceRuleRead"}, "type": "array", "title": "Response Get Maintenance Rules Maintenance Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["maintenance"], "summary": "Create Maintenance Rule", "description": "Create a new maintenance rule", "operationId": "create_maintenance_rule_maintenance_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/MaintenanceRuleCreate"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/MaintenanceRuleRead"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/maintenance/{rule_id}": {"put": {"tags": ["maintenance"], "summary": "Update Maintenance Rule", "description": "Update an existing maintenance rule", "operationId": "update_maintenance_rule_maintenance__rule_id__put", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Rule Id"}, "name": "rule_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/MaintenanceRuleCreate"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/MaintenanceRuleRead"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["maintenance"], "summary": "Delete Maintenance Rule", "description": "Delete a maintenance rule", "operationId": "delete_maintenance_rule_maintenance__rule_id__delete", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Rule Id"}, "name": "rule_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/topology": {"get": {"tags": ["topology"], "summary": "Get Topology Data", "description": "Get all topology data", "operationId": "get_topology_data_topology_get", "parameters": [{"required": false, "schema": {"type": "string", "title": "Provider Ids"}, "name": "provider_ids", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Services"}, "name": "services", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Environment"}, "name": "environment", "in": "query"}, {"required": false, "schema": {"type": "boolean", "title": "Include Empty Deps", "default": true}, "name": "include_empty_deps", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/TopologyServiceDtoOut"}, "type": "array", "title": "Response Get Topology Data Topology Get"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/topology/applications": {"get": {"tags": ["topology"], "summary": "Get Applications", "description": "Get all applications", "operationId": "get_applications_topology_applications_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"items": {"$ref": "#/components/schemas/TopologyApplicationDtoOut"}, "type": "array", "title": "Response Get Applications Topology Applications Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["topology"], "summary": "Create Application", "description": "Create a new application", "operationId": "create_application_topology_applications_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/TopologyApplicationDtoIn"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/TopologyApplicationDtoOut"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/topology/applications/{application_id}": {"put": {"tags": ["topology"], "summary": "Update Application", "description": "Update an application", "operationId": "update_application_topology_applications__application_id__put", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Application Id"}, "name": "application_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/TopologyApplicationDtoIn"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/TopologyApplicationDtoOut"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["topology"], "summary": "Delete Application", "description": "Delete an application", "operationId": "delete_application_topology_applications__application_id__delete", "parameters": [{"required": true, "schema": {"type": "string", "format": "uuid", "title": "Application Id"}, "name": "application_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/deduplications": {"get": {"tags": ["deduplications"], "summary": "Get Deduplications", "description": "Get Deduplications", "operationId": "get_deduplications_deduplications_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "post": {"tags": ["deduplications"], "summary": "Create Deduplication Rule", "description": "Create Deduplication Rule", "operationId": "create_deduplication_rule_deduplications_post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/DeduplicationRuleRequestDto"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/deduplications/fields": {"get": {"tags": ["deduplications"], "summary": "Get Deduplication Fields", "description": "Get Optional Fields For Deduplications", "operationId": "get_deduplication_fields_deduplications_fields_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"additionalProperties": {"items": {"type": "string"}, "type": "array"}, "type": "object", "title": "Response Get Deduplication Fields Deduplications Fields Get"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}, "/deduplications/{rule_id}": {"put": {"tags": ["deduplications"], "summary": "Update Deduplication Rule", "description": "Update Deduplication Rule", "operationId": "update_deduplication_rule_deduplications__rule_id__put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Rule Id"}, "name": "rule_id", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/DeduplicationRuleRequestDto"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}, "delete": {"tags": ["deduplications"], "summary": "Delete Deduplication Rule", "description": "Delete Deduplication Rule", "operationId": "delete_deduplication_rule_deduplications__rule_id__delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Rule Id"}, "name": "rule_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}, "security": [{"API Key": []}, {"HTTPBasic": []}, {"OAuth2PasswordBearer": []}]}}}, "components": {"schemas": {"AlertActionType": {"enum": ["alert was triggered", "alert acknowledged", "alert automatically resolved", "alert automatically resolved by API", "alert manually resolved", "alert status manually changed", "alert status changed by API", "alert status undone", "alert enriched by workflow", "alert enriched by mapping rule", "alert was deduplicated", "alert was assigned with ticket", "alert was unassigned from ticket", "alert ticket was updated", "alert enrichments disposed", "alert deleted", "alert enriched", "alert un-enriched", "a comment was added to the alert", "a comment was removed from the alert", "Alert is in maintenance window", "A comment was added to the incident"], "title": "AlertActionType", "description": "An enumeration."}, "AlertAudit": {"properties": {"id": {"type": "string", "format": "uuid", "title": "Id"}, "fingerprint": {"type": "string", "title": "Fingerprint"}, "tenant_id": {"type": "string", "title": "Tenant Id"}, "timestamp": {"type": "string", "format": "date-time", "title": "Timestamp"}, "user_id": {"type": "string", "title": "User Id"}, "action": {"type": "string", "title": "Action"}, "description": {"type": "string", "title": "Description"}}, "type": "object", "required": ["fingerprint", "tenant_id", "user_id", "action", "description"], "title": "AlertAudit"}, "AlertAuditDto": {"properties": {"id": {"type": "string", "title": "Id"}, "timestamp": {"type": "string", "format": "date-time", "title": "Timestamp"}, "fingerprint": {"type": "string", "title": "Fingerprint"}, "action": {"$ref": "#/components/schemas/AlertActionType"}, "user_id": {"type": "string", "title": "User Id"}, "description": {"type": "string", "title": "Description"}}, "type": "object", "required": ["id", "timestamp", "fingerprint", "action", "user_id", "description"], "title": "AlertAuditDto"}, "AlertDto": {"properties": {"id": {"type": "string", "title": "Id"}, "name": {"type": "string", "title": "Name"}, "status": {"$ref": "#/components/schemas/AlertStatus"}, "severity": {"$ref": "#/components/schemas/AlertSeverity"}, "lastReceived": {"type": "string", "title": "Lastreceived"}, "firingStartTime": {"type": "string", "title": "Firingstarttime"}, "environment": {"type": "string", "title": "Environment", "default": "undefined"}, "isFullDuplicate": {"type": "boolean", "title": "Isfullduplicate", "default": false}, "isPartialDuplicate": {"type": "boolean", "title": "Ispartialduplicate", "default": false}, "duplicateReason": {"type": "string", "title": "Duplicatereason"}, "service": {"type": "string", "title": "Service"}, "source": {"items": {"type": "string"}, "type": "array", "title": "Source", "default": []}, "apiKeyRef": {"type": "string", "title": "Apikeyref"}, "message": {"type": "string", "title": "Message"}, "description": {"type": "string", "title": "Description"}, "pushed": {"type": "boolean", "title": "Pushed", "default": false}, "event_id": {"type": "string", "title": "Event Id"}, "url": {"type": "string", "maxLength": 65536, "minLength": 1, "format": "uri", "title": "Url"}, "labels": {"type": "object", "title": "Labels", "default": {}}, "fingerprint": {"type": "string", "title": "Fingerprint"}, "deleted": {"type": "boolean", "title": "Deleted", "default": false}, "dismissUntil": {"type": "string", "title": "Dismissuntil"}, "dismissed": {"type": "boolean", "title": "Dismissed", "default": false}, "assignee": {"type": "string", "title": "Assignee"}, "providerId": {"type": "string", "title": "Providerid"}, "providerType": {"type": "string", "title": "Providertype"}, "note": {"type": "string", "title": "Note"}, "startedAt": {"type": "string", "title": "Startedat"}, "isNoisy": {"type": "boolean", "title": "Isnoisy", "default": false}, "enriched_fields": {"items": {}, "type": "array", "title": "Enriched Fields", "default": []}, "incident": {"type": "string", "title": "Incident"}}, "type": "object", "required": ["name", "status", "severity", "lastReceived"], "title": "AlertDto", "example": {"id": "1234", "name": "Pod 'api-service-production' lacks memory", "status": "firing", "lastReceived": "2021-01-01T00:00:00.000Z", "environment": "production", "service": "backend", "source": ["prometheus"], "message": "The pod 'api-service-production' lacks memory causing high error rate", "description": "Due to the lack of memory, the pod 'api-service-production' is experiencing high error rate", "severity": "critical", "pushed": true, "url": "https://www.keephq.dev?alertId=1234", "labels": {"pod": "api-service-production", "region": "us-east-1", "cpu": "88", "memory": "100Mi"}, "ticket_url": "https://www.keephq.dev?enrichedTicketId=456", "fingerprint": "1234"}}, "AlertSeverity": {"enum": ["critical", "high", "warning", "info", "low"], "title": "AlertSeverity", "description": "An enumeration."}, "AlertStatus": {"enum": ["firing", "resolved", "acknowledged", "suppressed", "pending"], "title": "AlertStatus", "description": "An enumeration."}, "AlertWithIncidentLinkMetadataDto": {"properties": {"id": {"type": "string", "title": "Id"}, "name": {"type": "string", "title": "Name"}, "status": {"$ref": "#/components/schemas/AlertStatus"}, "severity": {"$ref": "#/components/schemas/AlertSeverity"}, "lastReceived": {"type": "string", "title": "Lastreceived"}, "firingStartTime": {"type": "string", "title": "Firingstarttime"}, "environment": {"type": "string", "title": "Environment", "default": "undefined"}, "isFullDuplicate": {"type": "boolean", "title": "Isfullduplicate", "default": false}, "isPartialDuplicate": {"type": "boolean", "title": "Ispartialduplicate", "default": false}, "duplicateReason": {"type": "string", "title": "Duplicatereason"}, "service": {"type": "string", "title": "Service"}, "source": {"items": {"type": "string"}, "type": "array", "title": "Source", "default": []}, "apiKeyRef": {"type": "string", "title": "Apikeyref"}, "message": {"type": "string", "title": "Message"}, "description": {"type": "string", "title": "Description"}, "pushed": {"type": "boolean", "title": "Pushed", "default": false}, "event_id": {"type": "string", "title": "Event Id"}, "url": {"type": "string", "maxLength": 65536, "minLength": 1, "format": "uri", "title": "Url"}, "labels": {"type": "object", "title": "Labels", "default": {}}, "fingerprint": {"type": "string", "title": "Fingerprint"}, "deleted": {"type": "boolean", "title": "Deleted", "default": false}, "dismissUntil": {"type": "string", "title": "Dismissuntil"}, "dismissed": {"type": "boolean", "title": "Dismissed", "default": false}, "assignee": {"type": "string", "title": "Assignee"}, "providerId": {"type": "string", "title": "Providerid"}, "providerType": {"type": "string", "title": "Providertype"}, "note": {"type": "string", "title": "Note"}, "startedAt": {"type": "string", "title": "Startedat"}, "isNoisy": {"type": "boolean", "title": "Isnoisy", "default": false}, "enriched_fields": {"items": {}, "type": "array", "title": "Enriched Fields", "default": []}, "incident": {"type": "string", "title": "Incident"}, "is_created_by_ai": {"type": "boolean", "title": "Is Created By Ai", "default": false}}, "type": "object", "required": ["name", "status", "severity", "lastReceived"], "title": "AlertWithIncidentLinkMetadataDto", "example": {"id": "1234", "name": "Pod 'api-service-production' lacks memory", "status": "firing", "lastReceived": "2021-01-01T00:00:00.000Z", "environment": "production", "service": "backend", "source": ["prometheus"], "message": "The pod 'api-service-production' lacks memory causing high error rate", "description": "Due to the lack of memory, the pod 'api-service-production' is experiencing high error rate", "severity": "critical", "pushed": true, "url": "https://www.keephq.dev?alertId=1234", "labels": {"pod": "api-service-production", "region": "us-east-1", "cpu": "88", "memory": "100Mi"}, "ticket_url": "https://www.keephq.dev?enrichedTicketId=456", "fingerprint": "1234"}}, "AlertWithIncidentLinkMetadataPaginatedResultsDto": {"properties": {"limit": {"type": "integer", "title": "Limit", "default": 25}, "offset": {"type": "integer", "title": "Offset", "default": 0}, "count": {"type": "integer", "title": "Count"}, "items": {"items": {"$ref": "#/components/schemas/AlertWithIncidentLinkMetadataDto"}, "type": "array", "title": "Items"}}, "type": "object", "required": ["count", "items"], "title": "AlertWithIncidentLinkMetadataPaginatedResultsDto"}, "Body_create_actions_actions_post": {"properties": {"file": {"type": "string", "format": "binary", "title": "File"}}, "type": "object", "title": "Body_create_actions_actions_post"}, "Body_create_workflow_workflows_post": {"properties": {"file": {"type": "string", "format": "binary", "title": "File"}}, "type": "object", "required": ["file"], "title": "Body_create_workflow_workflows_post"}, "Body_pusher_authentication_pusher_auth_post": {"properties": {"channel_name": {"title": "Channel Name"}, "socket_id": {"title": "Socket Id"}}, "type": "object", "required": ["channel_name", "socket_id"], "title": "Body_pusher_authentication_pusher_auth_post"}, "Body_put_action_actions__action_id__put": {"properties": {"file": {"type": "string", "format": "binary", "title": "File"}}, "type": "object", "required": ["file"], "title": "Body_put_action_actions__action_id__put"}, "Body_run_workflow_from_definition_workflows_test_post": {"properties": {"file": {"type": "string", "format": "binary", "title": "File"}}, "type": "object", "title": "Body_run_workflow_from_definition_workflows_test_post"}, "CreateOrUpdateGroupRequest": {"properties": {"name": {"type": "string", "title": "Name"}, "roles": {"items": {"type": "string"}, "type": "array", "title": "Roles"}, "members": {"items": {"type": "string"}, "type": "array", "title": "Members"}}, "type": "object", "required": ["name", "roles", "members"], "title": "CreateOrUpdateGroupRequest"}, "CreateOrUpdatePresetDto": {"properties": {"name": {"type": "string", "title": "Name"}, "options": {"items": {"$ref": "#/components/schemas/PresetOption"}, "type": "array", "title": "Options"}, "is_private": {"type": "boolean", "title": "Is Private", "default": false}, "is_noisy": {"type": "boolean", "title": "Is Noisy", "default": false}, "tags": {"items": {"$ref": "#/components/schemas/TagDto"}, "type": "array", "title": "Tags", "default": []}}, "type": "object", "required": ["options"], "title": "CreateOrUpdatePresetDto"}, "CreateOrUpdateRole": {"properties": {"name": {"type": "string", "title": "Name"}, "description": {"type": "string", "title": "Description"}, "scopes": {"items": {"type": "string"}, "type": "array", "uniqueItems": true, "title": "Scopes"}}, "type": "object", "title": "CreateOrUpdateRole"}, "CreatePresetTab": {"properties": {"name": {"type": "string", "title": "Name"}, "filter": {"type": "string", "title": "Filter"}}, "type": "object", "required": ["name", "filter"], "title": "CreatePresetTab"}, "CreateUserRequest": {"properties": {"username": {"type": "string", "title": "Username"}, "name": {"type": "string", "title": "Name"}, "password": {"type": "string", "title": "Password"}, "role": {"type": "string", "title": "Role"}, "groups": {"items": {"type": "string"}, "type": "array", "title": "Groups"}}, "type": "object", "required": ["username"], "title": "CreateUserRequest"}, "DashboardCreateDTO": {"properties": {"dashboard_name": {"type": "string", "title": "Dashboard Name"}, "dashboard_config": {"type": "object", "title": "Dashboard Config"}}, "type": "object", "required": ["dashboard_name", "dashboard_config"], "title": "DashboardCreateDTO"}, "DashboardResponseDTO": {"properties": {"id": {"type": "string", "title": "Id"}, "dashboard_name": {"type": "string", "title": "Dashboard Name"}, "dashboard_config": {"type": "object", "title": "Dashboard Config"}, "created_at": {"type": "string", "format": "date-time", "title": "Created At"}, "updated_at": {"type": "string", "format": "date-time", "title": "Updated At"}}, "type": "object", "required": ["id", "dashboard_name", "dashboard_config", "created_at", "updated_at"], "title": "DashboardResponseDTO"}, "DashboardUpdateDTO": {"properties": {"dashboard_config": {"type": "object", "title": "Dashboard Config"}, "dashboard_name": {"type": "string", "title": "Dashboard Name"}}, "type": "object", "title": "DashboardUpdateDTO"}, "DeduplicationRuleRequestDto": {"properties": {"name": {"type": "string", "title": "Name"}, "description": {"type": "string", "title": "Description"}, "provider_type": {"type": "string", "title": "Provider Type"}, "provider_id": {"type": "string", "title": "Provider Id"}, "fingerprint_fields": {"items": {"type": "string"}, "type": "array", "title": "Fingerprint Fields"}, "full_deduplication": {"type": "boolean", "title": "Full Deduplication", "default": false}, "ignore_fields": {"items": {"type": "string"}, "type": "array", "title": "Ignore Fields"}}, "type": "object", "required": ["name", "provider_type", "fingerprint_fields"], "title": "DeduplicationRuleRequestDto"}, "DeleteRequestBody": {"properties": {"fingerprint": {"type": "string", "title": "Fingerprint"}, "lastReceived": {"type": "string", "title": "Lastreceived"}, "restore": {"type": "boolean", "title": "Restore", "default": false}}, "type": "object", "required": ["fingerprint", "lastReceived"], "title": "DeleteRequestBody"}, "EnrichAlertRequestBody": {"properties": {"enrichments": {"additionalProperties": {"type": "string"}, "type": "object", "title": "Enrichments"}, "fingerprint": {"type": "string", "title": "Fingerprint"}}, "type": "object", "required": ["enrichments", "fingerprint"], "title": "EnrichAlertRequestBody"}, "ExtractionRuleDtoBase": {"properties": {"name": {"type": "string", "title": "Name"}, "description": {"type": "string", "title": "Description"}, "priority": {"type": "integer", "title": "Priority", "default": 0}, "attribute": {"type": "string", "title": "Attribute"}, "condition": {"type": "string", "title": "Condition"}, "disabled": {"type": "boolean", "title": "Disabled", "default": false}, "regex": {"type": "string", "title": "Regex"}, "pre": {"type": "boolean", "title": "Pre", "default": false}}, "type": "object", "required": ["name", "regex"], "title": "ExtractionRuleDtoBase"}, "ExtractionRuleDtoOut": {"properties": {"name": {"type": "string", "title": "Name"}, "description": {"type": "string", "title": "Description"}, "priority": {"type": "integer", "title": "Priority", "default": 0}, "attribute": {"type": "string", "title": "Attribute"}, "condition": {"type": "string", "title": "Condition"}, "disabled": {"type": "boolean", "title": "Disabled", "default": false}, "regex": {"type": "string", "title": "Regex"}, "pre": {"type": "boolean", "title": "Pre", "default": false}, "id": {"type": "integer", "title": "Id"}, "created_by": {"type": "string", "title": "Created By"}, "created_at": {"type": "string", "format": "date-time", "title": "Created At"}, "updated_by": {"type": "string", "title": "Updated By"}, "updated_at": {"type": "string", "format": "date-time", "title": "Updated At"}}, "type": "object", "required": ["name", "regex", "id", "created_at"], "title": "ExtractionRuleDtoOut"}, "Group": {"properties": {"id": {"type": "string", "title": "Id"}, "name": {"type": "string", "title": "Name"}, "roles": {"items": {"type": "string"}, "type": "array", "title": "Roles", "default": []}, "members": {"items": {"type": "string"}, "type": "array", "title": "Members", "default": []}, "memberCount": {"type": "integer", "title": "Membercount", "default": 0}}, "type": "object", "required": ["id", "name"], "title": "Group"}, "HTTPValidationError": {"properties": {"detail": {"items": {"$ref": "#/components/schemas/ValidationError"}, "type": "array", "title": "Detail"}}, "type": "object", "title": "HTTPValidationError"}, "IncidentCommit": {"properties": {"accepted": {"type": "boolean", "title": "Accepted"}, "original_suggestion": {"type": "object", "title": "Original Suggestion"}, "changes": {"type": "object", "title": "Changes"}, "incident": {"$ref": "#/components/schemas/IncidentDto"}}, "type": "object", "required": ["accepted", "original_suggestion", "incident"], "title": "IncidentCommit"}, "IncidentDto": {"properties": {"user_generated_name": {"type": "string", "title": "User Generated Name"}, "assignee": {"type": "string", "title": "Assignee"}, "user_summary": {"type": "string", "title": "User Summary"}, "same_incident_in_the_past_id": {"type": "string", "format": "uuid", "title": "Same Incident In The Past Id"}, "id": {"type": "string", "format": "uuid", "title": "Id"}, "start_time": {"type": "string", "format": "date-time", "title": "Start Time"}, "last_seen_time": {"type": "string", "format": "date-time", "title": "Last Seen Time"}, "end_time": {"type": "string", "format": "date-time", "title": "End Time"}, "creation_time": {"type": "string", "format": "date-time", "title": "Creation Time"}, "alerts_count": {"type": "integer", "title": "Alerts Count"}, "alert_sources": {"items": {"type": "string"}, "type": "array", "title": "Alert Sources"}, "severity": {"$ref": "#/components/schemas/IncidentSeverity"}, "status": {"allOf": [{"$ref": "#/components/schemas/IncidentStatus"}], "default": "firing"}, "services": {"items": {"type": "string"}, "type": "array", "title": "Services"}, "is_predicted": {"type": "boolean", "title": "Is Predicted"}, "is_confirmed": {"type": "boolean", "title": "Is Confirmed"}, "generated_summary": {"type": "string", "title": "Generated Summary"}, "ai_generated_name": {"type": "string", "title": "Ai Generated Name"}, "rule_fingerprint": {"type": "string", "title": "Rule Fingerprint"}, "fingerprint": {"type": "string", "title": "Fingerprint"}, "merged_into_incident_id": {"type": "string", "format": "uuid", "title": "Merged Into Incident Id"}, "merged_by": {"type": "string", "title": "Merged By"}, "merged_at": {"type": "string", "format": "date-time", "title": "Merged At"}}, "type": "object", "required": ["id", "alerts_count", "alert_sources", "severity", "services", "is_predicted", "is_confirmed"], "title": "IncidentDto", "example": {"id": "c2509cb3-6168-4347-b83b-a41da9df2d5b", "name": "Incident name", "user_summary": "Keep: Incident description", "status": "firing"}}, "IncidentDtoIn": {"properties": {"user_generated_name": {"type": "string", "title": "User Generated Name"}, "assignee": {"type": "string", "title": "Assignee"}, "user_summary": {"type": "string", "title": "User Summary"}, "same_incident_in_the_past_id": {"type": "string", "format": "uuid", "title": "Same Incident In The Past Id"}}, "type": "object", "title": "IncidentDtoIn", "example": {"id": "c2509cb3-6168-4347-b83b-a41da9df2d5b", "name": "Incident name", "user_summary": "Keep: Incident description", "status": "firing"}}, "IncidentListFilterParamsDto": {"properties": {"statuses": {"items": {"$ref": "#/components/schemas/IncidentStatus"}, "type": "array", "default": ["firing", "resolved", "acknowledged", "merged"]}, "severities": {"items": {"$ref": "#/components/schemas/IncidentSeverity"}, "type": "array", "default": ["critical", "high", "warning", "info", "low"]}, "assignees": {"items": {"type": "string"}, "type": "array", "title": "Assignees"}, "services": {"items": {"type": "string"}, "type": "array", "title": "Services"}, "sources": {"items": {"type": "string"}, "type": "array", "title": "Sources"}}, "type": "object", "required": ["assignees", "services", "sources"], "title": "IncidentListFilterParamsDto"}, "IncidentSeverity": {"enum": ["critical", "high", "warning", "info", "low"], "title": "IncidentSeverity", "description": "An enumeration."}, "IncidentSorting": {"enum": ["creation_time", "start_time", "last_seen_time", "severity", "status", "alerts_count", "-creation_time", "-start_time", "-last_seen_time", "-severity", "-status", "-alerts_count"], "title": "IncidentSorting", "description": "An enumeration."}, "IncidentStatus": {"enum": ["firing", "resolved", "acknowledged", "merged"], "title": "IncidentStatus", "description": "An enumeration."}, "IncidentStatusChangeDto": {"properties": {"status": {"$ref": "#/components/schemas/IncidentStatus"}, "comment": {"type": "string", "title": "Comment"}}, "type": "object", "required": ["status"], "title": "IncidentStatusChangeDto"}, "IncidentsClusteringSuggestion": {"properties": {"incident_suggestion": {"items": {"$ref": "#/components/schemas/IncidentDto"}, "type": "array", "title": "Incident Suggestion"}, "suggestion_id": {"type": "string", "title": "Suggestion Id"}}, "type": "object", "required": ["incident_suggestion", "suggestion_id"], "title": "IncidentsClusteringSuggestion"}, "IncidentsPaginatedResultsDto": {"properties": {"limit": {"type": "integer", "title": "Limit", "default": 25}, "offset": {"type": "integer", "title": "Offset", "default": 0}, "count": {"type": "integer", "title": "Count"}, "items": {"items": {"$ref": "#/components/schemas/IncidentDto"}, "type": "array", "title": "Items"}}, "type": "object", "required": ["count", "items"], "title": "IncidentsPaginatedResultsDto"}, "MaintenanceRuleCreate": {"properties": {"name": {"type": "string", "title": "Name"}, "description": {"type": "string", "title": "Description"}, "cel_query": {"type": "string", "title": "Cel Query"}, "start_time": {"type": "string", "format": "date-time", "title": "Start Time"}, "duration_seconds": {"type": "integer", "title": "Duration Seconds"}, "suppress": {"type": "boolean", "title": "Suppress", "default": false}, "enabled": {"type": "boolean", "title": "Enabled", "default": true}}, "type": "object", "required": ["name", "cel_query", "start_time"], "title": "MaintenanceRuleCreate"}, "MaintenanceRuleRead": {"properties": {"id": {"type": "integer", "title": "Id"}, "name": {"type": "string", "title": "Name"}, "description": {"type": "string", "title": "Description"}, "created_by": {"type": "string", "title": "Created By"}, "cel_query": {"type": "string", "title": "Cel Query"}, "start_time": {"type": "string", "format": "date-time", "title": "Start Time"}, "end_time": {"type": "string", "format": "date-time", "title": "End Time"}, "duration_seconds": {"type": "integer", "title": "Duration Seconds"}, "updated_at": {"type": "string", "format": "date-time", "title": "Updated At"}, "suppress": {"type": "boolean", "title": "Suppress", "default": false}, "enabled": {"type": "boolean", "title": "Enabled", "default": true}}, "type": "object", "required": ["id", "name", "created_by", "cel_query", "start_time", "end_time"], "title": "MaintenanceRuleRead"}, "MappingRule": {"properties": {"id": {"type": "integer", "title": "Id"}, "tenant_id": {"type": "string", "title": "Tenant Id"}, "priority": {"type": "integer", "title": "Priority", "default": 0}, "name": {"type": "string", "maxLength": 255, "title": "Name"}, "description": {"type": "string", "maxLength": 2048, "title": "Description"}, "file_name": {"type": "string", "maxLength": 255, "title": "File Name"}, "created_by": {"type": "string", "maxLength": 255, "title": "Created By"}, "created_at": {"type": "string", "format": "date-time", "title": "Created At"}, "disabled": {"type": "boolean", "title": "Disabled", "default": false}, "override": {"type": "boolean", "title": "Override", "default": true}, "condition": {"type": "string", "maxLength": 2000, "title": "Condition"}, "type": {"type": "string", "maxLength": 255, "title": "Type"}, "matchers": {"items": {"type": "string"}, "type": "array", "title": "Matchers"}, "rows": {"items": {"type": "object"}, "type": "array", "title": "Rows"}, "updated_by": {"type": "string", "maxLength": 255, "title": "Updated By"}, "last_updated_at": {"type": "string", "format": "date-time", "title": "Last Updated At"}}, "type": "object", "required": ["tenant_id", "name", "type", "matchers"], "title": "MappingRule"}, "MappingRuleDtoIn": {"properties": {"name": {"type": "string", "title": "Name"}, "description": {"type": "string", "title": "Description"}, "file_name": {"type": "string", "title": "File Name"}, "priority": {"type": "integer", "title": "Priority", "default": 0}, "matchers": {"items": {"type": "string"}, "type": "array", "title": "Matchers"}, "type": {"type": "string", "enum": ["csv", "topology"], "title": "Type", "default": "csv"}, "rows": {"items": {"type": "object"}, "type": "array", "title": "Rows"}}, "type": "object", "required": ["name", "matchers"], "title": "MappingRuleDtoIn"}, "MappingRuleDtoOut": {"properties": {"name": {"type": "string", "title": "Name"}, "description": {"type": "string", "title": "Description"}, "file_name": {"type": "string", "title": "File Name"}, "priority": {"type": "integer", "title": "Priority", "default": 0}, "matchers": {"items": {"type": "string"}, "type": "array", "title": "Matchers"}, "type": {"type": "string", "enum": ["csv", "topology"], "title": "Type", "default": "csv"}, "id": {"type": "integer", "title": "Id"}, "created_by": {"type": "string", "title": "Created By"}, "created_at": {"type": "string", "format": "date-time", "title": "Created At"}, "attributes": {"items": {"type": "string"}, "type": "array", "title": "Attributes", "default": []}, "updated_by": {"type": "string", "title": "Updated By"}, "last_updated_at": {"type": "string", "format": "date-time", "title": "Last Updated At"}}, "type": "object", "required": ["name", "matchers", "id", "created_at"], "title": "MappingRuleDtoOut"}, "MergeIncidentsRequestDto": {"properties": {"source_incident_ids": {"items": {"type": "string", "format": "uuid"}, "type": "array", "title": "Source Incident Ids"}, "destination_incident_id": {"type": "string", "format": "uuid", "title": "Destination Incident Id"}}, "type": "object", "required": ["source_incident_ids", "destination_incident_id"], "title": "MergeIncidentsRequestDto"}, "MergeIncidentsResponseDto": {"properties": {"merged_incident_ids": {"items": {"type": "string", "format": "uuid"}, "type": "array", "title": "Merged Incident Ids"}, "skipped_incident_ids": {"items": {"type": "string", "format": "uuid"}, "type": "array", "title": "Skipped Incident Ids"}, "failed_incident_ids": {"items": {"type": "string", "format": "uuid"}, "type": "array", "title": "Failed Incident Ids"}, "destination_incident_id": {"type": "string", "format": "uuid", "title": "Destination Incident Id"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["merged_incident_ids", "skipped_incident_ids", "failed_incident_ids", "destination_incident_id", "message"], "title": "MergeIncidentsResponseDto"}, "PermissionEntity": {"properties": {"id": {"type": "string", "title": "Id"}, "type": {"type": "string", "title": "Type"}, "name": {"type": "string", "title": "Name"}}, "type": "object", "required": ["id", "type"], "title": "PermissionEntity"}, "PresetDto": {"properties": {"id": {"type": "string", "format": "uuid", "title": "Id"}, "name": {"type": "string", "title": "Name"}, "options": {"items": {}, "type": "array", "title": "Options", "default": []}, "created_by": {"type": "string", "title": "Created By"}, "is_private": {"type": "boolean", "title": "Is Private", "default": false}, "is_noisy": {"type": "boolean", "title": "Is Noisy", "default": false}, "should_do_noise_now": {"type": "boolean", "title": "Should Do Noise Now", "default": false}, "alerts_count": {"type": "integer", "title": "Alerts Count", "default": 0}, "static": {"type": "boolean", "title": "Static", "default": false}, "tags": {"items": {"$ref": "#/components/schemas/TagDto"}, "type": "array", "title": "Tags", "default": []}}, "type": "object", "required": ["id", "name"], "title": "PresetDto"}, "PresetOption": {"properties": {"label": {"type": "string", "title": "Label"}, "value": {"anyOf": [{"type": "string"}, {"type": "object"}], "title": "Value"}}, "type": "object", "required": ["label", "value"], "title": "PresetOption"}, "PresetSearchQuery": {"properties": {"cel_query": {"type": "string", "minLength": 0, "title": "Cel Query"}, "sql_query": {"type": "object", "title": "Sql Query"}, "limit": {"type": "integer", "minimum": 0.0, "title": "Limit", "default": 1000}, "timeframe": {"type": "integer", "minimum": 0.0, "title": "Timeframe", "default": 0}}, "type": "object", "required": ["cel_query", "sql_query"], "title": "PresetSearchQuery"}, "ProviderDTO": {"properties": {"type": {"type": "string", "title": "Type"}, "id": {"type": "string", "title": "Id"}, "name": {"type": "string", "title": "Name"}, "installed": {"type": "boolean", "title": "Installed"}}, "type": "object", "required": ["type", "name", "installed"], "title": "ProviderDTO"}, "ProviderWebhookSettings": {"properties": {"webhookDescription": {"type": "string", "title": "Webhookdescription"}, "webhookTemplate": {"type": "string", "title": "Webhooktemplate"}, "webhookMarkdown": {"type": "string", "title": "Webhookmarkdown"}}, "type": "object", "required": ["webhookTemplate"], "title": "ProviderWebhookSettings"}, "ResourcePermission": {"properties": {"resource_id": {"type": "string", "title": "Resource Id"}, "resource_name": {"type": "string", "title": "Resource Name"}, "resource_type": {"type": "string", "title": "Resource Type"}, "permissions": {"items": {"$ref": "#/components/schemas/PermissionEntity"}, "type": "array", "title": "Permissions"}}, "type": "object", "required": ["resource_id", "resource_name", "resource_type", "permissions"], "title": "ResourcePermission"}, "Role": {"properties": {"id": {"type": "string", "title": "Id"}, "name": {"type": "string", "title": "Name"}, "description": {"type": "string", "title": "Description"}, "scopes": {"items": {"type": "string"}, "type": "array", "uniqueItems": true, "title": "Scopes"}, "predefined": {"type": "boolean", "title": "Predefined", "default": true}}, "type": "object", "required": ["id", "name", "description", "scopes"], "title": "Role"}, "RuleCreateDto": {"properties": {"ruleName": {"type": "string", "title": "Rulename"}, "sqlQuery": {"type": "object", "title": "Sqlquery"}, "celQuery": {"type": "string", "title": "Celquery"}, "timeframeInSeconds": {"type": "integer", "title": "Timeframeinseconds"}, "timeUnit": {"type": "string", "title": "Timeunit"}, "groupingCriteria": {"items": {}, "type": "array", "title": "Groupingcriteria", "default": []}, "groupDescription": {"type": "string", "title": "Groupdescription"}, "requireApprove": {"type": "boolean", "title": "Requireapprove", "default": false}, "resolveOn": {"type": "string", "title": "Resolveon", "default": "never"}}, "type": "object", "required": ["ruleName", "sqlQuery", "celQuery", "timeframeInSeconds", "timeUnit"], "title": "RuleCreateDto"}, "SMTPSettings": {"properties": {"host": {"type": "string", "title": "Host"}, "port": {"type": "integer", "title": "Port"}, "from_email": {"type": "string", "title": "From Email"}, "username": {"type": "string", "title": "Username"}, "password": {"type": "string", "format": "password", "title": "Password", "writeOnly": true}, "secure": {"type": "boolean", "title": "Secure", "default": true}, "to_email": {"type": "string", "title": "To Email", "default": "keep@example.com"}}, "type": "object", "required": ["host", "port", "from_email"], "title": "SMTPSettings", "example": {"host": "smtp.example.com", "port": 587, "username": "user@example.com", "password": "password", "secure": true, "from_email": "noreply@example.com", "to_email": ""}}, "SearchAlertsRequest": {"properties": {"query": {"$ref": "#/components/schemas/PresetSearchQuery"}, "timeframe": {"type": "integer", "title": "Timeframe"}}, "type": "object", "required": ["query", "timeframe"], "title": "SearchAlertsRequest"}, "TagDto": {"properties": {"id": {"type": "string", "title": "Id"}, "name": {"type": "string", "title": "Name"}}, "type": "object", "required": ["name"], "title": "TagDto"}, "TopologyApplicationDtoIn": {"properties": {"id": {"type": "string", "format": "uuid", "title": "Id"}, "name": {"type": "string", "title": "Name"}, "description": {"type": "string", "title": "Description"}, "services": {"items": {"$ref": "#/components/schemas/TopologyServiceDtoIn"}, "type": "array", "title": "Services", "default": []}}, "type": "object", "required": ["name"], "title": "TopologyApplicationDtoIn"}, "TopologyApplicationDtoOut": {"properties": {"id": {"type": "string", "format": "uuid", "title": "Id"}, "name": {"type": "string", "title": "Name"}, "description": {"type": "string", "title": "Description"}, "services": {"items": {"$ref": "#/components/schemas/TopologyApplicationServiceDto"}, "type": "array", "title": "Services", "default": []}}, "type": "object", "required": ["id", "name"], "title": "TopologyApplicationDtoOut"}, "TopologyApplicationServiceDto": {"properties": {"id": {"type": "integer", "title": "Id"}, "name": {"type": "string", "title": "Name"}, "service": {"type": "string", "title": "Service"}}, "type": "object", "required": ["id", "name", "service"], "title": "TopologyApplicationServiceDto"}, "TopologyServiceDependencyDto": {"properties": {"serviceId": {"type": "integer", "title": "Serviceid"}, "serviceName": {"type": "string", "title": "Servicename"}, "protocol": {"type": "string", "title": "Protocol", "default": "unknown"}}, "type": "object", "required": ["serviceId", "serviceName"], "title": "TopologyServiceDependencyDto"}, "TopologyServiceDtoIn": {"properties": {"id": {"type": "integer", "title": "Id"}}, "type": "object", "required": ["id"], "title": "TopologyServiceDtoIn"}, "TopologyServiceDtoOut": {"properties": {"source_provider_id": {"type": "string", "title": "Source Provider Id"}, "repository": {"type": "string", "title": "Repository"}, "tags": {"items": {"type": "string"}, "type": "array", "title": "Tags"}, "service": {"type": "string", "title": "Service"}, "display_name": {"type": "string", "title": "Display Name"}, "environment": {"type": "string", "title": "Environment", "default": "unknown"}, "description": {"type": "string", "title": "Description"}, "team": {"type": "string", "title": "Team"}, "email": {"type": "string", "title": "Email"}, "slack": {"type": "string", "title": "Slack"}, "ip_address": {"type": "string", "title": "Ip Address"}, "mac_address": {"type": "string", "title": "Mac Address"}, "category": {"type": "string", "title": "Category"}, "manufacturer": {"type": "string", "title": "Manufacturer"}, "id": {"type": "integer", "title": "Id"}, "dependencies": {"items": {"$ref": "#/components/schemas/TopologyServiceDependencyDto"}, "type": "array", "title": "Dependencies"}, "application_ids": {"items": {"type": "string", "format": "uuid"}, "type": "array", "title": "Application Ids"}, "updated_at": {"type": "string", "format": "date-time", "title": "Updated At"}}, "type": "object", "required": ["service", "display_name", "id", "dependencies", "application_ids"], "title": "TopologyServiceDtoOut"}, "UnEnrichAlertRequestBody": {"properties": {"enrichments": {"items": {"type": "string"}, "type": "array", "title": "Enrichments"}, "fingerprint": {"type": "string", "title": "Fingerprint"}}, "type": "object", "required": ["enrichments", "fingerprint"], "title": "UnEnrichAlertRequestBody"}, "UpdateUserRequest": {"properties": {"username": {"type": "string", "title": "Username"}, "password": {"type": "string", "title": "Password"}, "role": {"type": "string", "title": "Role"}, "groups": {"items": {"type": "string"}, "type": "array", "title": "Groups"}}, "type": "object", "title": "UpdateUserRequest"}, "User": {"properties": {"email": {"type": "string", "title": "Email"}, "name": {"type": "string", "title": "Name"}, "role": {"type": "string", "title": "Role"}, "picture": {"type": "string", "title": "Picture"}, "created_at": {"type": "string", "title": "Created At"}, "last_login": {"type": "string", "title": "Last Login"}, "ldap": {"type": "boolean", "title": "Ldap", "default": false}, "groups": {"items": {"$ref": "#/components/schemas/Group"}, "type": "array", "title": "Groups", "default": []}}, "type": "object", "required": ["email", "name", "created_at"], "title": "User"}, "ValidationError": {"properties": {"loc": {"items": {"anyOf": [{"type": "string"}, {"type": "integer"}]}, "type": "array", "title": "Location"}, "msg": {"type": "string", "title": "Message"}, "type": {"type": "string", "title": "Error Type"}}, "type": "object", "required": ["loc", "msg", "type"], "title": "ValidationError"}, "WebhookSettings": {"properties": {"webhookApi": {"type": "string", "title": "Webhookapi"}, "apiKey": {"type": "string", "title": "Apikey"}, "modelSchema": {"type": "object", "title": "Modelschema"}}, "type": "object", "required": ["webhookApi", "apiKey", "modelSchema"], "title": "WebhookSettings"}, "WorkflowCreateOrUpdateDTO": {"properties": {"workflow_id": {"type": "string", "title": "Workflow Id"}, "status": {"type": "string", "enum": ["created", "updated"], "title": "Status"}, "revision": {"type": "integer", "title": "Revision", "default": 1}}, "type": "object", "required": ["workflow_id", "status"], "title": "WorkflowCreateOrUpdateDTO"}, "WorkflowDTO": {"properties": {"id": {"type": "string", "title": "Id"}, "name": {"type": "string", "title": "Name", "default": "Workflow file doesn't contain name"}, "description": {"type": "string", "title": "Description", "default": "Workflow file doesn't contain description"}, "created_by": {"type": "string", "title": "Created By"}, "creation_time": {"type": "string", "format": "date-time", "title": "Creation Time"}, "triggers": {"items": {"type": "object"}, "type": "array", "title": "Triggers"}, "interval": {"type": "integer", "title": "Interval"}, "disabled": {"type": "boolean", "title": "Disabled", "default": false}, "last_execution_time": {"type": "string", "format": "date-time", "title": "Last Execution Time"}, "last_execution_status": {"type": "string", "title": "Last Execution Status"}, "providers": {"items": {"$ref": "#/components/schemas/ProviderDTO"}, "type": "array", "title": "Providers"}, "workflow_raw": {"type": "string", "title": "Workflow Raw"}, "revision": {"type": "integer", "title": "Revision", "default": 1}, "last_updated": {"type": "string", "format": "date-time", "title": "Last Updated"}, "invalid": {"type": "boolean", "title": "Invalid", "default": false}, "last_executions": {"items": {"type": "object"}, "type": "array", "title": "Last Executions"}, "last_execution_started": {"type": "string", "format": "date-time", "title": "Last Execution Started"}, "provisioned": {"type": "boolean", "title": "Provisioned", "default": false}, "provisioned_file": {"type": "string", "title": "Provisioned File"}}, "type": "object", "required": ["id", "created_by", "creation_time", "providers", "workflow_raw"], "title": "WorkflowDTO"}, "WorkflowExecutionDTO": {"properties": {"id": {"type": "string", "title": "Id"}, "workflow_id": {"type": "string", "title": "Workflow Id"}, "started": {"type": "string", "format": "date-time", "title": "Started"}, "triggered_by": {"type": "string", "title": "Triggered By"}, "status": {"type": "string", "title": "Status"}, "workflow_name": {"type": "string", "title": "Workflow Name"}, "logs": {"items": {"$ref": "#/components/schemas/WorkflowExecutionLogsDTO"}, "type": "array", "title": "Logs"}, "error": {"type": "string", "title": "Error"}, "execution_time": {"type": "number", "title": "Execution Time"}, "results": {"type": "object", "title": "Results"}}, "type": "object", "required": ["id", "workflow_id", "started", "triggered_by", "status"], "title": "WorkflowExecutionDTO"}, "WorkflowExecutionLogsDTO": {"properties": {"id": {"type": "integer", "title": "Id"}, "timestamp": {"type": "string", "format": "date-time", "title": "Timestamp"}, "message": {"type": "string", "title": "Message"}, "context": {"type": "object", "title": "Context"}}, "type": "object", "required": ["id", "timestamp", "message"], "title": "WorkflowExecutionLogsDTO"}, "WorkflowExecutionsPaginatedResultsDto": {"properties": {"limit": {"type": "integer", "title": "Limit", "default": 25}, "offset": {"type": "integer", "title": "Offset", "default": 0}, "count": {"type": "integer", "title": "Count"}, "items": {"items": {"$ref": "#/components/schemas/WorkflowExecutionDTO"}, "type": "array", "title": "Items"}, "passCount": {"type": "integer", "title": "Passcount", "default": 0}, "avgDuration": {"type": "number", "title": "Avgduration", "default": 0.0}, "workflow": {"$ref": "#/components/schemas/WorkflowDTO"}, "failCount": {"type": "integer", "title": "Failcount", "default": 0}}, "type": "object", "required": ["count", "items"], "title": "WorkflowExecutionsPaginatedResultsDto"}, "WorkflowToAlertExecutionDTO": {"properties": {"workflow_id": {"type": "string", "title": "Workflow Id"}, "workflow_execution_id": {"type": "string", "title": "Workflow Execution Id"}, "alert_fingerprint": {"type": "string", "title": "Alert Fingerprint"}, "workflow_status": {"type": "string", "title": "Workflow Status"}, "workflow_started": {"type": "string", "format": "date-time", "title": "Workflow Started"}}, "type": "object", "required": ["workflow_id", "workflow_execution_id", "alert_fingerprint", "workflow_status", "workflow_started"], "title": "WorkflowToAlertExecutionDTO"}}, "securitySchemes": {"API Key": {"type": "apiKey", "in": "header", "name": "X-API-KEY"}, "HTTPBasic": {"type": "http", "scheme": "basic"}, "OAuth2PasswordBearer": {"type": "oauth2", "flows": {"password": {"scopes": {}, "tokenUrl": "token"}}}}}}
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Keep API",
+    "description": "Rest API powering https://platform.keephq.dev and friends \ud83c\udfc4\u200d\u2640\ufe0f",
+    "version": "0.24.5"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "Root",
+        "description": "App desctiption and version.",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        }
+      }
+    },
+    "/providers": {
+      "get": {
+        "tags": ["providers"],
+        "summary": "Get Providers",
+        "operationId": "get_providers_providers_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/export": {
+      "get": {
+        "tags": ["providers"],
+        "summary": "Get Installed Providers",
+        "description": "export all installed providers",
+        "operationId": "get_installed_providers_providers_export_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/{provider_type}/{provider_id}/configured-alerts": {
+      "get": {
+        "tags": ["providers"],
+        "summary": "Get Alerts Configuration",
+        "description": "Get alerts configuration from a provider",
+        "operationId": "get_alerts_configuration_providers__provider_type___provider_id__configured_alerts_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Type" },
+            "name": "provider_type",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Id" },
+            "name": "provider_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {},
+                  "type": "array",
+                  "title": "Response Get Alerts Configuration Providers  Provider Type   Provider Id  Configured Alerts Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/{provider_type}/{provider_id}/logs": {
+      "get": {
+        "tags": ["providers"],
+        "summary": "Get Logs",
+        "description": "Get logs from a provider",
+        "operationId": "get_logs_providers__provider_type___provider_id__logs_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Type" },
+            "name": "provider_type",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Id" },
+            "name": "provider_id",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Limit", "default": 5 },
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {},
+                  "type": "array",
+                  "title": "Response Get Logs Providers  Provider Type   Provider Id  Logs Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/{provider_type}/schema": {
+      "get": {
+        "tags": ["providers"],
+        "summary": "Get Alerts Schema",
+        "description": "Get the provider's API schema used to push alerts configuration",
+        "operationId": "get_alerts_schema_providers__provider_type__schema_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Type" },
+            "name": "provider_type",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Get Alerts Schema Providers  Provider Type  Schema Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/providers/{provider_type}/{provider_id}/alerts/count": {
+      "get": {
+        "tags": ["providers"],
+        "summary": "Get Alert Count",
+        "description": "Get number of alerts a specific provider has received (in a specific time time period or ever)",
+        "operationId": "get_alert_count_providers__provider_type___provider_id__alerts_count_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Type" },
+            "name": "provider_type",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Id" },
+            "name": "provider_id",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": { "type": "boolean", "title": "Ever" },
+            "name": "ever",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Start Time"
+            },
+            "name": "start_time",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "title": "End Time"
+            },
+            "name": "end_time",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/{provider_type}/{provider_id}/alerts": {
+      "post": {
+        "tags": ["providers"],
+        "summary": "Add Alert",
+        "description": "Push new alerts to the provider",
+        "operationId": "add_alert_providers__provider_type___provider_id__alerts_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Type" },
+            "name": "provider_type",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Id" },
+            "name": "provider_id",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Alert Id" },
+            "name": "alert_id",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object", "title": "Alert" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/test": {
+      "post": {
+        "tags": ["providers"],
+        "summary": "Test Provider",
+        "description": "Test a provider's alert retrieval",
+        "operationId": "test_provider_providers_test_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object", "title": "Provider Info" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/{provider_type}/{provider_id}": {
+      "delete": {
+        "tags": ["providers"],
+        "summary": "Delete Provider",
+        "operationId": "delete_provider_providers__provider_type___provider_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Type" },
+            "name": "provider_type",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Id" },
+            "name": "provider_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/{provider_id}/scopes": {
+      "post": {
+        "tags": ["providers"],
+        "summary": "Validate Provider Scopes",
+        "description": "Validate provider scopes",
+        "operationId": "validate_provider_scopes_providers__provider_id__scopes_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Id" },
+            "name": "provider_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [{ "type": "boolean" }, { "type": "string" }]
+                  },
+                  "type": "object",
+                  "title": "Response Validate Provider Scopes Providers  Provider Id  Scopes Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/{provider_id}": {
+      "put": {
+        "tags": ["providers"],
+        "summary": "Update Provider",
+        "description": "Update provider",
+        "operationId": "update_provider_providers__provider_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Id" },
+            "name": "provider_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/install": {
+      "post": {
+        "tags": ["providers"],
+        "summary": "Install Provider",
+        "operationId": "install_provider_providers_install_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/install/oauth2/{provider_type}": {
+      "post": {
+        "tags": ["providers"],
+        "summary": "Install Provider Oauth2",
+        "operationId": "install_provider_oauth2_providers_install_oauth2__provider_type__post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Type" },
+            "name": "provider_type",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object", "title": "Provider Info" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/{provider_id}/invoke/{method}": {
+      "post": {
+        "tags": ["providers"],
+        "summary": "Invoke Provider Method",
+        "description": "Invoke provider special method",
+        "operationId": "invoke_provider_method_providers__provider_id__invoke__method__post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Id" },
+            "name": "provider_id",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Method" },
+            "name": "method",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object", "title": "Method Params" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/install/webhook/{provider_type}/{provider_id}": {
+      "post": {
+        "tags": ["providers"],
+        "summary": "Install Provider Webhook",
+        "operationId": "install_provider_webhook_providers_install_webhook__provider_type___provider_id__post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Type" },
+            "name": "provider_type",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Id" },
+            "name": "provider_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/providers/{provider_type}/webhook": {
+      "get": {
+        "tags": ["providers"],
+        "summary": "Get Webhook Settings",
+        "operationId": "get_webhook_settings_providers__provider_type__webhook_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Type" },
+            "name": "provider_type",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderWebhookSettings"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/actions": {
+      "get": {
+        "tags": ["actions"],
+        "summary": "Get Actions",
+        "description": "Get all actions",
+        "operationId": "get_actions_actions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["actions"],
+        "summary": "Create Actions",
+        "description": "Create new actions by uploading a file",
+        "operationId": "create_actions_actions_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_actions_actions_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/actions/{action_id}": {
+      "put": {
+        "tags": ["actions"],
+        "summary": "Put Action",
+        "description": "Update an action",
+        "operationId": "put_action_actions__action_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Action Id" },
+            "name": "action_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_put_action_actions__action_id__put"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["actions"],
+        "summary": "Delete Action",
+        "description": "Delete an action",
+        "operationId": "delete_action_actions__action_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Action Id" },
+            "name": "action_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/healthcheck": {
+      "get": {
+        "tags": ["healthcheck"],
+        "summary": "Healthcheck",
+        "description": "simple healthcheck endpoint",
+        "operationId": "healthcheck_healthcheck_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Healthcheck Healthcheck Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/alerts": {
+      "get": {
+        "tags": ["alerts"],
+        "summary": "Get All Alerts",
+        "description": "Get last alerts occurrence",
+        "operationId": "get_all_alerts_alerts_get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Limit", "default": 1000 },
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/AlertDto" },
+                  "type": "array",
+                  "title": "Response Get All Alerts Alerts Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["alerts"],
+        "summary": "Delete Alert",
+        "description": "Delete alert by fingerprint and last received time",
+        "operationId": "delete_alert_alerts_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/DeleteRequestBody" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": { "type": "string" },
+                  "type": "object",
+                  "title": "Response Delete Alert Alerts Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/alerts/{fingerprint}/history": {
+      "get": {
+        "tags": ["alerts"],
+        "summary": "Get Alert History",
+        "description": "Get alert history",
+        "operationId": "get_alert_history_alerts__fingerprint__history_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Fingerprint" },
+            "name": "fingerprint",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/AlertDto" },
+                  "type": "array",
+                  "title": "Response Get Alert History Alerts  Fingerprint  History Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/alerts/{fingerprint}/assign/{last_received}": {
+      "post": {
+        "tags": ["alerts"],
+        "summary": "Assign Alert",
+        "description": "Assign alert to user",
+        "operationId": "assign_alert_alerts__fingerprint__assign__last_received__post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Fingerprint" },
+            "name": "fingerprint",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Last Received" },
+            "name": "last_received",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "title": "Unassign",
+              "default": false
+            },
+            "name": "unassign",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": { "type": "string" },
+                  "type": "object",
+                  "title": "Response Assign Alert Alerts  Fingerprint  Assign  Last Received  Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/alerts/event": {
+      "post": {
+        "tags": ["alerts"],
+        "summary": "Receive Generic Event",
+        "description": "Receive a generic alert event",
+        "operationId": "receive_generic_event_alerts_event_post",
+        "parameters": [
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Fingerprint" },
+            "name": "fingerprint",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  { "$ref": "#/components/schemas/AlertDto" },
+                  {
+                    "items": { "$ref": "#/components/schemas/AlertDto" },
+                    "type": "array"
+                  },
+                  { "type": "object" }
+                ],
+                "title": "Event"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    { "$ref": "#/components/schemas/AlertDto" },
+                    {
+                      "items": { "$ref": "#/components/schemas/AlertDto" },
+                      "type": "array"
+                    }
+                  ],
+                  "title": "Response Receive Generic Event Alerts Event Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/alerts/event/netdata": {
+      "get": {
+        "tags": ["alerts"],
+        "summary": "Webhook Challenge",
+        "description": "Helper function to complete Netdata webhook challenge",
+        "operationId": "webhook_challenge_alerts_event_netdata_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        }
+      }
+    },
+    "/alerts/event/{provider_type}": {
+      "post": {
+        "tags": ["alerts"],
+        "summary": "Receive Event",
+        "description": "Receive an alert event from a provider",
+        "operationId": "receive_event_alerts_event__provider_type__post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Type" },
+            "name": "provider_type",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Provider Id" },
+            "name": "provider_id",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Fingerprint" },
+            "name": "fingerprint",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": { "type": "string" },
+                  "type": "object",
+                  "title": "Response Receive Event Alerts Event  Provider Type  Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/alerts/{fingerprint}": {
+      "get": {
+        "tags": ["alerts"],
+        "summary": "Get Alert",
+        "description": "Get alert by fingerprint",
+        "operationId": "get_alert_alerts__fingerprint__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Fingerprint" },
+            "name": "fingerprint",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AlertDto" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/alerts/enrich": {
+      "post": {
+        "tags": ["alerts"],
+        "summary": "Enrich Alert",
+        "description": "Enrich an alert",
+        "operationId": "enrich_alert_alerts_enrich_post",
+        "parameters": [
+          {
+            "description": "Dispose on new alert",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "title": "Dispose On New Alert",
+              "description": "Dispose on new alert",
+              "default": false
+            },
+            "name": "dispose_on_new_alert",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnrichAlertRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": { "type": "string" },
+                  "type": "object",
+                  "title": "Response Enrich Alert Alerts Enrich Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/alerts/unenrich": {
+      "post": {
+        "tags": ["alerts"],
+        "summary": "Unenrich Alert",
+        "description": "Un-Enrich an alert",
+        "operationId": "unenrich_alert_alerts_unenrich_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnEnrichAlertRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": { "type": "string" },
+                  "type": "object",
+                  "title": "Response Unenrich Alert Alerts Unenrich Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/alerts/search": {
+      "post": {
+        "tags": ["alerts"],
+        "summary": "Search Alerts",
+        "description": "Search alerts",
+        "operationId": "search_alerts_alerts_search_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SearchAlertsRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/AlertDto" },
+                  "type": "array",
+                  "title": "Response Search Alerts Alerts Search Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/alerts/audit": {
+      "post": {
+        "tags": ["alerts"],
+        "summary": "Get Multiple Fingerprint Alert Audit",
+        "description": "Get alert timeline audit trail for multiple fingerprints",
+        "operationId": "get_multiple_fingerprint_alert_audit_alerts_audit_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": { "type": "string" },
+                "type": "array",
+                "title": "Fingerprints"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/AlertAuditDto" },
+                  "type": "array",
+                  "title": "Response Get Multiple Fingerprint Alert Audit Alerts Audit Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/alerts/{fingerprint}/audit": {
+      "get": {
+        "tags": ["alerts"],
+        "summary": "Get Alert Audit",
+        "description": "Get alert timeline audit trail",
+        "operationId": "get_alert_audit_alerts__fingerprint__audit_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Fingerprint" },
+            "name": "fingerprint",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/AlertAuditDto" },
+                  "type": "array",
+                  "title": "Response Get Alert Audit Alerts  Fingerprint  Audit Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/alerts/quality/metrics": {
+      "get": {
+        "tags": ["alerts"],
+        "summary": "Get Alert Quality",
+        "description": "Get alert quality",
+        "operationId": "get_alert_quality_alerts_quality_metrics_get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "items": { "type": "string" },
+              "type": "array",
+              "title": "Fields",
+              "default": []
+            },
+            "name": "fields",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Time Stamp" },
+            "name": "time_stamp",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents": {
+      "get": {
+        "tags": ["incidents"],
+        "summary": "Get All Incidents",
+        "description": "Get last incidents",
+        "operationId": "get_all_incidents_incidents_get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "title": "Confirmed",
+              "default": true
+            },
+            "name": "confirmed",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Limit", "default": 25 },
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Offset", "default": 0 },
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/IncidentSorting" }],
+              "default": "creation_time"
+            },
+            "name": "sorting",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": { "$ref": "#/components/schemas/IncidentStatus" },
+              "type": "array"
+            },
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": { "$ref": "#/components/schemas/IncidentSeverity" },
+              "type": "array"
+            },
+            "name": "severity",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": { "type": "string" },
+              "type": "array",
+              "title": "Assignees"
+            },
+            "name": "assignees",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": { "type": "string" },
+              "type": "array",
+              "title": "Sources"
+            },
+            "name": "sources",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": { "type": "string" },
+              "type": "array",
+              "title": "Affected Services"
+            },
+            "name": "affected_services",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IncidentsPaginatedResultsDto"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["incidents"],
+        "summary": "Create Incident",
+        "description": "Create new incident",
+        "operationId": "create_incident_incidents_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/IncidentDtoIn" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/IncidentDto" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents/meta": {
+      "get": {
+        "tags": ["incidents"],
+        "summary": "Get Incidents Meta",
+        "description": "Get incidents' metadata for filtering",
+        "operationId": "get_incidents_meta_incidents_meta_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IncidentListFilterParamsDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents/{incident_id}": {
+      "get": {
+        "tags": ["incidents"],
+        "summary": "Get Incident",
+        "description": "Get incident by id",
+        "operationId": "get_incident_incidents__incident_id__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Incident Id"
+            },
+            "name": "incident_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/IncidentDto" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "put": {
+        "tags": ["incidents"],
+        "summary": "Update Incident",
+        "description": "Update incident by id",
+        "operationId": "update_incident_incidents__incident_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Incident Id"
+            },
+            "name": "incident_id",
+            "in": "path"
+          },
+          {
+            "description": "Whether the incident update request was generated by AI",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "title": "Generatedbyai",
+              "description": "Whether the incident update request was generated by AI",
+              "default": false
+            },
+            "name": "generatedByAi",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/IncidentDtoIn" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/IncidentDto" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["incidents"],
+        "summary": "Delete Incident",
+        "description": "Delete incident by incident id",
+        "operationId": "delete_incident_incidents__incident_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Incident Id"
+            },
+            "name": "incident_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents/merge": {
+      "post": {
+        "tags": ["incidents"],
+        "summary": "Merge Incidents",
+        "description": "Merge incidents",
+        "operationId": "merge_incidents_incidents_merge_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MergeIncidentsRequestDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MergeIncidentsResponseDto"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents/{incident_id}/alerts": {
+      "get": {
+        "tags": ["incidents"],
+        "summary": "Get Incident Alerts",
+        "description": "Get incident alerts by incident incident id",
+        "operationId": "get_incident_alerts_incidents__incident_id__alerts_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Incident Id"
+            },
+            "name": "incident_id",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Limit", "default": 25 },
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Offset", "default": 0 },
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "title": "Include Unlinked",
+              "default": false
+            },
+            "name": "include_unlinked",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertWithIncidentLinkMetadataPaginatedResultsDto"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["incidents"],
+        "summary": "Add Alerts To Incident",
+        "description": "Add alerts to incident",
+        "operationId": "add_alerts_to_incident_incidents__incident_id__alerts_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Incident Id"
+            },
+            "name": "incident_id",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "title": "Is Created By Ai",
+              "default": false
+            },
+            "name": "is_created_by_ai",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": { "type": "string", "format": "uuid" },
+                "type": "array",
+                "title": "Alert Ids"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/AlertDto" },
+                  "type": "array",
+                  "title": "Response Add Alerts To Incident Incidents  Incident Id  Alerts Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["incidents"],
+        "summary": "Delete Alerts From Incident",
+        "description": "Delete alerts from incident",
+        "operationId": "delete_alerts_from_incident_incidents__incident_id__alerts_delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Incident Id"
+            },
+            "name": "incident_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": { "type": "string", "format": "uuid" },
+                "type": "array",
+                "title": "Alert Ids"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/AlertDto" },
+                  "type": "array",
+                  "title": "Response Delete Alerts From Incident Incidents  Incident Id  Alerts Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents/{incident_id}/future_incidents": {
+      "get": {
+        "tags": ["incidents"],
+        "summary": "Get Future Incidents For An Incident",
+        "description": "Get same incidents linked to this one",
+        "operationId": "get_future_incidents_for_an_incident_incidents__incident_id__future_incidents_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Incident Id" },
+            "name": "incident_id",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Limit", "default": 25 },
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Offset", "default": 0 },
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IncidentsPaginatedResultsDto"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents/{incident_id}/workflows": {
+      "get": {
+        "tags": ["incidents"],
+        "summary": "Get Incident Workflows",
+        "description": "Get incident workflows by incident id",
+        "operationId": "get_incident_workflows_incidents__incident_id__workflows_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Incident Id"
+            },
+            "name": "incident_id",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Limit", "default": 25 },
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Offset", "default": 0 },
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowExecutionsPaginatedResultsDto"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents/event/{provider_type}": {
+      "post": {
+        "tags": ["incidents"],
+        "summary": "Receive Event",
+        "description": "Receive an alert event from a provider",
+        "operationId": "receive_event_incidents_event__provider_type__post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Provider Type" },
+            "name": "provider_type",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Provider Id" },
+            "name": "provider_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": { "type": "string" },
+                  "type": "object",
+                  "title": "Response Receive Event Incidents Event  Provider Type  Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents/{incident_id}/status": {
+      "post": {
+        "tags": ["incidents"],
+        "summary": "Change Incident Status",
+        "description": "Change incident status",
+        "operationId": "change_incident_status_incidents__incident_id__status_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Incident Id"
+            },
+            "name": "incident_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IncidentStatusChangeDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/IncidentDto" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents/{incident_id}/comment": {
+      "post": {
+        "tags": ["incidents"],
+        "summary": "Add Comment",
+        "description": "Add incident audit activity",
+        "operationId": "add_comment_incidents__incident_id__comment_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Incident Id"
+            },
+            "name": "incident_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IncidentStatusChangeDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AlertAudit" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents/ai/suggest": {
+      "post": {
+        "tags": ["incidents"],
+        "summary": "Create With Ai",
+        "description": "Create incident with AI",
+        "operationId": "create_with_ai_incidents_ai_suggest_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": { "type": "string" },
+                "type": "array",
+                "title": "Alerts Fingerprints"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IncidentsClusteringSuggestion"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents/ai/{suggestion_id}/commit": {
+      "post": {
+        "tags": ["incidents"],
+        "summary": "Commit With Ai",
+        "description": "Commit incidents with AI and user feedback",
+        "operationId": "commit_with_ai_incidents_ai__suggestion_id__commit_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Suggestion Id"
+            },
+            "name": "suggestion_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": { "$ref": "#/components/schemas/IncidentCommit" },
+                "type": "array",
+                "title": "Incidents With Feedback"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/IncidentDto" },
+                  "type": "array",
+                  "title": "Response Commit With Ai Incidents Ai  Suggestion Id  Commit Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/incidents/{incident_id}/confirm": {
+      "post": {
+        "tags": ["incidents"],
+        "summary": "Confirm Incident",
+        "description": "Confirm predicted incident by id",
+        "operationId": "confirm_incident_incidents__incident_id__confirm_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Incident Id"
+            },
+            "name": "incident_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/IncidentDto" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/settings/webhook": {
+      "get": {
+        "tags": ["settings"],
+        "summary": "Webhook Settings",
+        "description": "Get details about the webhook endpoint (e.g. the API url and an API key)",
+        "operationId": "webhook_settings_settings_webhook_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/WebhookSettings" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/settings/smtp": {
+      "get": {
+        "tags": ["settings"],
+        "summary": "Get Smtp Settings",
+        "description": "Get SMTP settings",
+        "operationId": "get_smtp_settings_settings_smtp_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["settings"],
+        "summary": "Update Smtp Settings",
+        "description": "Install or update SMTP settings",
+        "operationId": "update_smtp_settings_settings_smtp_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SMTPSettings" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["settings"],
+        "summary": "Delete Smtp Settings",
+        "description": "Delete SMTP settings",
+        "operationId": "delete_smtp_settings_settings_smtp_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/settings/smtp/test": {
+      "post": {
+        "tags": ["settings"],
+        "summary": "Test Smtp Settings",
+        "description": "Test SMTP settings",
+        "operationId": "test_smtp_settings_settings_smtp_test_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SMTPSettings" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/settings/apikey": {
+      "put": {
+        "tags": ["settings"],
+        "summary": "Update Api Key",
+        "description": "Update API key secret",
+        "operationId": "update_api_key_settings_apikey_put",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["settings"],
+        "summary": "Create Key",
+        "description": "Create API key",
+        "operationId": "create_key_settings_apikey_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/settings/apikeys": {
+      "get": {
+        "tags": ["settings"],
+        "summary": "Get Keys",
+        "description": "Get API keys",
+        "operationId": "get_keys_settings_apikeys_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/settings/apikey/{keyId}": {
+      "delete": {
+        "tags": ["settings"],
+        "summary": "Delete Api Key",
+        "description": "Delete API key",
+        "operationId": "delete_api_key_settings_apikey__keyId__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Keyid" },
+            "name": "keyId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/settings/sso": {
+      "get": {
+        "tags": ["settings"],
+        "summary": "Get Sso Settings",
+        "operationId": "get_sso_settings_settings_sso_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/workflows": {
+      "get": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Get Workflows",
+        "description": "Get workflows",
+        "operationId": "get_workflows_workflows_get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": { "type": "boolean", "title": "Is V2", "default": false },
+            "name": "is_v2",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "items": { "$ref": "#/components/schemas/WorkflowDTO" },
+                      "type": "array"
+                    },
+                    { "items": { "type": "object" }, "type": "array" }
+                  ],
+                  "title": "Response Get Workflows Workflows Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Create Workflow",
+        "description": "Create or update a workflow",
+        "operationId": "create_workflow_workflows_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_workflow_workflows_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowCreateOrUpdateDTO"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/workflows/export": {
+      "get": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Export Workflows",
+        "description": "export all workflow Yamls",
+        "operationId": "export_workflows_workflows_export_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "type": "string" },
+                  "type": "array",
+                  "title": "Response Export Workflows Workflows Export Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/workflows/{workflow_id}/run": {
+      "post": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Run Workflow",
+        "description": "Run a workflow",
+        "operationId": "run_workflow_workflows__workflow_id__run_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Workflow Id" },
+            "name": "workflow_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object", "title": "Body" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Run Workflow Workflows  Workflow Id  Run Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/workflows/test": {
+      "post": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Run Workflow From Definition",
+        "description": "Test run a workflow from a definition",
+        "operationId": "run_workflow_from_definition_workflows_test_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_run_workflow_from_definition_workflows_test_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Run Workflow From Definition Workflows Test Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/workflows/json": {
+      "post": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Create Workflow From Body",
+        "description": "Create or update a workflow",
+        "operationId": "create_workflow_from_body_workflows_json_post",
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowCreateOrUpdateDTO"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/workflows/random-templates": {
+      "get": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Get Random Workflow Templates",
+        "description": "Get random workflow templates",
+        "operationId": "get_random_workflow_templates_workflows_random_templates_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "type": "object" },
+                  "type": "array",
+                  "title": "Response Get Random Workflow Templates Workflows Random Templates Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/workflows/{workflow_id}": {
+      "get": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Get Workflow By Id",
+        "description": "Get workflow by ID",
+        "operationId": "get_workflow_by_id_workflows__workflow_id__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Workflow Id" },
+            "name": "workflow_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "put": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Update Workflow By Id",
+        "description": "Update a workflow",
+        "operationId": "update_workflow_by_id_workflows__workflow_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Workflow Id" },
+            "name": "workflow_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowCreateOrUpdateDTO"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Delete Workflow By Id",
+        "description": "Delete workflow",
+        "operationId": "delete_workflow_by_id_workflows__workflow_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Workflow Id" },
+            "name": "workflow_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/workflows/{workflow_id}/raw": {
+      "get": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Get Raw Workflow By Id",
+        "description": "Get workflow executions by ID",
+        "operationId": "get_raw_workflow_by_id_workflows__workflow_id__raw_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Workflow Id" },
+            "name": "workflow_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "title": "Response Get Raw Workflow By Id Workflows  Workflow Id  Raw Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/workflows/executions": {
+      "get": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Get Workflow Executions By Alert Fingerprint",
+        "description": "Get workflow executions by alert fingerprint",
+        "operationId": "get_workflow_executions_by_alert_fingerprint_workflows_executions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/WorkflowToAlertExecutionDTO"
+                  },
+                  "type": "array",
+                  "title": "Response Get Workflow Executions By Alert Fingerprint Workflows Executions Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/workflows/{workflow_id}/runs": {
+      "get": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Get Workflow By Id",
+        "description": "Get workflow executions by ID",
+        "operationId": "get_workflow_by_id_workflows__workflow_id__runs_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Workflow Id" },
+            "name": "workflow_id",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Tab", "default": 1 },
+            "name": "tab",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Limit", "default": 25 },
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "title": "Offset", "default": 0 },
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": { "type": "string" },
+              "type": "array",
+              "title": "Status"
+            },
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": { "type": "string" },
+              "type": "array",
+              "title": "Trigger"
+            },
+            "name": "trigger",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Execution Id" },
+            "name": "execution_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowExecutionsPaginatedResultsDto"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/workflows/{workflow_id}/runs/{workflow_execution_id}": {
+      "get": {
+        "tags": ["workflows", "alerts"],
+        "summary": "Get Workflow Execution Status",
+        "description": "Get a workflow execution status",
+        "operationId": "get_workflow_execution_status_workflows__workflow_id__runs__workflow_execution_id__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Workflow Execution Id" },
+            "name": "workflow_execution_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowExecutionDTO"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/whoami": {
+      "get": {
+        "tags": ["whoami"],
+        "summary": "Get Tenant Id",
+        "description": "Get tenant id",
+        "operationId": "get_tenant_id_whoami_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Get Tenant Id Whoami Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/pusher/auth": {
+      "post": {
+        "tags": ["pusher"],
+        "summary": "Pusher Authentication",
+        "description": "Authenticate a user to a private channel\n\nArgs:\n    request (Request): The request object\n    tenant_id (str, optional): The tenant ID. Defaults to Depends(verify_bearer_token).\n    pusher_client (Pusher, optional): Pusher client. Defaults to Depends(get_pusher_client).\n\nRaises:\n    HTTPException: 403 if the user is not allowed to access the channel.\n\nReturns:\n    dict: The authentication response.",
+        "operationId": "pusher_authentication_pusher_auth_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_pusher_authentication_pusher_auth_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Pusher Authentication Pusher Auth Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/status": {
+      "get": {
+        "tags": ["status"],
+        "summary": "Status",
+        "description": "simple status endpoint",
+        "operationId": "status_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Status Status Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rules": {
+      "get": {
+        "tags": ["rules"],
+        "summary": "Get Rules",
+        "description": "Get Rules",
+        "operationId": "get_rules_rules_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["rules"],
+        "summary": "Create Rule",
+        "description": "Create Rule",
+        "operationId": "create_rule_rules_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/RuleCreateDto" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/rules/{rule_id}": {
+      "put": {
+        "tags": ["rules"],
+        "summary": "Update Rule",
+        "description": "Update Rule",
+        "operationId": "update_rule_rules__rule_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Rule Id" },
+            "name": "rule_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["rules"],
+        "summary": "Delete Rule",
+        "description": "Delete Rule",
+        "operationId": "delete_rule_rules__rule_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Rule Id" },
+            "name": "rule_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/preset": {
+      "get": {
+        "tags": ["preset"],
+        "summary": "Get Presets",
+        "description": "Get all presets for tenant",
+        "operationId": "get_presets_preset_get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Time Stamp" },
+            "name": "time_stamp",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/PresetDto" },
+                  "type": "array",
+                  "title": "Response Get Presets Preset Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["preset"],
+        "summary": "Create Preset",
+        "description": "Create a preset for tenant",
+        "operationId": "create_preset_preset_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrUpdatePresetDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PresetDto" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/preset/{uuid}": {
+      "put": {
+        "tags": ["preset"],
+        "summary": "Update Preset",
+        "description": "Update a preset for tenant",
+        "operationId": "update_preset_preset__uuid__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Uuid" },
+            "name": "uuid",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrUpdatePresetDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PresetDto" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["preset"],
+        "summary": "Delete Preset",
+        "description": "Delete a preset for tenant",
+        "operationId": "delete_preset_preset__uuid__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Uuid" },
+            "name": "uuid",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/preset/{preset_name}/alerts": {
+      "get": {
+        "tags": ["preset"],
+        "summary": "Get Preset Alerts",
+        "description": "Get the alerts of a preset",
+        "operationId": "get_preset_alerts_preset__preset_name__alerts_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Preset Name" },
+            "name": "preset_name",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {},
+                  "type": "array",
+                  "title": "Response Get Preset Alerts Preset  Preset Name  Alerts Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/preset/{preset_id}/tab": {
+      "post": {
+        "tags": ["preset"],
+        "summary": "Create Preset Tab",
+        "description": "Create a tab for a preset",
+        "operationId": "create_preset_tab_preset__preset_id__tab_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Preset Id" },
+            "name": "preset_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreatePresetTab" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/preset/{preset_id}/tab/{tab_id}": {
+      "delete": {
+        "tags": ["preset"],
+        "summary": "Delete Tab",
+        "description": "Delete a tab from a preset",
+        "operationId": "delete_tab_preset__preset_id__tab__tab_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Preset Id" },
+            "name": "preset_id",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Tab Id" },
+            "name": "tab_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/mapping": {
+      "get": {
+        "tags": ["enrichment", "mapping"],
+        "summary": "Get Rules",
+        "description": "Get all mapping rules",
+        "operationId": "get_rules_mapping_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/MappingRuleDtoOut" },
+                  "type": "array",
+                  "title": "Response Get Rules Mapping Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["enrichment", "mapping"],
+        "summary": "Create Rule",
+        "description": "Create a new mapping rule",
+        "operationId": "create_rule_mapping_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MappingRuleDtoIn" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MappingRule" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/mapping/{rule_id}": {
+      "put": {
+        "tags": ["enrichment", "mapping"],
+        "summary": "Update Rule",
+        "description": "Update an existing rule",
+        "operationId": "update_rule_mapping__rule_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "integer", "title": "Rule Id" },
+            "name": "rule_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MappingRuleDtoIn" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MappingRuleDtoOut" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["enrichment", "mapping"],
+        "summary": "Delete Rule",
+        "description": "Delete a mapping rule",
+        "operationId": "delete_rule_mapping__rule_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "integer", "title": "Rule Id" },
+            "name": "rule_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/auth/groups": {
+      "get": {
+        "tags": ["auth", "groups"],
+        "summary": "Get Groups",
+        "description": "Get all groups",
+        "operationId": "get_groups_auth_groups_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/Group" },
+                  "type": "array",
+                  "title": "Response Get Groups Auth Groups Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["auth", "groups"],
+        "summary": "Create Group",
+        "description": "Create a group",
+        "operationId": "create_group_auth_groups_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrUpdateGroupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/auth/groups/{group_name}": {
+      "put": {
+        "tags": ["auth", "groups"],
+        "summary": "Update Group",
+        "description": "Update a group",
+        "operationId": "update_group_auth_groups__group_name__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Group Name" },
+            "name": "group_name",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrUpdateGroupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["auth", "groups"],
+        "summary": "Delete Group",
+        "description": "Delete a group",
+        "operationId": "delete_group_auth_groups__group_name__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Group Name" },
+            "name": "group_name",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/auth/permissions": {
+      "get": {
+        "tags": ["auth", "permissions"],
+        "summary": "Get Permissions",
+        "description": "Get resources permissions",
+        "operationId": "get_permissions_auth_permissions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ResourcePermission"
+                  },
+                  "type": "array",
+                  "title": "Response Get Permissions Auth Permissions Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["auth", "permissions"],
+        "summary": "Create Permissions",
+        "description": "Create permissions for resources",
+        "operationId": "create_permissions_auth_permissions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": { "$ref": "#/components/schemas/ResourcePermission" },
+                "type": "array",
+                "title": "Resource Permissions",
+                "description": "List of resource permissions"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/auth/permissions/scopes": {
+      "get": {
+        "tags": ["auth", "permissions"],
+        "summary": "Get Scopes",
+        "description": "Get all resources types",
+        "operationId": "get_scopes_auth_permissions_scopes_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "type": "string" },
+                  "type": "array",
+                  "title": "Response Get Scopes Auth Permissions Scopes Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/auth/roles": {
+      "get": {
+        "tags": ["auth", "roles"],
+        "summary": "Get Roles",
+        "description": "Get roles",
+        "operationId": "get_roles_auth_roles_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/Role" },
+                  "type": "array",
+                  "title": "Response Get Roles Auth Roles Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["auth", "roles"],
+        "summary": "Create Role",
+        "description": "Create role",
+        "operationId": "create_role_auth_roles_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  { "$ref": "#/components/schemas/CreateOrUpdateRole" }
+                ],
+                "title": "Role",
+                "description": "Role"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/auth/roles/{role_id}": {
+      "put": {
+        "tags": ["auth", "roles"],
+        "summary": "Update Role",
+        "description": "Update role",
+        "operationId": "update_role_auth_roles__role_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Role Id" },
+            "name": "role_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  { "$ref": "#/components/schemas/CreateOrUpdateRole" }
+                ],
+                "title": "Role",
+                "description": "Role"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["auth", "roles"],
+        "summary": "Delete Role",
+        "description": "Delete role",
+        "operationId": "delete_role_auth_roles__role_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Role Id" },
+            "name": "role_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/auth/users": {
+      "get": {
+        "tags": ["auth", "users"],
+        "summary": "Get Users",
+        "description": "Get all users",
+        "operationId": "get_users_auth_users_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/User" },
+                  "type": "array",
+                  "title": "Response Get Users Auth Users Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["auth", "users"],
+        "summary": "Create User",
+        "description": "Create a user",
+        "operationId": "create_user_auth_users_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateUserRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/auth/users/{user_email}": {
+      "put": {
+        "tags": ["auth", "users"],
+        "summary": "Update User",
+        "description": "Update a user",
+        "operationId": "update_user_auth_users__user_email__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "User Email" },
+            "name": "user_email",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateUserRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["auth", "users"],
+        "summary": "Delete User",
+        "description": "Delete a user",
+        "operationId": "delete_user_auth_users__user_email__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "User Email" },
+            "name": "user_email",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/metrics": {
+      "get": {
+        "tags": ["metrics"],
+        "summary": "Get Metrics",
+        "description": "This endpoint is used by Prometheus to scrape such metrics from the application:\n- alerts_total {incident_name, incident_id} - The total number of alerts per incident.\n- open_incidents_total - The total number of open incidents.\n- workflows_executions_total {status} - The total number of workflow executions.\n\nPlease note that those metrics are per-tenant and are not designed to be used for the monitoring of the application itself.\n\nExample prometheus configuration:\n```\nscrape_configs:\n- job_name: \"scrape_keep\"\n  scrape_interval: 5m  # It's important to scrape not too often to avoid rate limiting.\n  static_configs:\n  - targets: [\"https://api.keephq.dev\"]  # Or your own domain.\n  authorization:\n    type: Bearer\n    credentials: \"{Your API Key}\"\n\n  # Optional, you can add labels to exported incidents. \n  # Label values will be equal to the last incident's alert payload value matching the label.\n  # Attention! Don't add \"flaky\" labels which could change from alert to alert within the same incident.\n  # Good labels: ['labels.department', 'labels.team'], bad labels: ['labels.severity', 'labels.pod_id']\n  # Check Keep -> Feed -> \"extraPayload\" column, it will help in writing labels.\n\n  params:\n    labels: ['labels.service', 'labels.queue']\n  # Will resuld as: \"labels_service\" and \"labels_queue\".\n```",
+        "operationId": "get_metrics_metrics_get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "items": { "type": "string" },
+              "type": "array",
+              "title": "Labels"
+            },
+            "name": "labels",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/extraction": {
+      "get": {
+        "tags": ["enrichment", "extraction"],
+        "summary": "Get Extraction Rules",
+        "description": "Get all extraction rules",
+        "operationId": "get_extraction_rules_extraction_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ExtractionRuleDtoOut"
+                  },
+                  "type": "array",
+                  "title": "Response Get Extraction Rules Extraction Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["enrichment", "extraction"],
+        "summary": "Create Extraction Rule",
+        "description": "Create a new extraction rule",
+        "operationId": "create_extraction_rule_extraction_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ExtractionRuleDtoBase" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtractionRuleDtoOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/extraction/{rule_id}": {
+      "put": {
+        "tags": ["enrichment", "extraction"],
+        "summary": "Update Extraction Rule",
+        "description": "Update an existing extraction rule",
+        "operationId": "update_extraction_rule_extraction__rule_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "integer", "title": "Rule Id" },
+            "name": "rule_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ExtractionRuleDtoBase" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtractionRuleDtoOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["enrichment", "extraction"],
+        "summary": "Delete Extraction Rule",
+        "description": "Delete an extraction rule",
+        "operationId": "delete_extraction_rule_extraction__rule_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "integer", "title": "Rule Id" },
+            "name": "rule_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/dashboard": {
+      "get": {
+        "tags": ["dashboard"],
+        "summary": "Read Dashboards",
+        "operationId": "read_dashboards_dashboard_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DashboardResponseDTO"
+                  },
+                  "type": "array",
+                  "title": "Response Read Dashboards Dashboard Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["dashboard"],
+        "summary": "Create Dashboard",
+        "operationId": "create_dashboard_dashboard_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/DashboardCreateDTO" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardResponseDTO"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/dashboard/{dashboard_id}": {
+      "put": {
+        "tags": ["dashboard"],
+        "summary": "Update Dashboard",
+        "operationId": "update_dashboard_dashboard__dashboard_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Dashboard Id" },
+            "name": "dashboard_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/DashboardUpdateDTO" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardResponseDTO"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["dashboard"],
+        "summary": "Delete Dashboard",
+        "operationId": "delete_dashboard_dashboard__dashboard_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Dashboard Id" },
+            "name": "dashboard_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/dashboard/metric-widgets": {
+      "get": {
+        "tags": ["dashboard"],
+        "summary": "Get Metric Widgets",
+        "operationId": "get_metric_widgets_dashboard_metric_widgets_get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": { "type": "boolean", "title": "Mttr", "default": true },
+            "name": "mttr",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "boolean", "title": "Apd", "default": true },
+            "name": "apd",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "boolean", "title": "Ipd", "default": true },
+            "name": "ipd",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "boolean", "title": "Wpd", "default": true },
+            "name": "wpd",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Time Stamp" },
+            "name": "time_stamp",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/tags": {
+      "get": {
+        "tags": ["tags"],
+        "summary": "Get Tags",
+        "description": "get tags",
+        "operationId": "get_tags_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "type": "object" },
+                  "type": "array",
+                  "title": "Response Get Tags Tags Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/maintenance": {
+      "get": {
+        "tags": ["maintenance"],
+        "summary": "Get Maintenance Rules",
+        "description": "Get all maintenance rules",
+        "operationId": "get_maintenance_rules_maintenance_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MaintenanceRuleRead"
+                  },
+                  "type": "array",
+                  "title": "Response Get Maintenance Rules Maintenance Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["maintenance"],
+        "summary": "Create Maintenance Rule",
+        "description": "Create a new maintenance rule",
+        "operationId": "create_maintenance_rule_maintenance_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MaintenanceRuleCreate" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MaintenanceRuleRead" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/maintenance/{rule_id}": {
+      "put": {
+        "tags": ["maintenance"],
+        "summary": "Update Maintenance Rule",
+        "description": "Update an existing maintenance rule",
+        "operationId": "update_maintenance_rule_maintenance__rule_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "integer", "title": "Rule Id" },
+            "name": "rule_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MaintenanceRuleCreate" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MaintenanceRuleRead" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["maintenance"],
+        "summary": "Delete Maintenance Rule",
+        "description": "Delete a maintenance rule",
+        "operationId": "delete_maintenance_rule_maintenance__rule_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "integer", "title": "Rule Id" },
+            "name": "rule_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/topology": {
+      "get": {
+        "tags": ["topology"],
+        "summary": "Get Topology Data",
+        "description": "Get all topology data",
+        "operationId": "get_topology_data_topology_get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Provider Ids" },
+            "name": "provider_ids",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Services" },
+            "name": "services",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "title": "Environment" },
+            "name": "environment",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "title": "Include Empty Deps",
+              "default": true
+            },
+            "name": "include_empty_deps",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TopologyServiceDtoOut"
+                  },
+                  "type": "array",
+                  "title": "Response Get Topology Data Topology Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/topology/applications": {
+      "get": {
+        "tags": ["topology"],
+        "summary": "Get Applications",
+        "description": "Get all applications",
+        "operationId": "get_applications_topology_applications_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TopologyApplicationDtoOut"
+                  },
+                  "type": "array",
+                  "title": "Response Get Applications Topology Applications Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["topology"],
+        "summary": "Create Application",
+        "description": "Create a new application",
+        "operationId": "create_application_topology_applications_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TopologyApplicationDtoIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopologyApplicationDtoOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/topology/applications/{application_id}": {
+      "put": {
+        "tags": ["topology"],
+        "summary": "Update Application",
+        "description": "Update an application",
+        "operationId": "update_application_topology_applications__application_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Application Id"
+            },
+            "name": "application_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TopologyApplicationDtoIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopologyApplicationDtoOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["topology"],
+        "summary": "Delete Application",
+        "description": "Delete an application",
+        "operationId": "delete_application_topology_applications__application_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Application Id"
+            },
+            "name": "application_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/deduplications": {
+      "get": {
+        "tags": ["deduplications"],
+        "summary": "Get Deduplications",
+        "description": "Get Deduplications",
+        "operationId": "get_deduplications_deduplications_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "post": {
+        "tags": ["deduplications"],
+        "summary": "Create Deduplication Rule",
+        "description": "Create Deduplication Rule",
+        "operationId": "create_deduplication_rule_deduplications_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeduplicationRuleRequestDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/deduplications/fields": {
+      "get": {
+        "tags": ["deduplications"],
+        "summary": "Get Deduplication Fields",
+        "description": "Get Optional Fields For Deduplications",
+        "operationId": "get_deduplication_fields_deduplications_fields_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": { "type": "string" },
+                    "type": "array"
+                  },
+                  "type": "object",
+                  "title": "Response Get Deduplication Fields Deduplications Fields Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    },
+    "/deduplications/{rule_id}": {
+      "put": {
+        "tags": ["deduplications"],
+        "summary": "Update Deduplication Rule",
+        "description": "Update Deduplication Rule",
+        "operationId": "update_deduplication_rule_deduplications__rule_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Rule Id" },
+            "name": "rule_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeduplicationRuleRequestDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      },
+      "delete": {
+        "tags": ["deduplications"],
+        "summary": "Delete Deduplication Rule",
+        "description": "Delete Deduplication Rule",
+        "operationId": "delete_deduplication_rule_deduplications__rule_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "title": "Rule Id" },
+            "name": "rule_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [
+          { "API Key": [] },
+          { "HTTPBasic": [] },
+          { "OAuth2PasswordBearer": [] }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AlertActionType": {
+        "enum": [
+          "alert was triggered",
+          "alert acknowledged",
+          "alert automatically resolved",
+          "alert automatically resolved by API",
+          "alert manually resolved",
+          "alert status manually changed",
+          "alert status changed by API",
+          "alert status undone",
+          "alert enriched by workflow",
+          "alert enriched by mapping rule",
+          "alert was deduplicated",
+          "alert was assigned with ticket",
+          "alert was unassigned from ticket",
+          "alert ticket was updated",
+          "alert enrichments disposed",
+          "alert deleted",
+          "alert enriched",
+          "alert un-enriched",
+          "a comment was added to the alert",
+          "a comment was removed from the alert",
+          "Alert is in maintenance window",
+          "A comment was added to the incident"
+        ],
+        "title": "AlertActionType",
+        "description": "An enumeration."
+      },
+      "AlertAudit": {
+        "properties": {
+          "id": { "type": "string", "format": "uuid", "title": "Id" },
+          "fingerprint": { "type": "string", "title": "Fingerprint" },
+          "tenant_id": { "type": "string", "title": "Tenant Id" },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "user_id": { "type": "string", "title": "User Id" },
+          "action": { "type": "string", "title": "Action" },
+          "description": { "type": "string", "title": "Description" }
+        },
+        "type": "object",
+        "required": [
+          "fingerprint",
+          "tenant_id",
+          "user_id",
+          "action",
+          "description"
+        ],
+        "title": "AlertAudit"
+      },
+      "AlertAuditDto": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "fingerprint": { "type": "string", "title": "Fingerprint" },
+          "action": { "$ref": "#/components/schemas/AlertActionType" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "description": { "type": "string", "title": "Description" }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "timestamp",
+          "fingerprint",
+          "action",
+          "user_id",
+          "description"
+        ],
+        "title": "AlertAuditDto"
+      },
+      "AlertDto": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "status": { "$ref": "#/components/schemas/AlertStatus" },
+          "severity": { "$ref": "#/components/schemas/AlertSeverity" },
+          "lastReceived": { "type": "string", "title": "Lastreceived" },
+          "firingStartTime": { "type": "string", "title": "Firingstarttime" },
+          "environment": {
+            "type": "string",
+            "title": "Environment",
+            "default": "undefined"
+          },
+          "isFullDuplicate": {
+            "type": "boolean",
+            "title": "Isfullduplicate",
+            "default": false
+          },
+          "isPartialDuplicate": {
+            "type": "boolean",
+            "title": "Ispartialduplicate",
+            "default": false
+          },
+          "duplicateReason": { "type": "string", "title": "Duplicatereason" },
+          "service": { "type": "string", "title": "Service" },
+          "source": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Source",
+            "default": []
+          },
+          "apiKeyRef": { "type": "string", "title": "Apikeyref" },
+          "message": { "type": "string", "title": "Message" },
+          "description": { "type": "string", "title": "Description" },
+          "pushed": { "type": "boolean", "title": "Pushed", "default": false },
+          "event_id": { "type": "string", "title": "Event Id" },
+          "url": {
+            "type": "string",
+            "maxLength": 65536,
+            "minLength": 1,
+            "format": "uri",
+            "title": "Url"
+          },
+          "labels": { "type": "object", "title": "Labels", "default": {} },
+          "fingerprint": { "type": "string", "title": "Fingerprint" },
+          "deleted": {
+            "type": "boolean",
+            "title": "Deleted",
+            "default": false
+          },
+          "dismissUntil": { "type": "string", "title": "Dismissuntil" },
+          "dismissed": {
+            "type": "boolean",
+            "title": "Dismissed",
+            "default": false
+          },
+          "assignee": { "type": "string", "title": "Assignee" },
+          "providerId": { "type": "string", "title": "Providerid" },
+          "providerType": { "type": "string", "title": "Providertype" },
+          "note": { "type": "string", "title": "Note" },
+          "startedAt": { "type": "string", "title": "Startedat" },
+          "isNoisy": {
+            "type": "boolean",
+            "title": "Isnoisy",
+            "default": false
+          },
+          "enriched_fields": {
+            "items": {},
+            "type": "array",
+            "title": "Enriched Fields",
+            "default": []
+          },
+          "incident": { "type": "string", "title": "Incident" }
+        },
+        "type": "object",
+        "required": ["name", "status", "severity", "lastReceived"],
+        "title": "AlertDto",
+        "example": {
+          "id": "1234",
+          "name": "Pod 'api-service-production' lacks memory",
+          "status": "firing",
+          "lastReceived": "2021-01-01T00:00:00.000Z",
+          "environment": "production",
+          "service": "backend",
+          "source": ["prometheus"],
+          "message": "The pod 'api-service-production' lacks memory causing high error rate",
+          "description": "Due to the lack of memory, the pod 'api-service-production' is experiencing high error rate",
+          "severity": "critical",
+          "pushed": true,
+          "url": "https://www.keephq.dev?alertId=1234",
+          "labels": {
+            "pod": "api-service-production",
+            "region": "us-east-1",
+            "cpu": "88",
+            "memory": "100Mi"
+          },
+          "ticket_url": "https://www.keephq.dev?enrichedTicketId=456",
+          "fingerprint": "1234"
+        }
+      },
+      "AlertSeverity": {
+        "enum": ["critical", "high", "warning", "info", "low"],
+        "title": "AlertSeverity",
+        "description": "An enumeration."
+      },
+      "AlertStatus": {
+        "enum": ["firing", "resolved", "acknowledged", "suppressed", "pending"],
+        "title": "AlertStatus",
+        "description": "An enumeration."
+      },
+      "AlertWithIncidentLinkMetadataDto": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "status": { "$ref": "#/components/schemas/AlertStatus" },
+          "severity": { "$ref": "#/components/schemas/AlertSeverity" },
+          "lastReceived": { "type": "string", "title": "Lastreceived" },
+          "firingStartTime": { "type": "string", "title": "Firingstarttime" },
+          "environment": {
+            "type": "string",
+            "title": "Environment",
+            "default": "undefined"
+          },
+          "isFullDuplicate": {
+            "type": "boolean",
+            "title": "Isfullduplicate",
+            "default": false
+          },
+          "isPartialDuplicate": {
+            "type": "boolean",
+            "title": "Ispartialduplicate",
+            "default": false
+          },
+          "duplicateReason": { "type": "string", "title": "Duplicatereason" },
+          "service": { "type": "string", "title": "Service" },
+          "source": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Source",
+            "default": []
+          },
+          "apiKeyRef": { "type": "string", "title": "Apikeyref" },
+          "message": { "type": "string", "title": "Message" },
+          "description": { "type": "string", "title": "Description" },
+          "pushed": { "type": "boolean", "title": "Pushed", "default": false },
+          "event_id": { "type": "string", "title": "Event Id" },
+          "url": {
+            "type": "string",
+            "maxLength": 65536,
+            "minLength": 1,
+            "format": "uri",
+            "title": "Url"
+          },
+          "labels": { "type": "object", "title": "Labels", "default": {} },
+          "fingerprint": { "type": "string", "title": "Fingerprint" },
+          "deleted": {
+            "type": "boolean",
+            "title": "Deleted",
+            "default": false
+          },
+          "dismissUntil": { "type": "string", "title": "Dismissuntil" },
+          "dismissed": {
+            "type": "boolean",
+            "title": "Dismissed",
+            "default": false
+          },
+          "assignee": { "type": "string", "title": "Assignee" },
+          "providerId": { "type": "string", "title": "Providerid" },
+          "providerType": { "type": "string", "title": "Providertype" },
+          "note": { "type": "string", "title": "Note" },
+          "startedAt": { "type": "string", "title": "Startedat" },
+          "isNoisy": {
+            "type": "boolean",
+            "title": "Isnoisy",
+            "default": false
+          },
+          "enriched_fields": {
+            "items": {},
+            "type": "array",
+            "title": "Enriched Fields",
+            "default": []
+          },
+          "incident": { "type": "string", "title": "Incident" },
+          "is_created_by_ai": {
+            "type": "boolean",
+            "title": "Is Created By Ai",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": ["name", "status", "severity", "lastReceived"],
+        "title": "AlertWithIncidentLinkMetadataDto",
+        "example": {
+          "id": "1234",
+          "name": "Pod 'api-service-production' lacks memory",
+          "status": "firing",
+          "lastReceived": "2021-01-01T00:00:00.000Z",
+          "environment": "production",
+          "service": "backend",
+          "source": ["prometheus"],
+          "message": "The pod 'api-service-production' lacks memory causing high error rate",
+          "description": "Due to the lack of memory, the pod 'api-service-production' is experiencing high error rate",
+          "severity": "critical",
+          "pushed": true,
+          "url": "https://www.keephq.dev?alertId=1234",
+          "labels": {
+            "pod": "api-service-production",
+            "region": "us-east-1",
+            "cpu": "88",
+            "memory": "100Mi"
+          },
+          "ticket_url": "https://www.keephq.dev?enrichedTicketId=456",
+          "fingerprint": "1234"
+        }
+      },
+      "AlertWithIncidentLinkMetadataPaginatedResultsDto": {
+        "properties": {
+          "limit": { "type": "integer", "title": "Limit", "default": 25 },
+          "offset": { "type": "integer", "title": "Offset", "default": 0 },
+          "count": { "type": "integer", "title": "Count" },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AlertWithIncidentLinkMetadataDto"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": ["count", "items"],
+        "title": "AlertWithIncidentLinkMetadataPaginatedResultsDto"
+      },
+      "Body_create_actions_actions_post": {
+        "properties": {
+          "file": { "type": "string", "format": "binary", "title": "File" }
+        },
+        "type": "object",
+        "title": "Body_create_actions_actions_post"
+      },
+      "Body_create_workflow_workflows_post": {
+        "properties": {
+          "file": { "type": "string", "format": "binary", "title": "File" }
+        },
+        "type": "object",
+        "required": ["file"],
+        "title": "Body_create_workflow_workflows_post"
+      },
+      "Body_pusher_authentication_pusher_auth_post": {
+        "properties": {
+          "channel_name": { "title": "Channel Name" },
+          "socket_id": { "title": "Socket Id" }
+        },
+        "type": "object",
+        "required": ["channel_name", "socket_id"],
+        "title": "Body_pusher_authentication_pusher_auth_post"
+      },
+      "Body_put_action_actions__action_id__put": {
+        "properties": {
+          "file": { "type": "string", "format": "binary", "title": "File" }
+        },
+        "type": "object",
+        "required": ["file"],
+        "title": "Body_put_action_actions__action_id__put"
+      },
+      "Body_run_workflow_from_definition_workflows_test_post": {
+        "properties": {
+          "file": { "type": "string", "format": "binary", "title": "File" }
+        },
+        "type": "object",
+        "title": "Body_run_workflow_from_definition_workflows_test_post"
+      },
+      "CreateOrUpdateGroupRequest": {
+        "properties": {
+          "name": { "type": "string", "title": "Name" },
+          "roles": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Roles"
+          },
+          "members": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Members"
+          }
+        },
+        "type": "object",
+        "required": ["name", "roles", "members"],
+        "title": "CreateOrUpdateGroupRequest"
+      },
+      "CreateOrUpdatePresetDto": {
+        "properties": {
+          "name": { "type": "string", "title": "Name" },
+          "options": {
+            "items": { "$ref": "#/components/schemas/PresetOption" },
+            "type": "array",
+            "title": "Options"
+          },
+          "is_private": {
+            "type": "boolean",
+            "title": "Is Private",
+            "default": false
+          },
+          "is_noisy": {
+            "type": "boolean",
+            "title": "Is Noisy",
+            "default": false
+          },
+          "tags": {
+            "items": { "$ref": "#/components/schemas/TagDto" },
+            "type": "array",
+            "title": "Tags",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": ["options"],
+        "title": "CreateOrUpdatePresetDto"
+      },
+      "CreateOrUpdateRole": {
+        "properties": {
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "scopes": {
+            "items": { "type": "string" },
+            "type": "array",
+            "uniqueItems": true,
+            "title": "Scopes"
+          }
+        },
+        "type": "object",
+        "title": "CreateOrUpdateRole"
+      },
+      "CreatePresetTab": {
+        "properties": {
+          "name": { "type": "string", "title": "Name" },
+          "filter": { "type": "string", "title": "Filter" }
+        },
+        "type": "object",
+        "required": ["name", "filter"],
+        "title": "CreatePresetTab"
+      },
+      "CreateUserRequest": {
+        "properties": {
+          "username": { "type": "string", "title": "Username" },
+          "name": { "type": "string", "title": "Name" },
+          "password": { "type": "string", "title": "Password" },
+          "role": { "type": "string", "title": "Role" },
+          "groups": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Groups"
+          }
+        },
+        "type": "object",
+        "required": ["username"],
+        "title": "CreateUserRequest"
+      },
+      "DashboardCreateDTO": {
+        "properties": {
+          "dashboard_name": { "type": "string", "title": "Dashboard Name" },
+          "dashboard_config": { "type": "object", "title": "Dashboard Config" }
+        },
+        "type": "object",
+        "required": ["dashboard_name", "dashboard_config"],
+        "title": "DashboardCreateDTO"
+      },
+      "DashboardResponseDTO": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "dashboard_name": { "type": "string", "title": "Dashboard Name" },
+          "dashboard_config": { "type": "object", "title": "Dashboard Config" },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "dashboard_name",
+          "dashboard_config",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "DashboardResponseDTO"
+      },
+      "DashboardUpdateDTO": {
+        "properties": {
+          "dashboard_config": { "type": "object", "title": "Dashboard Config" },
+          "dashboard_name": { "type": "string", "title": "Dashboard Name" }
+        },
+        "type": "object",
+        "title": "DashboardUpdateDTO"
+      },
+      "DeduplicationRuleRequestDto": {
+        "properties": {
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "provider_type": { "type": "string", "title": "Provider Type" },
+          "provider_id": { "type": "string", "title": "Provider Id" },
+          "fingerprint_fields": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Fingerprint Fields"
+          },
+          "full_deduplication": {
+            "type": "boolean",
+            "title": "Full Deduplication",
+            "default": false
+          },
+          "ignore_fields": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Ignore Fields"
+          }
+        },
+        "type": "object",
+        "required": ["name", "provider_type", "fingerprint_fields"],
+        "title": "DeduplicationRuleRequestDto"
+      },
+      "DeleteRequestBody": {
+        "properties": {
+          "fingerprint": { "type": "string", "title": "Fingerprint" },
+          "lastReceived": { "type": "string", "title": "Lastreceived" },
+          "restore": { "type": "boolean", "title": "Restore", "default": false }
+        },
+        "type": "object",
+        "required": ["fingerprint"],
+        "title": "DeleteRequestBody"
+      },
+      "EnrichAlertRequestBody": {
+        "properties": {
+          "enrichments": {
+            "additionalProperties": { "type": "string" },
+            "type": "object",
+            "title": "Enrichments"
+          },
+          "fingerprint": { "type": "string", "title": "Fingerprint" }
+        },
+        "type": "object",
+        "required": ["enrichments", "fingerprint"],
+        "title": "EnrichAlertRequestBody"
+      },
+      "ExtractionRuleDtoBase": {
+        "properties": {
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "priority": { "type": "integer", "title": "Priority", "default": 0 },
+          "attribute": { "type": "string", "title": "Attribute" },
+          "condition": { "type": "string", "title": "Condition" },
+          "disabled": {
+            "type": "boolean",
+            "title": "Disabled",
+            "default": false
+          },
+          "regex": { "type": "string", "title": "Regex" },
+          "pre": { "type": "boolean", "title": "Pre", "default": false }
+        },
+        "type": "object",
+        "required": ["name", "regex"],
+        "title": "ExtractionRuleDtoBase"
+      },
+      "ExtractionRuleDtoOut": {
+        "properties": {
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "priority": { "type": "integer", "title": "Priority", "default": 0 },
+          "attribute": { "type": "string", "title": "Attribute" },
+          "condition": { "type": "string", "title": "Condition" },
+          "disabled": {
+            "type": "boolean",
+            "title": "Disabled",
+            "default": false
+          },
+          "regex": { "type": "string", "title": "Regex" },
+          "pre": { "type": "boolean", "title": "Pre", "default": false },
+          "id": { "type": "integer", "title": "Id" },
+          "created_by": { "type": "string", "title": "Created By" },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_by": { "type": "string", "title": "Updated By" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": ["name", "regex", "id", "created_at"],
+        "title": "ExtractionRuleDtoOut"
+      },
+      "Group": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "roles": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Roles",
+            "default": []
+          },
+          "members": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Members",
+            "default": []
+          },
+          "memberCount": {
+            "type": "integer",
+            "title": "Membercount",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": ["id", "name"],
+        "title": "Group"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": { "$ref": "#/components/schemas/ValidationError" },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "IncidentCommit": {
+        "properties": {
+          "accepted": { "type": "boolean", "title": "Accepted" },
+          "original_suggestion": {
+            "type": "object",
+            "title": "Original Suggestion"
+          },
+          "changes": { "type": "object", "title": "Changes" },
+          "incident": { "$ref": "#/components/schemas/IncidentDto" }
+        },
+        "type": "object",
+        "required": ["accepted", "original_suggestion", "incident"],
+        "title": "IncidentCommit"
+      },
+      "IncidentDto": {
+        "properties": {
+          "user_generated_name": {
+            "type": "string",
+            "title": "User Generated Name"
+          },
+          "assignee": { "type": "string", "title": "Assignee" },
+          "user_summary": { "type": "string", "title": "User Summary" },
+          "same_incident_in_the_past_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Same Incident In The Past Id"
+          },
+          "id": { "type": "string", "format": "uuid", "title": "Id" },
+          "start_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start Time"
+          },
+          "last_seen_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Seen Time"
+          },
+          "end_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "End Time"
+          },
+          "creation_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Creation Time"
+          },
+          "alerts_count": { "type": "integer", "title": "Alerts Count" },
+          "alert_sources": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Alert Sources"
+          },
+          "severity": { "$ref": "#/components/schemas/IncidentSeverity" },
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/IncidentStatus" }],
+            "default": "firing"
+          },
+          "services": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Services"
+          },
+          "is_predicted": { "type": "boolean", "title": "Is Predicted" },
+          "is_confirmed": { "type": "boolean", "title": "Is Confirmed" },
+          "generated_summary": {
+            "type": "string",
+            "title": "Generated Summary"
+          },
+          "ai_generated_name": {
+            "type": "string",
+            "title": "Ai Generated Name"
+          },
+          "rule_fingerprint": { "type": "string", "title": "Rule Fingerprint" },
+          "fingerprint": { "type": "string", "title": "Fingerprint" },
+          "merged_into_incident_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Merged Into Incident Id"
+          },
+          "merged_by": { "type": "string", "title": "Merged By" },
+          "merged_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Merged At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "alerts_count",
+          "alert_sources",
+          "severity",
+          "services",
+          "is_predicted",
+          "is_confirmed"
+        ],
+        "title": "IncidentDto",
+        "example": {
+          "id": "c2509cb3-6168-4347-b83b-a41da9df2d5b",
+          "name": "Incident name",
+          "user_summary": "Keep: Incident description",
+          "status": "firing"
+        }
+      },
+      "IncidentDtoIn": {
+        "properties": {
+          "user_generated_name": {
+            "type": "string",
+            "title": "User Generated Name"
+          },
+          "assignee": { "type": "string", "title": "Assignee" },
+          "user_summary": { "type": "string", "title": "User Summary" },
+          "same_incident_in_the_past_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Same Incident In The Past Id"
+          }
+        },
+        "type": "object",
+        "title": "IncidentDtoIn",
+        "example": {
+          "id": "c2509cb3-6168-4347-b83b-a41da9df2d5b",
+          "name": "Incident name",
+          "user_summary": "Keep: Incident description",
+          "status": "firing"
+        }
+      },
+      "IncidentListFilterParamsDto": {
+        "properties": {
+          "statuses": {
+            "items": { "$ref": "#/components/schemas/IncidentStatus" },
+            "type": "array",
+            "default": ["firing", "resolved", "acknowledged", "merged"]
+          },
+          "severities": {
+            "items": { "$ref": "#/components/schemas/IncidentSeverity" },
+            "type": "array",
+            "default": ["critical", "high", "warning", "info", "low"]
+          },
+          "assignees": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Assignees"
+          },
+          "services": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Services"
+          },
+          "sources": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Sources"
+          }
+        },
+        "type": "object",
+        "required": ["assignees", "services", "sources"],
+        "title": "IncidentListFilterParamsDto"
+      },
+      "IncidentSeverity": {
+        "enum": ["critical", "high", "warning", "info", "low"],
+        "title": "IncidentSeverity",
+        "description": "An enumeration."
+      },
+      "IncidentSorting": {
+        "enum": [
+          "creation_time",
+          "start_time",
+          "last_seen_time",
+          "severity",
+          "status",
+          "alerts_count",
+          "-creation_time",
+          "-start_time",
+          "-last_seen_time",
+          "-severity",
+          "-status",
+          "-alerts_count"
+        ],
+        "title": "IncidentSorting",
+        "description": "An enumeration."
+      },
+      "IncidentStatus": {
+        "enum": ["firing", "resolved", "acknowledged", "merged"],
+        "title": "IncidentStatus",
+        "description": "An enumeration."
+      },
+      "IncidentStatusChangeDto": {
+        "properties": {
+          "status": { "$ref": "#/components/schemas/IncidentStatus" },
+          "comment": { "type": "string", "title": "Comment" }
+        },
+        "type": "object",
+        "required": ["status"],
+        "title": "IncidentStatusChangeDto"
+      },
+      "IncidentsClusteringSuggestion": {
+        "properties": {
+          "incident_suggestion": {
+            "items": { "$ref": "#/components/schemas/IncidentDto" },
+            "type": "array",
+            "title": "Incident Suggestion"
+          },
+          "suggestion_id": { "type": "string", "title": "Suggestion Id" }
+        },
+        "type": "object",
+        "required": ["incident_suggestion", "suggestion_id"],
+        "title": "IncidentsClusteringSuggestion"
+      },
+      "IncidentsPaginatedResultsDto": {
+        "properties": {
+          "limit": { "type": "integer", "title": "Limit", "default": 25 },
+          "offset": { "type": "integer", "title": "Offset", "default": 0 },
+          "count": { "type": "integer", "title": "Count" },
+          "items": {
+            "items": { "$ref": "#/components/schemas/IncidentDto" },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": ["count", "items"],
+        "title": "IncidentsPaginatedResultsDto"
+      },
+      "MaintenanceRuleCreate": {
+        "properties": {
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "cel_query": { "type": "string", "title": "Cel Query" },
+          "start_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start Time"
+          },
+          "duration_seconds": {
+            "type": "integer",
+            "title": "Duration Seconds"
+          },
+          "suppress": {
+            "type": "boolean",
+            "title": "Suppress",
+            "default": false
+          },
+          "enabled": { "type": "boolean", "title": "Enabled", "default": true }
+        },
+        "type": "object",
+        "required": ["name", "cel_query", "start_time"],
+        "title": "MaintenanceRuleCreate"
+      },
+      "MaintenanceRuleRead": {
+        "properties": {
+          "id": { "type": "integer", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "created_by": { "type": "string", "title": "Created By" },
+          "cel_query": { "type": "string", "title": "Cel Query" },
+          "start_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start Time"
+          },
+          "end_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "End Time"
+          },
+          "duration_seconds": {
+            "type": "integer",
+            "title": "Duration Seconds"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "suppress": {
+            "type": "boolean",
+            "title": "Suppress",
+            "default": false
+          },
+          "enabled": { "type": "boolean", "title": "Enabled", "default": true }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "created_by",
+          "cel_query",
+          "start_time",
+          "end_time"
+        ],
+        "title": "MaintenanceRuleRead"
+      },
+      "MappingRule": {
+        "properties": {
+          "id": { "type": "integer", "title": "Id" },
+          "tenant_id": { "type": "string", "title": "Tenant Id" },
+          "priority": { "type": "integer", "title": "Priority", "default": 0 },
+          "name": { "type": "string", "maxLength": 255, "title": "Name" },
+          "description": {
+            "type": "string",
+            "maxLength": 2048,
+            "title": "Description"
+          },
+          "file_name": {
+            "type": "string",
+            "maxLength": 255,
+            "title": "File Name"
+          },
+          "created_by": {
+            "type": "string",
+            "maxLength": 255,
+            "title": "Created By"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "disabled": {
+            "type": "boolean",
+            "title": "Disabled",
+            "default": false
+          },
+          "override": {
+            "type": "boolean",
+            "title": "Override",
+            "default": true
+          },
+          "condition": {
+            "type": "string",
+            "maxLength": 2000,
+            "title": "Condition"
+          },
+          "type": { "type": "string", "maxLength": 255, "title": "Type" },
+          "matchers": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Matchers"
+          },
+          "rows": {
+            "items": { "type": "object" },
+            "type": "array",
+            "title": "Rows"
+          },
+          "updated_by": {
+            "type": "string",
+            "maxLength": 255,
+            "title": "Updated By"
+          },
+          "last_updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Updated At"
+          }
+        },
+        "type": "object",
+        "required": ["tenant_id", "name", "type", "matchers"],
+        "title": "MappingRule"
+      },
+      "MappingRuleDtoIn": {
+        "properties": {
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "file_name": { "type": "string", "title": "File Name" },
+          "priority": { "type": "integer", "title": "Priority", "default": 0 },
+          "matchers": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Matchers"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["csv", "topology"],
+            "title": "Type",
+            "default": "csv"
+          },
+          "rows": {
+            "items": { "type": "object" },
+            "type": "array",
+            "title": "Rows"
+          }
+        },
+        "type": "object",
+        "required": ["name", "matchers"],
+        "title": "MappingRuleDtoIn"
+      },
+      "MappingRuleDtoOut": {
+        "properties": {
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "file_name": { "type": "string", "title": "File Name" },
+          "priority": { "type": "integer", "title": "Priority", "default": 0 },
+          "matchers": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Matchers"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["csv", "topology"],
+            "title": "Type",
+            "default": "csv"
+          },
+          "id": { "type": "integer", "title": "Id" },
+          "created_by": { "type": "string", "title": "Created By" },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "attributes": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Attributes",
+            "default": []
+          },
+          "updated_by": { "type": "string", "title": "Updated By" },
+          "last_updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Updated At"
+          }
+        },
+        "type": "object",
+        "required": ["name", "matchers", "id", "created_at"],
+        "title": "MappingRuleDtoOut"
+      },
+      "MergeIncidentsRequestDto": {
+        "properties": {
+          "source_incident_ids": {
+            "items": { "type": "string", "format": "uuid" },
+            "type": "array",
+            "title": "Source Incident Ids"
+          },
+          "destination_incident_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Destination Incident Id"
+          }
+        },
+        "type": "object",
+        "required": ["source_incident_ids", "destination_incident_id"],
+        "title": "MergeIncidentsRequestDto"
+      },
+      "MergeIncidentsResponseDto": {
+        "properties": {
+          "merged_incident_ids": {
+            "items": { "type": "string", "format": "uuid" },
+            "type": "array",
+            "title": "Merged Incident Ids"
+          },
+          "skipped_incident_ids": {
+            "items": { "type": "string", "format": "uuid" },
+            "type": "array",
+            "title": "Skipped Incident Ids"
+          },
+          "failed_incident_ids": {
+            "items": { "type": "string", "format": "uuid" },
+            "type": "array",
+            "title": "Failed Incident Ids"
+          },
+          "destination_incident_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Destination Incident Id"
+          },
+          "message": { "type": "string", "title": "Message" }
+        },
+        "type": "object",
+        "required": [
+          "merged_incident_ids",
+          "skipped_incident_ids",
+          "failed_incident_ids",
+          "destination_incident_id",
+          "message"
+        ],
+        "title": "MergeIncidentsResponseDto"
+      },
+      "PermissionEntity": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "type": { "type": "string", "title": "Type" },
+          "name": { "type": "string", "title": "Name" }
+        },
+        "type": "object",
+        "required": ["id", "type"],
+        "title": "PermissionEntity"
+      },
+      "PresetDto": {
+        "properties": {
+          "id": { "type": "string", "format": "uuid", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "options": {
+            "items": {},
+            "type": "array",
+            "title": "Options",
+            "default": []
+          },
+          "created_by": { "type": "string", "title": "Created By" },
+          "is_private": {
+            "type": "boolean",
+            "title": "Is Private",
+            "default": false
+          },
+          "is_noisy": {
+            "type": "boolean",
+            "title": "Is Noisy",
+            "default": false
+          },
+          "should_do_noise_now": {
+            "type": "boolean",
+            "title": "Should Do Noise Now",
+            "default": false
+          },
+          "alerts_count": {
+            "type": "integer",
+            "title": "Alerts Count",
+            "default": 0
+          },
+          "static": { "type": "boolean", "title": "Static", "default": false },
+          "tags": {
+            "items": { "$ref": "#/components/schemas/TagDto" },
+            "type": "array",
+            "title": "Tags",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": ["id", "name"],
+        "title": "PresetDto"
+      },
+      "PresetOption": {
+        "properties": {
+          "label": { "type": "string", "title": "Label" },
+          "value": {
+            "anyOf": [{ "type": "string" }, { "type": "object" }],
+            "title": "Value"
+          }
+        },
+        "type": "object",
+        "required": ["label", "value"],
+        "title": "PresetOption"
+      },
+      "PresetSearchQuery": {
+        "properties": {
+          "cel_query": {
+            "type": "string",
+            "minLength": 0,
+            "title": "Cel Query"
+          },
+          "sql_query": { "type": "object", "title": "Sql Query" },
+          "limit": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Limit",
+            "default": 1000
+          },
+          "timeframe": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Timeframe",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": ["cel_query", "sql_query"],
+        "title": "PresetSearchQuery"
+      },
+      "ProviderDTO": {
+        "properties": {
+          "type": { "type": "string", "title": "Type" },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "installed": { "type": "boolean", "title": "Installed" }
+        },
+        "type": "object",
+        "required": ["type", "name", "installed"],
+        "title": "ProviderDTO"
+      },
+      "ProviderWebhookSettings": {
+        "properties": {
+          "webhookDescription": {
+            "type": "string",
+            "title": "Webhookdescription"
+          },
+          "webhookTemplate": { "type": "string", "title": "Webhooktemplate" },
+          "webhookMarkdown": { "type": "string", "title": "Webhookmarkdown" }
+        },
+        "type": "object",
+        "required": ["webhookTemplate"],
+        "title": "ProviderWebhookSettings"
+      },
+      "ResourcePermission": {
+        "properties": {
+          "resource_id": { "type": "string", "title": "Resource Id" },
+          "resource_name": { "type": "string", "title": "Resource Name" },
+          "resource_type": { "type": "string", "title": "Resource Type" },
+          "permissions": {
+            "items": { "$ref": "#/components/schemas/PermissionEntity" },
+            "type": "array",
+            "title": "Permissions"
+          }
+        },
+        "type": "object",
+        "required": [
+          "resource_id",
+          "resource_name",
+          "resource_type",
+          "permissions"
+        ],
+        "title": "ResourcePermission"
+      },
+      "Role": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "scopes": {
+            "items": { "type": "string" },
+            "type": "array",
+            "uniqueItems": true,
+            "title": "Scopes"
+          },
+          "predefined": {
+            "type": "boolean",
+            "title": "Predefined",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": ["id", "name", "description", "scopes"],
+        "title": "Role"
+      },
+      "RuleCreateDto": {
+        "properties": {
+          "ruleName": { "type": "string", "title": "Rulename" },
+          "sqlQuery": { "type": "object", "title": "Sqlquery" },
+          "celQuery": { "type": "string", "title": "Celquery" },
+          "timeframeInSeconds": {
+            "type": "integer",
+            "title": "Timeframeinseconds"
+          },
+          "timeUnit": { "type": "string", "title": "Timeunit" },
+          "groupingCriteria": {
+            "items": {},
+            "type": "array",
+            "title": "Groupingcriteria",
+            "default": []
+          },
+          "groupDescription": { "type": "string", "title": "Groupdescription" },
+          "requireApprove": {
+            "type": "boolean",
+            "title": "Requireapprove",
+            "default": false
+          },
+          "resolveOn": {
+            "type": "string",
+            "title": "Resolveon",
+            "default": "never"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ruleName",
+          "sqlQuery",
+          "celQuery",
+          "timeframeInSeconds",
+          "timeUnit"
+        ],
+        "title": "RuleCreateDto"
+      },
+      "SMTPSettings": {
+        "properties": {
+          "host": { "type": "string", "title": "Host" },
+          "port": { "type": "integer", "title": "Port" },
+          "from_email": { "type": "string", "title": "From Email" },
+          "username": { "type": "string", "title": "Username" },
+          "password": {
+            "type": "string",
+            "format": "password",
+            "title": "Password",
+            "writeOnly": true
+          },
+          "secure": { "type": "boolean", "title": "Secure", "default": true },
+          "to_email": {
+            "type": "string",
+            "title": "To Email",
+            "default": "keep@example.com"
+          }
+        },
+        "type": "object",
+        "required": ["host", "port", "from_email"],
+        "title": "SMTPSettings",
+        "example": {
+          "host": "smtp.example.com",
+          "port": 587,
+          "username": "user@example.com",
+          "password": "password",
+          "secure": true,
+          "from_email": "noreply@example.com",
+          "to_email": ""
+        }
+      },
+      "SearchAlertsRequest": {
+        "properties": {
+          "query": { "$ref": "#/components/schemas/PresetSearchQuery" },
+          "timeframe": { "type": "integer", "title": "Timeframe" }
+        },
+        "type": "object",
+        "required": ["query", "timeframe"],
+        "title": "SearchAlertsRequest"
+      },
+      "TagDto": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" }
+        },
+        "type": "object",
+        "required": ["name"],
+        "title": "TagDto"
+      },
+      "TopologyApplicationDtoIn": {
+        "properties": {
+          "id": { "type": "string", "format": "uuid", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "services": {
+            "items": { "$ref": "#/components/schemas/TopologyServiceDtoIn" },
+            "type": "array",
+            "title": "Services",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": ["name"],
+        "title": "TopologyApplicationDtoIn"
+      },
+      "TopologyApplicationDtoOut": {
+        "properties": {
+          "id": { "type": "string", "format": "uuid", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "services": {
+            "items": {
+              "$ref": "#/components/schemas/TopologyApplicationServiceDto"
+            },
+            "type": "array",
+            "title": "Services",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": ["id", "name"],
+        "title": "TopologyApplicationDtoOut"
+      },
+      "TopologyApplicationServiceDto": {
+        "properties": {
+          "id": { "type": "integer", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "service": { "type": "string", "title": "Service" }
+        },
+        "type": "object",
+        "required": ["id", "name", "service"],
+        "title": "TopologyApplicationServiceDto"
+      },
+      "TopologyServiceDependencyDto": {
+        "properties": {
+          "serviceId": { "type": "integer", "title": "Serviceid" },
+          "serviceName": { "type": "string", "title": "Servicename" },
+          "protocol": {
+            "type": "string",
+            "title": "Protocol",
+            "default": "unknown"
+          }
+        },
+        "type": "object",
+        "required": ["serviceId", "serviceName"],
+        "title": "TopologyServiceDependencyDto"
+      },
+      "TopologyServiceDtoIn": {
+        "properties": { "id": { "type": "integer", "title": "Id" } },
+        "type": "object",
+        "required": ["id"],
+        "title": "TopologyServiceDtoIn"
+      },
+      "TopologyServiceDtoOut": {
+        "properties": {
+          "source_provider_id": {
+            "type": "string",
+            "title": "Source Provider Id"
+          },
+          "repository": { "type": "string", "title": "Repository" },
+          "tags": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Tags"
+          },
+          "service": { "type": "string", "title": "Service" },
+          "display_name": { "type": "string", "title": "Display Name" },
+          "environment": {
+            "type": "string",
+            "title": "Environment",
+            "default": "unknown"
+          },
+          "description": { "type": "string", "title": "Description" },
+          "team": { "type": "string", "title": "Team" },
+          "email": { "type": "string", "title": "Email" },
+          "slack": { "type": "string", "title": "Slack" },
+          "ip_address": { "type": "string", "title": "Ip Address" },
+          "mac_address": { "type": "string", "title": "Mac Address" },
+          "category": { "type": "string", "title": "Category" },
+          "manufacturer": { "type": "string", "title": "Manufacturer" },
+          "id": { "type": "integer", "title": "Id" },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/TopologyServiceDependencyDto"
+            },
+            "type": "array",
+            "title": "Dependencies"
+          },
+          "application_ids": {
+            "items": { "type": "string", "format": "uuid" },
+            "type": "array",
+            "title": "Application Ids"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "service",
+          "display_name",
+          "id",
+          "dependencies",
+          "application_ids"
+        ],
+        "title": "TopologyServiceDtoOut"
+      },
+      "UnEnrichAlertRequestBody": {
+        "properties": {
+          "enrichments": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Enrichments"
+          },
+          "fingerprint": { "type": "string", "title": "Fingerprint" }
+        },
+        "type": "object",
+        "required": ["enrichments", "fingerprint"],
+        "title": "UnEnrichAlertRequestBody"
+      },
+      "UpdateUserRequest": {
+        "properties": {
+          "username": { "type": "string", "title": "Username" },
+          "password": { "type": "string", "title": "Password" },
+          "role": { "type": "string", "title": "Role" },
+          "groups": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Groups"
+          }
+        },
+        "type": "object",
+        "title": "UpdateUserRequest"
+      },
+      "User": {
+        "properties": {
+          "email": { "type": "string", "title": "Email" },
+          "name": { "type": "string", "title": "Name" },
+          "role": { "type": "string", "title": "Role" },
+          "picture": { "type": "string", "title": "Picture" },
+          "created_at": { "type": "string", "title": "Created At" },
+          "last_login": { "type": "string", "title": "Last Login" },
+          "ldap": { "type": "boolean", "title": "Ldap", "default": false },
+          "groups": {
+            "items": { "$ref": "#/components/schemas/Group" },
+            "type": "array",
+            "title": "Groups",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": ["email", "name", "created_at"],
+        "title": "User"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": { "anyOf": [{ "type": "string" }, { "type": "integer" }] },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": { "type": "string", "title": "Message" },
+          "type": { "type": "string", "title": "Error Type" }
+        },
+        "type": "object",
+        "required": ["loc", "msg", "type"],
+        "title": "ValidationError"
+      },
+      "WebhookSettings": {
+        "properties": {
+          "webhookApi": { "type": "string", "title": "Webhookapi" },
+          "apiKey": { "type": "string", "title": "Apikey" },
+          "modelSchema": { "type": "object", "title": "Modelschema" }
+        },
+        "type": "object",
+        "required": ["webhookApi", "apiKey", "modelSchema"],
+        "title": "WebhookSettings"
+      },
+      "WorkflowCreateOrUpdateDTO": {
+        "properties": {
+          "workflow_id": { "type": "string", "title": "Workflow Id" },
+          "status": {
+            "type": "string",
+            "enum": ["created", "updated"],
+            "title": "Status"
+          },
+          "revision": { "type": "integer", "title": "Revision", "default": 1 }
+        },
+        "type": "object",
+        "required": ["workflow_id", "status"],
+        "title": "WorkflowCreateOrUpdateDTO"
+      },
+      "WorkflowDTO": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "default": "Workflow file doesn't contain name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "default": "Workflow file doesn't contain description"
+          },
+          "created_by": { "type": "string", "title": "Created By" },
+          "creation_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Creation Time"
+          },
+          "triggers": {
+            "items": { "type": "object" },
+            "type": "array",
+            "title": "Triggers"
+          },
+          "interval": { "type": "integer", "title": "Interval" },
+          "disabled": {
+            "type": "boolean",
+            "title": "Disabled",
+            "default": false
+          },
+          "last_execution_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Execution Time"
+          },
+          "last_execution_status": {
+            "type": "string",
+            "title": "Last Execution Status"
+          },
+          "providers": {
+            "items": { "$ref": "#/components/schemas/ProviderDTO" },
+            "type": "array",
+            "title": "Providers"
+          },
+          "workflow_raw": { "type": "string", "title": "Workflow Raw" },
+          "revision": { "type": "integer", "title": "Revision", "default": 1 },
+          "last_updated": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Updated"
+          },
+          "invalid": {
+            "type": "boolean",
+            "title": "Invalid",
+            "default": false
+          },
+          "last_executions": {
+            "items": { "type": "object" },
+            "type": "array",
+            "title": "Last Executions"
+          },
+          "last_execution_started": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Execution Started"
+          },
+          "provisioned": {
+            "type": "boolean",
+            "title": "Provisioned",
+            "default": false
+          },
+          "provisioned_file": { "type": "string", "title": "Provisioned File" }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "created_by",
+          "creation_time",
+          "providers",
+          "workflow_raw"
+        ],
+        "title": "WorkflowDTO"
+      },
+      "WorkflowExecutionDTO": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "workflow_id": { "type": "string", "title": "Workflow Id" },
+          "started": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Started"
+          },
+          "triggered_by": { "type": "string", "title": "Triggered By" },
+          "status": { "type": "string", "title": "Status" },
+          "workflow_name": { "type": "string", "title": "Workflow Name" },
+          "logs": {
+            "items": {
+              "$ref": "#/components/schemas/WorkflowExecutionLogsDTO"
+            },
+            "type": "array",
+            "title": "Logs"
+          },
+          "error": { "type": "string", "title": "Error" },
+          "execution_time": { "type": "number", "title": "Execution Time" },
+          "results": { "type": "object", "title": "Results" }
+        },
+        "type": "object",
+        "required": ["id", "workflow_id", "started", "triggered_by", "status"],
+        "title": "WorkflowExecutionDTO"
+      },
+      "WorkflowExecutionLogsDTO": {
+        "properties": {
+          "id": { "type": "integer", "title": "Id" },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "message": { "type": "string", "title": "Message" },
+          "context": { "type": "object", "title": "Context" }
+        },
+        "type": "object",
+        "required": ["id", "timestamp", "message"],
+        "title": "WorkflowExecutionLogsDTO"
+      },
+      "WorkflowExecutionsPaginatedResultsDto": {
+        "properties": {
+          "limit": { "type": "integer", "title": "Limit", "default": 25 },
+          "offset": { "type": "integer", "title": "Offset", "default": 0 },
+          "count": { "type": "integer", "title": "Count" },
+          "items": {
+            "items": { "$ref": "#/components/schemas/WorkflowExecutionDTO" },
+            "type": "array",
+            "title": "Items"
+          },
+          "passCount": {
+            "type": "integer",
+            "title": "Passcount",
+            "default": 0
+          },
+          "avgDuration": {
+            "type": "number",
+            "title": "Avgduration",
+            "default": 0.0
+          },
+          "workflow": { "$ref": "#/components/schemas/WorkflowDTO" },
+          "failCount": { "type": "integer", "title": "Failcount", "default": 0 }
+        },
+        "type": "object",
+        "required": ["count", "items"],
+        "title": "WorkflowExecutionsPaginatedResultsDto"
+      },
+      "WorkflowToAlertExecutionDTO": {
+        "properties": {
+          "workflow_id": { "type": "string", "title": "Workflow Id" },
+          "workflow_execution_id": {
+            "type": "string",
+            "title": "Workflow Execution Id"
+          },
+          "alert_fingerprint": {
+            "type": "string",
+            "title": "Alert Fingerprint"
+          },
+          "workflow_status": { "type": "string", "title": "Workflow Status" },
+          "workflow_started": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Workflow Started"
+          }
+        },
+        "type": "object",
+        "required": [
+          "workflow_id",
+          "workflow_execution_id",
+          "alert_fingerprint",
+          "workflow_status",
+          "workflow_started"
+        ],
+        "title": "WorkflowToAlertExecutionDTO"
+      }
+    },
+    "securitySchemes": {
+      "API Key": { "type": "apiKey", "in": "header", "name": "X-API-KEY" },
+      "HTTPBasic": { "type": "http", "scheme": "basic" },
+      "OAuth2PasswordBearer": {
+        "type": "oauth2",
+        "flows": { "password": { "scopes": {}, "tokenUrl": "token" } }
+      }
+    }
+  }
+}

--- a/keep/api/models/alert.py
+++ b/keep/api/models/alert.py
@@ -157,9 +157,7 @@ class AlertDto(BaseModel):
     fingerprint: str | None = (
         None  # The fingerprint of the alert (used for alert de-duplication)
     )
-    deleted: bool = (
-        False  # @tal: Obselete field since we have dismissed, but kept for backwards compatibility
-    )
+    deleted: bool = False  # @tal: Obselete field since we have dismissed, but kept for backwards compatibility
     dismissUntil: str | None = None  # The time until the alert is dismissed
     # DO NOT MOVE DISMISSED ABOVE dismissedUntil since it is used in root_validator
     dismissed: bool = False  # Whether the alert has been dismissed
@@ -167,9 +165,7 @@ class AlertDto(BaseModel):
     providerId: str | None = None  # The provider id
     providerType: str | None = None  # The provider type
     note: str | None = None  # The note of the alert
-    startedAt: str | None = (
-        None  # The time the alert started - e.g. if alert triggered multiple times, it will be the time of the first trigger (calculated on querying)
-    )
+    startedAt: str | None = None  # The time the alert started - e.g. if alert triggered multiple times, it will be the time of the first trigger (calculated on querying)
     isNoisy: bool = False  # Whether the alert is noisy
 
     enriched_fields: list = []
@@ -393,7 +389,7 @@ class AlertWithIncidentLinkMetadataDto(AlertDto):
 
 class DeleteRequestBody(BaseModel):
     fingerprint: str
-    lastReceived: str
+    lastReceived: Optional[str] = None
     restore: bool = False
 
 
@@ -535,7 +531,6 @@ class IncidentDto(IncidentDtoIn):
 
     @classmethod
     def from_db_incident(cls, db_incident: "Incident", rule: "Rule" = None):
-
         severity = (
             IncidentSeverity.from_number(db_incident.severity)
             if isinstance(db_incident.severity, int)

--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -317,7 +317,7 @@ def delete_alert(
             # Restore all timestamps
             deleted_last_received = []
     else:
-        if delete_alert.lastReceived:
+        if delete_alert.lastReceived is None:
             # Delete a single timestamp if it’s not already deleted
             if delete_alert.lastReceived not in deleted_last_received:
                 deleted_last_received.append(delete_alert.lastReceived)


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2817

## 📑 Description
Currently, the DELETE /alerts API allows only a specific timestamp to be deleted or restored at a time, requiring lastReceived to be provided.

This update enhances the API by allowing all timestamps associated with an alert's fingerprint to be deleted when lastReceived is omitted.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
