### PR TITLE
fix: Handle both dashed and non-dashed alert_id formats.

### DIFF
--- a/keep-ui/app/(keep)/extraction/[rule_id]/executions/[execution_id]/page.tsx
+++ b/keep-ui/app/(keep)/extraction/[rule_id]/executions/[execution_id]/page.tsx
@@ -25,8 +25,11 @@ export default function ExtractionExecutionDetailsPage({
     return null;
   }
 
+  // alert_id in enrichmentevent (keep/api/models/db/enrichment_event.py#L34) refers not to alert.PK,
+  // but to `alert.event->>'id'`.
+  // So, we can't guarantee the format it is stored in. It could be any - dashed or non-dashed
   const alertFilterUrl = `/alerts/feed?cel=${encodeURIComponent(
-    `id=="${execution.enrichment_event.alert_id}"`
+    `id=="${execution.enrichment_event.alert_id}" || id=="${execution.enrichment_event.alert_id.replace("-", "")}"`
   )}`;
 
   return (

--- a/keep-ui/app/(keep)/mapping/[rule_id]/executions/[execution_id]/page.tsx
+++ b/keep-ui/app/(keep)/mapping/[rule_id]/executions/[execution_id]/page.tsx
@@ -25,8 +25,11 @@ export default function MappingExecutionDetailsPage({
     return null;
   }
 
+  // alert_id in enrichmentevent (keep/api/models/db/enrichment_event.py#L34) refers not to alert.PK,
+  // but to `alert.event->>'id'`.
+  // So, we can't guarantee the format it is stored in. It could be any - dashed or non-dashed
   const alertFilterUrl = `/alerts/feed?cel=${encodeURIComponent(
-    `id=="${execution.enrichment_event.alert_id}"`
+    `id=="${execution.enrichment_event.alert_id}" || id=="${execution.enrichment_event.alert_id.replace("-", "")}"`
   )}`;
 
   return (


### PR DESCRIPTION
Updated alert filter logic to accommodate variations in alert_id format. This ensures compatibility with different storage formats in enrichment events.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3518 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
