### PR TITLE
fix: Clear filters in incidents does not reset default facets

### DIFF
--- a/keep-ui/features/filter/facet-panel-server-side.tsx
+++ b/keep-ui/features/filter/facet-panel-server-side.tsx
@@ -27,11 +27,6 @@ export interface FacetsPanelProps {
    * Filters will be cleared every clearFiltersToken value change.
    **/
   clearFiltersToken?: string | null;
-  /**
-   * Object with facets that should be unchecked by default.
-   * Key is the facet name, value is the list of option values to uncheck.
-   **/
-  uncheckedByDefaultOptionValues?: { [key: string]: string[] };
   facetsConfig?: FacetsConfig;
   /** Callback to handle the change of the CEL when options toggle */
   onCelChange?: (cel: string) => void;
@@ -46,7 +41,6 @@ export const FacetsPanelServerSide: React.FC<FacetsPanelProps> = ({
   revalidationToken,
   clearFiltersToken,
   onCelChange = undefined,
-  uncheckedByDefaultOptionValues,
   facetsConfig,
 }) => {
   function buildFacetOptionsQuery() {
@@ -162,7 +156,6 @@ export const FacetsPanelServerSide: React.FC<FacetsPanelProps> = ({
         facetOptions={facetOptions as any}
         areFacetOptionsLoading={!isSilentLoading && isLoading}
         clearFiltersToken={clearFiltersToken}
-        uncheckedByDefaultOptionValues={uncheckedByDefaultOptionValues}
         facetsConfig={facetsConfig}
         onCelChange={(cel: string) => {
           onCelChange && onCelChange(cel);

--- a/keep-ui/features/filter/facets-panel.tsx
+++ b/keep-ui/features/filter/facets-panel.tsx
@@ -97,7 +97,6 @@ export const FacetsPanel: React.FC<FacetsPanelProps> = ({
   facetOptions,
   areFacetOptionsLoading = false,
   clearFiltersToken,
-  uncheckedByDefaultOptionValues,
   facetsConfig,
   onCelChange = undefined,
   onAddFacet = undefined,
@@ -127,10 +126,13 @@ export const FacetsPanel: React.FC<FacetsPanelProps> = ({
           ((facetOption: FacetOptionDto) => (
             <span className="capitalize">{facetOption.display_name}</span>
           ));
+        const uncheckedByDefaultOptionValues =
+          facetConfig?.uncheckedByDefaultOptionValues;
         result[facet.id] = {
           sortCallback,
           renderOptionIcon,
           renderOptionLabel,
+          uncheckedByDefaultOptionValues,
         };
       });
     }
@@ -141,15 +143,14 @@ export const FacetsPanel: React.FC<FacetsPanelProps> = ({
   function getFacetState(facetId: string): Set<string> {
     if (
       !defaultStateHandledForFacetIds.has(facetId) &&
-      uncheckedByDefaultOptionValues &&
-      Object.keys(uncheckedByDefaultOptionValues).length
+      facetsConfigIdBased[facetId]?.uncheckedByDefaultOptionValues
     ) {
       const facetState = new Set<string>(...(facetsState[facetId] || []));
       const facet = facets.find((f) => f.id === facetId);
 
       if (facet) {
-        uncheckedByDefaultOptionValues[facet?.name]?.forEach((optionValue) =>
-          facetState.add(optionValue)
+        facetsConfigIdBased[facetId]?.uncheckedByDefaultOptionValues.forEach(
+          (optionValue) => facetState.add(optionValue)
         );
         defaultStateHandledForFacetIds.add(facetId);
       }

--- a/keep-ui/features/filter/facets-panel.tsx
+++ b/keep-ui/features/filter/facets-panel.tsx
@@ -73,7 +73,6 @@ export interface FacetsPanelProps {
    * Object with facets that should be unchecked by default.
    * Key is the facet name, value is the list of option values to uncheck.
    **/
-  uncheckedByDefaultOptionValues?: { [key: string]: string[] };
   facetsConfig?: FacetsConfig;
   renderFacetOptionLabel?: (
     facetName: string,
@@ -252,7 +251,16 @@ export const FacetsPanel: React.FC<FacetsPanelProps> = ({
   }
 
   function clearFilters(): void {
-    setFacetsState({});
+    Object.keys(facetsState).forEach((facetId) => facetsState[facetId].clear());
+    defaultStateHandledForFacetIds.clear();
+
+    const newFacetsState: FacetState = {};
+
+    facets.forEach((facet) => {
+      newFacetsState[facet.id] = getFacetState(facet.id);
+    });
+
+    setFacetsState(newFacetsState);
   }
 
   useEffect(

--- a/keep-ui/features/filter/models.tsx
+++ b/keep-ui/features/filter/models.tsx
@@ -1,4 +1,5 @@
 export interface FacetConfig {
+  uncheckedByDefaultOptionValues?: string[];
   renderOptionIcon?: (facetOption: FacetOptionDto) => JSX.Element | undefined;
   renderOptionLabel?: (
     facetOption: FacetOptionDto

--- a/keep-ui/features/incident-list/ui/incident-list.tsx
+++ b/keep-ui/features/incident-list/ui/incident-list.tsx
@@ -176,6 +176,7 @@ export function IncidentList({
           reverseSeverityMapping[facetOption.value] || 100, // if status is not in the mapping, it should be at the end
       },
       ["Status"]: {
+        uncheckedByDefaultOptionValues: ["resolved", "deleted"],
         renderOptionIcon: (facetOption) => (
           <Icon
             icon={getStatusIcon(facetOption.display_name)}
@@ -288,10 +289,6 @@ export function IncidentList({
     );
   }
 
-  const uncheckedFacetOptionsByDefault: Record<string, string[]> = {
-    Status: ["resolved", "deleted"],
-  };
-
   const renderDateTimePicker = () => {
     return (
       <div className="flex justify-end">
@@ -363,9 +360,6 @@ export function IncidentList({
                   usePropertyPathsSuggestions={true}
                   clearFiltersToken={clearFiltersToken}
                   initialFacetsData={initialFacetsData}
-                  uncheckedByDefaultOptionValues={
-                    uncheckedFacetOptionsByDefault
-                  }
                   onCelChange={(cel) => setFilterCel(cel)}
                   revalidationToken={filterRevalidationToken}
                 />


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3641

## 📑 Description
- Move uncheckedByDefaultOptionValues to FacetConfig interface

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
