### PR TITLE
fix: multiline strings starting with "|"

### DIFF
--- a/keep-ui/entities/workflows/lib/__tests__/yaml-utils.test.ts
+++ b/keep-ui/entities/workflows/lib/__tests__/yaml-utils.test.ts
@@ -78,6 +78,25 @@ workflow:
           message: "Error in clickhouse logs_table: {{ steps.clickhouse-step.results.level }}"
 `;
 
+const multilineClickhouseExampleYaml = `
+workflow:
+  id: query-clickhouse
+  name: Query Clickhouse and send an alert if there is an error
+  description: Query Clickhouse and send an alert if there is an error
+  disabled: false
+  triggers:
+    - type: manual
+  steps:
+    - name: clickhouse-observability-urls
+      provider:
+        config: "{{ providers.clickhouse }}"
+        type: clickhouse
+        with:
+          query: |
+            SELECT Url, Status FROM "observability"."Urls"
+            WHERE ( Url LIKE '%te_tests%' ) AND Timestamp >= toStartOfMinute(date_add(toDateTime(NOW()), INTERVAL -1 MINUTE)) AND Status = 0;
+`;
+
 describe("YAML Utils", () => {
   it("getOrderedWorkflowYamlString should reorder the workflow sections while keeping the quote style", () => {
     const reorderedWorkflow = getOrderedWorkflowYamlString(
@@ -89,5 +108,14 @@ describe("YAML Utils", () => {
   it("getOrderedWorkflowYamlStringFromJSON should return the same string if the input is already ordered", () => {
     const orderedWorkflow = getOrderedWorkflowYamlString(clickhouseExampleYaml);
     expect(orderedWorkflow.trim()).toEqual(clickhouseExampleYaml.trim());
+  });
+
+  it("getOrderedWorkflowYamlString should return the same string if the input", () => {
+    const orderedWorkflow = getOrderedWorkflowYamlString(
+      multilineClickhouseExampleYaml
+    );
+    expect(orderedWorkflow.trim()).toEqual(
+      multilineClickhouseExampleYaml.trim()
+    );
   });
 });

--- a/tests/test_cyaml.py
+++ b/tests/test_cyaml.py
@@ -166,3 +166,17 @@ def test_stream_output():
     assert stream_content is not None
     assert '"Test Stream"' in stream_content
     assert '"SELECT * FROM table;"' in stream_content 
+
+def test_multiline_strings():
+    """Test that multiline strings are preserved."""
+    yaml_str = """
+      query: |
+        SELECT Url, Status FROM "observability"."Urls"
+        WHERE ( Url LIKE '%te_tests%' ) AND Timestamp >= toStartOfMinute(date_add(toDateTime(NOW()), INTERVAL -1 MINUTE)) AND Status = 0;
+    """
+    data = cyaml.safe_load(yaml_str)
+    dumped_yaml = cyaml.dump(data)
+    
+    assert dumped_yaml is not None
+    assert 'query: |' in dumped_yaml
+    


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3826  <!-- Issue # here -->

## Import 
```yaml
id: query-clickhouse
description: Query Clickhouse and send an alert if there is an error
triggers:
  - type: manual

steps:
  - name: clickhouse-observability-urls
    provider:
      config: "{{ providers.clickhouse }}"
      type: clickhouse
      with:
        query: |
          SELECT Url, Status FROM "observability"."Urls"
          WHERE ( Url LIKE '%te_tests%' ) AND Timestamp >= toStartOfMinute(date_add(toDateTime(NOW()), INTERVAL -1 MINUTE)) AND Status = 0;

  - name: clickhouse-observability-events
    provider:
      config: "{{ providers.clickhouse }}"
      type: clickhouse
      with:
        query: |
          SELECT arrayElement(Metrics.testName, 1) AS mytest FROM observability.Events
          WHERE (Sources = 'ThousandEyes') AND (Timestamp >= toStartOfMinute(toDateTime(NOW()) + toIntervalMinute(-1))) AND (mytest = 'Oceanspot-TE')

  - name: clickhouse-observability-traces
    provider:
      config: "{{ providers.clickhouse }}"
      type: clickhouse
      with:
        query: |
          SELECT count(*) as c FROM "observability"."Traces"
          WHERE ( SpanName LIKE '%te_tests%' ) AND Timestamp >= toStartOfMinute(date_add(toDateTime(NOW()), INTERVAL -1 MINUTE));

  - name: clickhouse-observability-follow-up-query
    # if any of the previous queries return results, run this query
    if: keep.len( {{ steps.clickhouse-observability-urls.results }} ) or keep.len( {{ steps.clickhouse-observability-events.results }} ) or keep.len( {{ steps.clickhouse-observability-traces.results }} )
    provider:
      config: "{{ providers.clickhouse }}"
      type: clickhouse
      with:
        query: |
          SELECT Url, Status FROM "observability"."Urls"
          WHERE ( Url LIKE '%te_tests%' ) AND Timestamp >= toStartOfMinute(date_add(toDateTime(NOW()), INTERVAL -1 MINUTE)) AND Status = 0;

actions:
  - name: snow-action
    # if any of the previous queries return results, run this query
    if: keep.len( {{ steps.clickhouse-observability-urls.results }} ) or keep.len( {{ steps.clickhouse-observability-events.results }} ) or keep.len( {{ steps.clickhouse-observability-traces.results }} )
    provider:
      type: servicenow
      config: "{{ providers.servicenow }}"
      with:
        table_name: "yourtablename"
        payload:
          short_description: "Results returned for clickhouse-observability"
          description: |
            Urls: {{ steps.clickhouse-observability-urls.results }}
            Events: {{ steps.clickhouse-observability-events.results }}
            Traces: {{ steps.clickhouse-observability-traces.results }}
```

## Before
```yaml
workflow:
  id: query-clickhouse
  name: query-clickhouse
  description: Query Clickhouse and send an alert if there is an error
  triggers:
    - type: manual
  steps:
    - name: clickhouse-observability-urls
      provider:
        config: "{{ providers.clickhouse }}"
        type: clickhouse
        with:
          query: 'SELECT Url, Status FROM "observability"."Urls"

            WHERE ( Url LIKE ''%te_tests%'' ) AND Timestamp >= toStartOfMinute(date_add(toDateTime(NOW()), INTERVAL -1 MINUTE)) AND Status = 0;

            '
    - name: clickhouse-observability-events
      provider:
        config: "{{ providers.clickhouse }}"
        type: clickhouse
        with:
          query: 'SELECT arrayElement(Metrics.testName, 1) AS mytest FROM observability.Events

            WHERE (Sources = ''ThousandEyes'') AND (Timestamp >= toStartOfMinute(toDateTime(NOW()) + toIntervalMinute(-1))) AND (mytest = ''Oceanspot-TE'')

            '
    - name: clickhouse-observability-traces
      provider:
        config: "{{ providers.clickhouse }}"
        type: clickhouse
        with:
          query: 'SELECT count(*) as c FROM "observability"."Traces"

            WHERE ( SpanName LIKE ''%te_tests%'' ) AND Timestamp >= toStartOfMinute(date_add(toDateTime(NOW()), INTERVAL -1 MINUTE));

            '
    - name: clickhouse-observability-follow-up-query
      if: keep.len( {{ steps.clickhouse-observability-urls.results }} ) or keep.len( {{ steps.clickhouse-observability-events.results }} ) or keep.len( {{ steps.clickhouse-observability-traces.results }} )
      provider:
        config: "{{ providers.clickhouse }}"
        type: clickhouse
        with:
          query: 'SELECT Url, Status FROM "observability"."Urls"

            WHERE ( Url LIKE ''%te_tests%'' ) AND Timestamp >= toStartOfMinute(date_add(toDateTime(NOW()), INTERVAL -1 MINUTE)) AND Status = 0;

            '
  actions:
    - name: snow-action
      if: keep.len( {{ steps.clickhouse-observability-urls.results }} ) or keep.len( {{ steps.clickhouse-observability-events.results }} ) or keep.len( {{ steps.clickhouse-observability-traces.results }} )
      provider:
        type: servicenow
        config: "{{ providers.servicenow }}"
        with:
          table_name: "yourtablename"
          payload:
            short_description: "Results returned for clickhouse-observability"
            description: 'Urls: {{ steps.clickhouse-observability-urls.results }}

              Events: {{ steps.clickhouse-observability-events.results }}

              Traces: {{ steps.clickhouse-observability-traces.results }}'
```

## After
```yaml
workflow:
  id: query-clickhouse
  description: Query Clickhouse and send an alert if there is an error
  triggers:
    - type: manual
  steps:
    - name: clickhouse-observability-urls
      provider:
        config: "{{ providers.clickhouse }}"
        type: clickhouse
        with:
          query: |
            SELECT Url, Status FROM "observability"."Urls"
            WHERE ( Url LIKE '%te_tests%' ) AND Timestamp >= toStartOfMinute(date_add(toDateTime(NOW()), INTERVAL -1 MINUTE)) AND Status = 0;
    - name: clickhouse-observability-events
      provider:
        config: "{{ providers.clickhouse }}"
        type: clickhouse
        with:
          query: |
            SELECT arrayElement(Metrics.testName, 1) AS mytest FROM observability.Events
            WHERE (Sources = 'ThousandEyes') AND (Timestamp >= toStartOfMinute(toDateTime(NOW()) + toIntervalMinute(-1))) AND (mytest = 'Oceanspot-TE')
    - name: clickhouse-observability-traces
      provider:
        config: "{{ providers.clickhouse }}"
        type: clickhouse
        with:
          query: |
            SELECT count(*) as c FROM "observability"."Traces"
            WHERE ( SpanName LIKE '%te_tests%' ) AND Timestamp >= toStartOfMinute(date_add(toDateTime(NOW()), INTERVAL -1 MINUTE));
    - name: clickhouse-observability-follow-up-query
      if: keep.len( {{ steps.clickhouse-observability-urls.results }} ) or keep.len( {{ steps.clickhouse-observability-events.results }} ) or keep.len( {{ steps.clickhouse-observability-traces.results }} )
      provider:
        config: "{{ providers.clickhouse }}"
        type: clickhouse
        with:
          query: |
            SELECT Url, Status FROM "observability"."Urls"
            WHERE ( Url LIKE '%te_tests%' ) AND Timestamp >= toStartOfMinute(date_add(toDateTime(NOW()), INTERVAL -1 MINUTE)) AND Status = 0;
  actions:
    - name: snow-action
      if: keep.len( {{ steps.clickhouse-observability-urls.results }} ) or keep.len( {{ steps.clickhouse-observability-events.results }} ) or keep.len( {{ steps.clickhouse-observability-traces.results }} )
      provider:
        type: servicenow
        config: "{{ providers.servicenow }}"
        with:
          table_name: "yourtablename"
          payload:
            short_description: "Results returned for clickhouse-observability"
            description: |-
              Urls: {{ steps.clickhouse-observability-urls.results }}
              Events: {{ steps.clickhouse-observability-events.results }}
              Traces: {{ steps.clickhouse-observability-traces.results }}
```