### PR TITLE
fix: Refactor timestamp handling for incident alerts

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -23,7 +23,6 @@ from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 from psycopg2.errors import NoActiveSqlTransaction
 from sqlalchemy import (
     String,
-    DATETIME,
     and_,
     case,
     cast,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -721,7 +721,7 @@ def create_alert(db_session):
             event={
                 "name": random_name,
                 "fingerprint": fingerprint,
-                "lastReceived": timestamp.isoformat(),
+                "lastReceived": details.pop('lastReceived', timestamp.isoformat()),
                 "status": status.value,
                 **details,
             },

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
-from dateutil.parser import parse
 from fastapi import HTTPException
 from sqlalchemy import and_, desc, distinct, func
 

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -1,9 +1,10 @@
-from datetime import datetime
+from datetime import datetime, timedelta, UTC
 from itertools import cycle
 from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+from dateutil.parser import parse
 from fastapi import HTTPException
 from sqlalchemy import and_, desc, distinct, func
 
@@ -1633,3 +1634,59 @@ def test_correlation_with_mapping(db_session, create_alert):
 
     assert total == 1
     assert incidents[0].alerts_count == 3
+
+
+@pytest.mark.asyncio
+async def test_incident_timestamps_based_on_alert_last_received(db_session, create_alert):
+    # Create alerts with past, current, and future timestamps
+
+    now = datetime.now(UTC)
+    past_date =  now - timedelta(days=1)
+    current_date = now
+    future_date = now + timedelta(days=1)
+
+    past_alert_data = {"lastReceived": past_date.isoformat()}
+    current_alert_data = {"lastReceived": current_date.isoformat()}
+    future_alert_data = {"lastReceived": future_date.isoformat()}
+
+    create_alert(
+        "past-alert",
+        AlertStatus.FIRING,
+        now,
+        past_alert_data,
+    )
+    create_alert(
+        "current-alert",
+        AlertStatus.FIRING,
+        now,
+        current_alert_data,
+    )
+    create_alert(
+        "future-alert",
+        AlertStatus.FIRING,
+        now,
+        future_alert_data,
+    )
+
+    # Link alerts to an incident
+    alerts = db_session.query(Alert).all()
+
+    assert alerts[0].event['lastReceived'] == past_date.isoformat(timespec='milliseconds').replace("+00:00", "Z")
+    assert alerts[1].event['lastReceived'] == current_date.isoformat(timespec='milliseconds').replace("+00:00", "Z")
+    assert alerts[2].event['lastReceived'] == future_date.isoformat(timespec='milliseconds').replace("+00:00", "Z")
+
+    incident = create_incident_from_dict(
+        SINGLE_TENANT_UUID,
+        {"user_generated_name": "Incident with varied timestamps", "user_summary": "Test incident"},
+    )
+    add_alerts_to_incident_by_incident_id(
+        SINGLE_TENANT_UUID, incident.id, [alert.fingerprint for alert in alerts]
+    )
+
+    # Refresh incident data
+    db_session.expire_all()
+    updated_incident = get_incident_by_id(SINGLE_TENANT_UUID, incident.id)
+
+    # Assert that timestamps match expectations
+    assert updated_incident.start_time.replace(microsecond=0) == past_date.replace(microsecond=0, tzinfo=None)
+    assert updated_incident.last_seen_time.replace(microsecond=0) == future_date.replace(microsecond=0, tzinfo=None)


### PR DESCRIPTION
Update incident start and last seen times to use the "lastReceived" field from alerts instead of "timestamp". Added parsing logic for string timestamps and a test to validate the timestamp handling based on varied alert data.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3822

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
