### PR TITLE
fix: Add `resolve_on` field to incident creation for grouping rule

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -1891,6 +1891,7 @@ def create_incident_for_grouping_rule(
             and not rule.require_approve,
             incident_type=IncidentType.RULE.value,
             same_incident_in_the_past_id=past_incident.id if past_incident else None,
+            resolve_on=rule.resolve_on,
         )
         session.add(incident)
         session.commit()


### PR DESCRIPTION
This change ensures the `resolve_on` field is properly set when creating incidents. It improves data consistency and supports future use cases that depend on this attribute.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3913 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
