### PR TITLE
fix: remove outdated 'react-loading'

### DIFF
--- a/keep-ui/app/(keep)/workflows/[workflow_id]/workflow-sync-status.tsx
+++ b/keep-ui/app/(keep)/workflows/[workflow_id]/workflow-sync-status.tsx
@@ -12,7 +12,9 @@ export function WorkflowSyncStatus() {
     isInitialized,
   } = useWorkflowStore();
   const isChangesSaved =
-    isEditorSyncedWithNodes && lastDeployedAt >= lastChangedAt;
+    isEditorSyncedWithNodes &&
+    lastDeployedAt === null &&
+    lastDeployedAt >= lastChangedAt;
 
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {

--- a/keep-ui/features/workflows/builder/ui/Editor/StepTest.tsx
+++ b/keep-ui/features/workflows/builder/ui/Editor/StepTest.tsx
@@ -305,6 +305,7 @@ export function TestRunStepForm({
           className="w-full"
           color="orange"
           disabled={isLoading || isDisabled}
+          data-testid="wf-editor-step-test-run-button"
         >
           {isLoading ? "Running..." : "Test Run"}
         </Button>

--- a/keep-ui/features/workflows/test-run/ui/builder-workflow-testrun-modal-content.tsx
+++ b/keep-ui/features/workflows/test-run/ui/builder-workflow-testrun-modal-content.tsx
@@ -1,5 +1,4 @@
 import { Title } from "@tremor/react";
-import ReactLoading from "react-loading";
 import {
   isWorkflowExecution,
   WorkflowExecutionDetail,
@@ -7,6 +6,7 @@ import {
 } from "@/shared/api/workflow-executions";
 import { WorkflowExecutionResults } from "@/features/workflow-execution-results";
 import { IoClose } from "react-icons/io5";
+import { KeepLoader } from "@/shared/ui";
 
 interface Props {
   closeModal: () => void;
@@ -44,12 +44,7 @@ export function BuilderWorkflowTestRunModalContent({
           />
         ) : (
           <div className="flex justify-center">
-            <ReactLoading
-              type="spin"
-              color="rgb(234 160 112)"
-              height={50}
-              width={50}
-            />
+            <KeepLoader loadingText="Loading workflow execution results..." />
           </div>
         )}
       </div>

--- a/keep-ui/package-lock.json
+++ b/keep-ui/package-lock.json
@@ -66,7 +66,6 @@
         "react-hook-form": "^7.54.2",
         "react-hotkeys-hook": "^4.5.0",
         "react-icons": "^5.5.0",
-        "react-loading": "^2.0.3",
         "react-loading-skeleton": "^3.3.1",
         "react-markdown": "^10.1.0",
         "react-name-initials-avatar": "^0.0.7",
@@ -23456,15 +23455,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/react-loading": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/react-loading/-/react-loading-2.0.3.tgz",
-      "integrity": "sha512-Vdqy79zq+bpeWJqC+xjltUjuGApyoItPgL0vgVfcJHhqwU7bAMKzysfGW/ADu6i0z0JiOCRJjo+IkFNkRNbA3A==",
-      "peerDependencies": {
-        "prop-types": "^15.6.0",
-        "react": ">=0.14.0"
-      }
     },
     "node_modules/react-loading-skeleton": {
       "version": "3.5.0",

--- a/keep-ui/package.json
+++ b/keep-ui/package.json
@@ -70,7 +70,6 @@
     "react-hook-form": "^7.54.2",
     "react-hotkeys-hook": "^4.5.0",
     "react-icons": "^5.5.0",
-    "react-loading": "^2.0.3",
     "react-loading-skeleton": "^3.3.1",
     "react-markdown": "^10.1.0",
     "react-name-initials-avatar": "^0.0.7",

--- a/keep-ui/shared/api/ApiClient.ts
+++ b/keep-ui/shared/api/ApiClient.ts
@@ -14,6 +14,7 @@ const READ_ONLY_ALWAYS_ALLOWED_URLS = [
   "/alerts/query",
   "/incidents/facets/options",
   "/workflows/query",
+  "/workflows/facets/options",
 ];
 
 interface ApiClientOptions {

--- a/keep-ui/widgets/workflow-builder/workflow-builder-widget.tsx
+++ b/keep-ui/widgets/workflow-builder/workflow-builder-widget.tsx
@@ -160,6 +160,7 @@ export function WorkflowBuilderWidget({
               icon={PlayIcon}
               disabled={!isValid}
               onClick={() => triggerRun()}
+              data-testid="wf-builder-main-test-run-button"
             >
               Test Run
             </Button>

--- a/tests/e2e_tests/test_end_to_end.py
+++ b/tests/e2e_tests/test_end_to_end.py
@@ -339,6 +339,42 @@ def test_add_workflow(browser: Page, setup_page_logging, failure_artifacts):
         raise
 
 
+def test_test_run_workflow(browser: Page):
+    """
+    Test to test run a workflow
+    """
+    page = browser
+    log_entries = []
+    setup_console_listener(page, log_entries)
+    try:
+        init_e2e_test(browser, next_url="/signin")
+        page.get_by_role("link", name="Workflows").click()
+        page.get_by_role("button", name="Create Workflow").click()
+        page.wait_for_url("http://localhost:3000/workflows/builder")
+        page.get_by_placeholder("Set the name").click()
+        page.get_by_placeholder("Set the name").press("ControlOrMeta+a")
+        page.get_by_placeholder("Set the name").fill("Test Run Workflow")
+        page.get_by_placeholder("Set the name").press("Tab")
+        page.get_by_placeholder("Set the description").fill(
+            "Test Run workflow description"
+        )
+        page.get_by_test_id("wf-add-trigger-button").first.click()
+        page.get_by_text("Manual").click()
+        page.get_by_test_id("wf-add-step-button").first.click()
+        page.get_by_placeholder("Search...").click()
+        page.get_by_placeholder("Search...").fill("cons")
+        page.get_by_text("console-action").click()
+        page.get_by_placeholder("message", exact=True).click()
+        page.get_by_placeholder("message", exact=True).fill("Hello world!")
+        page.get_by_test_id("wf-editor-configure-save-button").click()
+        page.wait_for_url(re.compile(r"http://localhost:3000/workflows/(?!builder).*"))
+        page.get_by_text("Builder").click()
+        page.get_by_test_id("wf-builder-main-test-run-button").click()
+        page.wait_for_selector("text=Workflow Execution Results")
+    except Exception:
+        save_failure_artifacts(page, log_entries)
+        raise
+
 def test_paste_workflow_yaml_quotes_preserved(browser: Page):
     # browser is actually a page object
     page = browser


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4078 

Before:

https://github.com/user-attachments/assets/00275178-de5b-4b14-8fcd-23831886740b

After:

https://github.com/user-attachments/assets/8cc75d48-74cd-4f53-8ce7-1b15d76c5bdb

