### PR TITLE
fix: Add support for record type in workflow model validation

### DIFF
--- a/keep-ui/entities/workflows/model/types.ts
+++ b/keep-ui/entities/workflows/model/types.ts
@@ -129,6 +129,7 @@ export const V2StepStepSchema = z.object({
           z.string(),
           z.number(),
           z.boolean(),
+          z.record(z.string(), z.any()),
           z.object({}),
           z.array(z.any()),
         ])


### PR DESCRIPTION
Extend the workflow model types to include `z.record` for better handling of key-value structured data. This enhances flexibility and aligns with the expected data structures in workflows.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4088 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
