### PR TITLE
fix: incorrect isCandidate prop in IncidentAlerts component

### DIFF
--- a/keep-ui/app/(keep)/incidents/[id]/alerts/incident-alerts.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/alerts/incident-alerts.tsx
@@ -247,7 +247,7 @@ export default function IncidentAlerts({ incident }: Props) {
                   }
                 }
               }}
-              isCandidate={!incident.is_candidate}
+              isCandidate={incident.is_candidate}
             />
           </div>
         ),


### PR DESCRIPTION
Corrected the logic for the isCandidate prop by aligning its value with the `incident.is_candidate` field. This ensures the component behaves as expected based on the incident's candidate status.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4075

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
