### PR TITLE
fix: Handle StaleDataError with retries in database updates.

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -41,6 +41,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import joinedload, subqueryload
+from sqlalchemy.orm.exc import StaleDataError
 from sqlalchemy.sql import exists, expression
 from sqlmodel import Session, SQLModel, col, or_, select, text
 
@@ -2511,6 +2512,7 @@ def get_last_alert_hashes_by_fingerprints(
 def update_key_last_used(
     tenant_id: str,
     reference_id: str,
+    max_retries=3,
 ) -> str:
     """
     Updates API key last used.
@@ -2542,8 +2544,22 @@ def update_key_last_used(
             )
             return
         tenant_api_key_entry.last_used = datetime.utcnow()
-        session.add(tenant_api_key_entry)
-        session.commit()
+
+        for attempt in range(max_retries):
+            try:
+                session.add(tenant_api_key_entry)
+                session.commit()
+            except StaleDataError as ex:
+                if "expected to update" in ex.args[0]:
+                    logger.info(
+                        f"Phantom read detected while updating API key `{reference_id}`, retry #{attempt}"
+                    )
+                    session.rollback()
+                    continue
+                else:
+                    raise
+
+
 
 
 def get_linked_providers(tenant_id: str) -> List[Tuple[str, str, datetime]]:
@@ -3978,6 +3994,7 @@ def add_alerts_to_incident(
     session: Optional[Session] = None,
     override_count: bool = False,
     exclude_unlinked_alerts: bool = False,  # if True, do not add alerts to incident if they are manually unlinked
+    max_retries=3,
 ) -> Optional[Incident]:
     logger.info(
         f"Adding alerts to incident {incident.id} in database, total {len(fingerprints)} alerts",
@@ -4117,8 +4134,19 @@ def add_alerts_to_incident(
             incident.start_time = started_at
             incident.last_seen_time = last_seen_at
 
-            session.add(incident)
-            session.commit()
+            for attempt in range(max_retries):
+                try:
+                    session.add(incident)
+                    session.commit()
+                except StaleDataError as ex:
+                    if "expected to update" in ex.args[0]:
+                        logger.info(
+                            f"Phantom read detected while updating incident `{incident.id}`, retry #{attempt}"
+                        )
+                        session.rollback()
+                        continue
+                    else:
+                        raise
             session.refresh(incident)
 
             return incident


### PR DESCRIPTION
Introduced retry logic to address StaleDataError during `session.commit` in `update_key_last_used` and `add_alerts_to_incident` functions. This ensures resilience against phantom reads by retrying up to a maximum number of attempts. Added `max_retries` parameter to allow configuration of retry limits.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4152 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
