### PR TITLE
fix: Add safe_run_worker to handle Redis connection errors

### DIFF
--- a/keep/api/api.py
+++ b/keep/api/api.py
@@ -24,7 +24,7 @@ from starlette_context.middleware import RawContextMiddleware
 import keep.api.logging
 import keep.api.observability
 import keep.api.utils.import_ee
-from keep.api.arq_worker import get_arq_worker
+from keep.api.arq_worker import get_arq_worker, safe_run_worker
 from keep.api.consts import (
     KEEP_ARQ_QUEUE_BASIC,
     KEEP_ARQ_TASK_POOL,
@@ -167,11 +167,11 @@ async def startup():
         if KEEP_ARQ_TASK_POOL == KEEP_ARQ_TASK_POOL_ALL:
             logger.info("Starting all task pools")
             basic_worker = get_arq_worker(KEEP_ARQ_QUEUE_BASIC)
-            event_loop.create_task(basic_worker.async_run())
+            event_loop.create_task(safe_run_worker(basic_worker))
         elif KEEP_ARQ_TASK_POOL == KEEP_ARQ_TASK_POOL_BASIC_PROCESSING:
             logger.info("Starting Basic Processing task pool")
             arq_worker = get_arq_worker(KEEP_ARQ_QUEUE_BASIC)
-            event_loop.create_task(arq_worker.async_run())
+            event_loop.create_task(safe_run_worker(arq_worker))
         else:
             raise ValueError(f"Invalid task pool: {KEEP_ARQ_TASK_POOL}")
 


### PR DESCRIPTION
Introduced a safe_run_worker function to manage Redis connection errors with retries, enhancing worker reliability. Updated task pool execution to use safe_run_worker instead of async_run, ensuring improved fault tolerance during Redis failures.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4155 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
