### PR TITLE
fix: Refactor incident resolution logic to handle active statuses.

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -3685,12 +3685,12 @@ def create_incident_from_dto(
 
 
 def create_incident_from_dict(
-    tenant_id: str, incident_data: dict
+    tenant_id: str, incident_data: dict, session: Optional[Session] = None
 ) -> Optional[Incident]:
     is_predicted = incident_data.get("is_predicted", False)
     if "is_candidate" not in incident_data:
         incident_data["is_candidate"] = is_predicted
-    with Session(engine) as session:
+    with existed_or_new_session(session) as session:
         new_incident = Incident(**incident_data, tenant_id=tenant_id)
         session.add(new_incident)
         session.commit()

--- a/keep/api/models/db/incident.py
+++ b/keep/api/models/db/incident.py
@@ -60,6 +60,20 @@ class IncidentStatus(enum.Enum):
     # Incident was removed
     DELETED = "deleted"
 
+    @classmethod
+    def get_active(cls, return_values=False) -> List[str | enum.Enum]:
+        statuses = [cls.FIRING, cls.ACKNOWLEDGED]
+        if return_values:
+            return [s.value for s in statuses]
+        return statuses
+
+    @classmethod
+    def get_closed(cls, return_values=False) -> List[str | enum.Enum]:
+        statuses = [cls.RESOLVED, cls.MERGED, cls.DELETED]
+        if return_values:
+            return [s.value for s in statuses]
+        return statuses
+
 
 class Incident(SQLModel, table=True):
     id: UUID = Field(default_factory=uuid4, primary_key=True)

--- a/keep/api/tasks/process_event_task.py
+++ b/keep/api/tasks/process_event_task.py
@@ -42,6 +42,7 @@ from keep.api.core.metrics import (
 from keep.api.models.action_type import ActionType
 from keep.api.models.alert import AlertDto, AlertStatus
 from keep.api.models.db.alert import Alert, AlertAudit, AlertRaw
+from keep.api.models.db.incident import IncidentStatus
 from keep.api.models.incident import IncidentDto
 from keep.api.tasks.notification_cache import get_notification_cache
 from keep.api.utils.enrichment_helpers import (
@@ -278,9 +279,10 @@ def __save_to_db(
                         extra={"alert_id": alert.id, "tenant_id": tenant_id},
                     )
                     for incident in alert._incidents:
-                        IncidentBl(tenant_id, session).resolve_incident_if_require(
-                            incident
-                        )
+                        if incident.status in IncidentStatus.get_active(return_values=True):
+                            IncidentBl(tenant_id, session).resolve_incident_if_require(
+                                incident
+                            )
             logger.info(
                 "Completed checking for incidents to resolve",
                 extra={"tenant_id": tenant_id},


### PR DESCRIPTION
Added a helper method `get_active` to the `IncidentStatus` model to identify active statuses. Updated incident resolution to only apply to incidents with active statuses. Added test cases to validate the behavior and refactored session handling in `create_incident_from_dict`.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4158 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
