### PR TITLE
fix: retry loops by adding break statements after commits

### DIFF
--- a/keep/api/bl/incidents_bl.py
+++ b/keep/api/bl/incidents_bl.py
@@ -444,6 +444,7 @@ class IncidentBl:
                     incident.status = IncidentStatus.RESOLVED.value
                 self.session.add(incident)
                 self.session.commit()
+                break
             except StaleDataError as ex:
                 if "expected to update" in ex.args[0]:
                     self.logger.info(

--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -2549,6 +2549,7 @@ def update_key_last_used(
             try:
                 session.add(tenant_api_key_entry)
                 session.commit()
+                break
             except StaleDataError as ex:
                 if "expected to update" in ex.args[0]:
                     logger.info(
@@ -4138,6 +4139,7 @@ def add_alerts_to_incident(
                 try:
                     session.add(incident)
                     session.commit()
+                    break
                 except StaleDataError as ex:
                     if "expected to update" in ex.args[0]:
                         logger.info(
@@ -5321,6 +5323,7 @@ def set_last_alert(
 
                 session.add(last_alert)
                 session.commit()
+                break
             except OperationalError as ex:
                 if "no such savepoint" in ex.args[0]:
                     logger.info(

--- a/keep/api/tasks/process_event_task.py
+++ b/keep/api/tasks/process_event_task.py
@@ -272,6 +272,8 @@ def __save_to_db(
             saved_alerts = enrich_alerts_with_incidents(
                 tenant_id, saved_alerts, session
             )  # note: this only enriches incidents that were not yet ended
+
+            incident_bl = IncidentBl(tenant_id, session)
             for alert in saved_alerts:
                 if alert.event.get("status") == AlertStatus.RESOLVED.value:
                     logger.debug(
@@ -280,7 +282,7 @@ def __save_to_db(
                     )
                     for incident in alert._incidents:
                         if incident.status in IncidentStatus.get_active(return_values=True):
-                            IncidentBl(tenant_id, session).resolve_incident_if_require(
+                            incident_bl.resolve_incident_if_require(
                                 incident
                             )
             logger.info(


### PR DESCRIPTION
Added break statements to exit loops after successful commit operations, preventing infinite retries in case of StaleDataError or similar exceptions. Also refactored incident resolution logic in `process_event_task.py` for efficiency by reusing the IncidentBl object.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4160

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
