### PR TITLE
fix(provision): Use the provider name as the key in the deduplication rules enrichment logic

### DIFF
--- a/docs/deployment/provision/provider.mdx
+++ b/docs/deployment/provision/provider.mdx
@@ -21,19 +21,19 @@ Providers provisioning JSON example:
     "type": "victoriametrics",
     "authentication": {
       "VMAlertHost": "http://localhost",
-      "VMAlertPort": 1234,
-      "deduplication_rules": {
-        "deduplication rule name example 1": {
-          "description": "deduplication rule name example 1",
-          "fingerprint_fields": ["fingerprint", "source", "service"],
-          "full_deduplication": true,
-          "ignore_fields": ["name", "lastReceived"]
-        },
-        "deduplication rule name example 2": {
-          "description": "deduplication rule name example 2",
-          "fingerprint_fields": ["fingerprint", "source", "service"],
-          "full_deduplication": false,
-        }
+      "VMAlertPort": 1234
+    },
+    "deduplication_rules": {
+      "deduplication rule name example 1": {
+        "description": "deduplication rule name example 1",
+        "fingerprint_fields": ["fingerprint", "source", "service"],
+        "full_deduplication": true,
+        "ignore_fields": ["name", "lastReceived"]
+      },
+      "deduplication rule name example 2": {
+        "description": "deduplication rule name example 2",
+        "fingerprint_fields": ["fingerprint", "source", "service"],
+        "full_deduplication": false,
       }
     }
   },

--- a/keep/api/alert_deduplicator/deduplication_rules_provisioning.py
+++ b/keep/api/alert_deduplicator/deduplication_rules_provisioning.py
@@ -111,14 +111,11 @@ def enrich_with_providers_info(deduplication_rules: list[dict[str,any]], tenant_
     """
 
     installed_providers = ProvidersFactory.get_installed_providers(tenant_id)
-    linked_providers = ProvidersFactory.get_linked_providers(tenant_id)
-    all_providers = installed_providers + linked_providers
-    all_providers_dict = {f"{provider.type}_{provider.display_name}": provider for provider in all_providers}
+    installed_providers_dict = {provider.details.get("name"): provider for provider in installed_providers}
 
     for rule_name, rule in deduplication_rules.items():
-        print('f')
-        provider_dict_key = f"{rule.get('provider_type')}_{rule.get('provider_name')}"
-        provider = all_providers_dict.get(provider_dict_key)
+        logger.info(f"Enriching deduplication rule: {rule_name}")
+        provider = installed_providers_dict.get(rule.get("provider_name"))
         rule["provider_id"] = provider.id
         rule["provider_type"] = provider.type
 

--- a/keep/api/models/provider.py
+++ b/keep/api/models/provider.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Literal
+from typing import Literal, Any
 
 from pydantic import BaseModel, Field
 
@@ -16,7 +16,7 @@ class Provider(BaseModel):
     display_name: str
     type: str
     config: dict[str, dict] = Field(default_factory=dict)
-    details: dict[str, dict] | None = None
+    details: dict[str, Any] | None = None
     can_notify: bool
     # TODO: consider making it strongly typed for UI validations
     notify_params: list[str] | None = None

--- a/tests/deduplication/test_deduplications_provisioning.py
+++ b/tests/deduplication/test_deduplications_provisioning.py
@@ -23,7 +23,7 @@ def setup(monkeypatch):
                 }
             }
         },
-        "Linked Grafana provider": {
+        "Installed Grafana provider": {
             "type": "grafana",
             "deduplication_rules": {
                 "fake new deduplication rule": {
@@ -38,30 +38,39 @@ def setup(monkeypatch):
     deduplication_rules_in_db = [
         AlertDeduplicationRule(
             id=UUID("f3a2b76c8430491da71684de9cf257ab"),
+            tenant_id="fake_tenant_id",
             name="provisioned fake existing deduplication rule",
             description="provisioned fake existing deduplication rule description",
             provider_id="edc4d65d53204cefb511321be98f748e",
             provider_type="prometheus",
+            last_updated_by="system",
+            created_by="system",
             fingerprint_fields=["fingerprint", "source", "service"],
             full_deduplication=False,
             is_provisioned=True,
         ),
         AlertDeduplicationRule(
             id=UUID("a5d8f32b6c7049efb913c21da7e845fd"),
+            tenant_id="fake_tenant_id",
             name="provisioned fake deduplication rule to delete",
             description="fake new deduplication rule description",
             provider_id="a1b2c3d4e5f64789ab1234567890abcd",
             provider_type="grafana",
+            last_updated_by="system",
+            created_by="system",
             fingerprint_fields=["fingerprint"],
             full_deduplication=False,
             is_provisioned=True,
         ),
         AlertDeduplicationRule(
             id=UUID("c7e3d28f95104b6a8f12dc45eb7639fa"),
+            tenant_id="fake_tenant_id",
             name="not provisioned fake deduplication rule",
             description="not provisioned fake deduplication rule",
             provider_id="a1b2c3d4e5f64789ab1234567890abcd",
             provider_type="grafana",
+            last_updated_by="user",
+            created_by="user",
             fingerprint_fields=["fingerprint"],
             full_deduplication=False,
             is_provisioned=False,
@@ -70,31 +79,35 @@ def setup(monkeypatch):
     installed_providers = [
         Provider(
             id="edc4d65d53204cefb511321be98f748e",
-            name="Installed Prometheus provider",
-            display_name="Installed Prometheus provider",
+            display_name="Prometheus",
             type="prometheus",
-            enabled=True,
+            details={"name": "Installed Prometheus provider"},
             can_query=True,
             can_notify=True,
         ),
         Provider(
             id="p2b2c3d4e5f64789ab1234567890abcd",
-            name="Installed Prometheus provider second",
-            display_name="Installed Prometheus provider",
+            display_name="Prometheus",
             type="prometheus",
-            enabled=True,
+            details={"name": "Installed Prometheus provider second"},
             can_query=True,
             can_notify=True,
         ),
+        Provider(
+            id="a1b2c3d4e5f64789ab1234567890abcd",
+            display_name="Grafana",
+            type="grafana",
+            details={"name": "Installed Grafana provider"},
+            can_query=True,
+            can_notify=True,
+        )
     ]
 
     linked_providers = [
         Provider(
-            id="a1b2c3d4e5f64789ab1234567890abcd",
-            name="Linked Grafana provider",
-            display_name="Linked Grafana provider",
+            id="abcda1b2c3d4e5f64789ab1234567890",
+            display_name="Grafana",
             type="grafana",
-            enabled=True,
             can_query=True,
             can_notify=True,
         )
@@ -168,7 +181,7 @@ def test_provisioning_of_existing_rule(setup):
         rule_id=str(UUID("f3a2b76c8430491da71684de9cf257ab")),
         name="provisioned fake existing deduplication rule",
         description="new description",
-        provider_id="p2b2c3d4e5f64789ab1234567890abcd",
+        provider_id="edc4d65d53204cefb511321be98f748e",
         provider_type="prometheus",
         last_updated_by="system",
         enabled=True,


### PR DESCRIPTION
Closes #4175

## 📑 Description
Currently, there is a mismatch between the key of `all_providers_dict` and `provider_dict_key`: the provider display name is not equal to the provider name.
The provider provisioning already uses the provider name as an identity: https://github.com/keephq/keep/blob/04fdc95226696e43d52d51d8d24dc0c24c29f101/keep/providers/providers_service.py#L392
Therefore, we can cascade this to the deduplication rules provisioning.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed