### PR TITLE
feat: add html & markdown compability in alert's description

### DIFF
--- a/keep-ui/app/(keep)/alerts/alert-create-incident-ai-card.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-create-incident-ai-card.tsx
@@ -24,6 +24,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { AlertDto } from "@/entities/alerts/model";
 import { IncidentCandidateDto } from "@/entities/incidents/model";
+import { FormattedContent } from "@/shared/ui/FormattedContent/FormattedContent";
 
 interface IncidentCardProps {
   incident: IncidentCandidateDto;
@@ -89,13 +90,18 @@ const DraggableAlertRow: React.FC<DraggableAlertRowProps> = ({
       style={style}
       {...attributes}
       {...listeners}
-      className={`${isDragging ? "bg-gray-50" : ""} hover:bg-gray-50 transition-colors`}
+      className={`${
+        isDragging ? "bg-gray-50" : ""
+      } hover:bg-gray-50 transition-colors`}
     >
       <TableCell className="w-1/6 break-words">
         {alert.name || "Unnamed Alert"}
       </TableCell>
       <TableCell className="w-2/3 break-words whitespace-normal">
-        {alert.description || "No description"}
+        <FormattedContent
+          content={alert.description || "No description"}
+          format={alert.description_format}
+        />
       </TableCell>
       <TableCell className="w-1/12 break-words">
         {alert.severity || "N/A"}
@@ -204,7 +210,10 @@ const IncidentCard: React.FC<IncidentCardProps> = ({
           <Title>{editedIncident.name || "Unnamed Incident"}</Title>
           <Subtitle className="mt-2">Description</Subtitle>
           <Text className="mt-2">
-            {editedIncident.description || "No description"}
+            <FormattedContent
+              content={editedIncident.description || "No description"}
+              format={editedIncident.description_format}
+            />
           </Text>
           <Subtitle className="mt-2">Severity</Subtitle>
           <Badge color="orange">{editedIncident.severity || "N/A"}</Badge>

--- a/keep-ui/app/(keep)/alerts/alert-create-incident-ai-modal.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-create-incident-ai-modal.tsx
@@ -21,6 +21,7 @@ import { useIncidents } from "utils/hooks/useIncidents";
 import { useRouter } from "next/navigation";
 import { useApi } from "@/shared/lib/hooks/useApi";
 import { KeepApiError } from "@/shared/api";
+import { FormattedContent } from "@/shared/ui/FormattedContent/FormattedContent";
 
 interface CreateIncidentWithAIModalProps {
   isOpen: boolean;
@@ -372,7 +373,10 @@ const CreateIncidentWithAIModal = ({
                       {activeAlert.name || "Unnamed Alert"}
                     </div>
                     <div className="w-2/3 break-words whitespace-normal text-gray-600">
-                      {activeAlert.description || "No description"}
+                      <FormattedContent
+                        content={activeAlert.description || "No description"}
+                        format={activeAlert.description_format}
+                      />
                     </div>
                     <div className="w-1/12 break-words">
                       <span className="bg-orange-100 text-orange-800 px-2 py-1 rounded text-sm">

--- a/keep-ui/app/(keep)/alerts/alert-sidebar.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-sidebar.tsx
@@ -14,6 +14,7 @@ import { DynamicImageProviderIcon } from "@/components/ui";
 import { useProviders } from "@/utils/hooks/useProviders";
 import AlertMenu from "./alert-menu";
 import { useConfig } from "@/utils/hooks/useConfig";
+import { FormattedContent } from "@/shared/ui/FormattedContent/FormattedContent";
 
 type AlertSidebarProps = {
   isOpen: boolean;
@@ -133,9 +134,10 @@ const AlertSidebar = ({
                   </p>
                   <p>
                     <FieldHeader>Description</FieldHeader>
-                    <pre className="whitespace-pre-wrap">
-                      {alert.description}
-                    </pre>
+                    <FormattedContent
+                      content={alert.description}
+                      format={alert.description_format}
+                    />
                   </p>
                   <p>
                     <FieldHeader className="flex items-center gap-1">

--- a/keep-ui/app/(keep)/incidents/[id]/timeline/incident-timeline.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/timeline/incident-timeline.tsx
@@ -18,6 +18,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { DynamicImageProviderIcon } from "@/components/ui";
 import { CiViewTimeline } from "react-icons/ci";
 import { EmptyStateCard } from "@/shared/ui";
+import { FormattedContent } from "@/shared/ui/FormattedContent/FormattedContent";
 
 const severityColors = {
   critical: "bg-red-300",
@@ -60,7 +61,12 @@ const AlertEventInfo: React.FC<{ event: AuditEvent; alert: AlertDto }> = ({
   return (
     <div className="h-full p-4 bg-gray-100 border-l">
       <h2 className="font-semibold mb-2">{alert.name}</h2>
-      <p className="mb-2 text-md">{alert.description}</p>
+      <p className="mb-2 text-md">
+        <FormattedContent
+          content={alert.description}
+          format={alert.description_format}
+        />
+      </p>
       <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
         <p className="text-gray-400">Date:</p>
         <p>

--- a/keep-ui/entities/alerts/model/models.tsx
+++ b/keep-ui/entities/alerts/model/models.tsx
@@ -46,6 +46,7 @@ export interface AlertDto {
   source: string[];
   message?: string;
   description?: string;
+  description_format?: "markdown" | "html" | null;
   severity?: Severity;
   url?: string;
   imageUrl?: string;

--- a/keep-ui/entities/incidents/model/models.ts
+++ b/keep-ui/entities/incidents/model/models.ts
@@ -80,6 +80,7 @@ export interface IncidentCandidateDto {
   id: string;
   name: string;
   description: string;
+  description_format?: "markdown" | "html" | null;
   severity: string;
   confidence_score: number;
   confidence_explanation: string;

--- a/keep-ui/shared/ui/FormattedContent/FormattedContent.tsx
+++ b/keep-ui/shared/ui/FormattedContent/FormattedContent.tsx
@@ -1,0 +1,57 @@
+import React, { FC } from "react";
+import ReactMarkdown from "react-markdown";
+
+interface FormattedContentProps {
+  content: string | null | undefined;
+  format?: "markdown" | "html" | null;
+}
+
+export const FormattedContent: FC<FormattedContentProps> = ({
+  content,
+  format,
+}) => {
+  if (!content) {
+    return null;
+  }
+
+  if (format === "markdown") {
+    return (
+      <div
+        className="prose prose-slate dark:prose-invert max-w-none
+        prose-headings:font-semibold
+        prose-h1:text-3xl prose-h1:mb-4
+        prose-h2:text-2xl prose-h2:mb-3
+        prose-h3:text-xl prose-h3:mb-2
+        prose-p:text-base prose-p:leading-7 prose-p:mb-4
+        prose-ul:my-4 prose-ul:list-disc prose-ul:pl-6
+        prose-ol:my-4 prose-ol:list-decimal prose-ol:pl-6
+        prose-li:my-1
+        prose-pre:bg-gray-100 dark:prose-pre:bg-gray-800 prose-pre:p-4 prose-pre:rounded-lg
+        prose-code:text-sm prose-code:bg-gray-100 dark:prose-code:bg-gray-800 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded
+        prose-a:text-blue-600 dark:prose-a:text-blue-400 prose-a:no-underline hover:prose-a:underline"
+      >
+        <ReactMarkdown>{content}</ReactMarkdown>
+      </div>
+    );
+  }
+
+  if (format === "html") {
+    return (
+      <div
+        className="prose prose-slate dark:prose-invert max-w-none
+          prose-headings:font-semibold
+          prose-p:text-base prose-p:leading-7
+          prose-ul:list-disc prose-ul:pl-6
+          prose-ol:list-decimal prose-ol:pl-6"
+        dangerouslySetInnerHTML={{ __html: content }}
+      />
+    );
+  }
+
+  // Default to plain text with preserved whitespace
+  return (
+    <pre className="whitespace-pre-wrap text-base text-gray-700 dark:text-gray-300">
+      {content}
+    </pre>
+  );
+};

--- a/keep/api/models/alert.py
+++ b/keep/api/models/alert.py
@@ -82,6 +82,7 @@ class AlertDto(BaseModel):
     apiKeyRef: str | None = None
     message: str | None = None
     description: str | None = None
+    description_format: str | None = None  # Can be 'markdown' or 'html'
     pushed: bool = False  # Whether the alert was pushed or pulled from the provider
     event_id: str | None = None  # Database alert id
     url: AnyHttpUrl | None = None
@@ -219,6 +220,15 @@ class AlertDto(BaseModel):
         )
         return dismissed
 
+    @validator("description_format")
+    def validate_description_format(cls, description_format):
+        if description_format is None:
+            return None
+        valid_formats = ["markdown", "html"]
+        if description_format not in valid_formats:
+            raise ValueError(f"description_format must be one of {valid_formats}")
+        return description_format
+
     @root_validator(pre=True)
     def set_default_values(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         # Check and set id:
@@ -292,6 +302,7 @@ class AlertDto(BaseModel):
                     "source": ["prometheus"],
                     "message": "The pod 'api-service-production' lacks memory causing high error rate",
                     "description": "Due to the lack of memory, the pod 'api-service-production' is experiencing high error rate",
+                    "description_format": "markdown",
                     "severity": "critical",
                     "pushed": True,
                     "url": "https://www.keephq.dev?alertId=1234",

--- a/keep/api/models/alert.py
+++ b/keep/api/models/alert.py
@@ -302,7 +302,6 @@ class AlertDto(BaseModel):
                     "source": ["prometheus"],
                     "message": "The pod 'api-service-production' lacks memory causing high error rate",
                     "description": "Due to the lack of memory, the pod 'api-service-production' is experiencing high error rate",
-                    "description_format": "markdown",
                     "severity": "critical",
                     "pushed": True,
                     "url": "https://www.keephq.dev?alertId=1234",


### PR DESCRIPTION
Closes #4167

## 📑 Description
Add HTML & Markdown compatibility in Keep's alert description.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information

### Markdown Display

Configuring the below description format will result in the markdown formatted:

```bash
"description": "### High CPU Usage Detected\n\n**Server:** web-server-1\n**Time:** 2024-03-21 14:30 UTC\n**Usage:** 95%\n\n#### Details\n- Current Usage: 95%\n- Threshold: 80%\n- Duration: 15 minutes\n\n##### Recommended Actions\n1. Check running processes\n2. Review recent deployments\n3. Scale up resources if needed",
"description_format": "markdown"
```

<img width="719" alt="image" src="https://github.com/user-attachments/assets/beba8f5a-f51f-4c46-8765-939c5770a173" />

### HTML Display

Configuring the below description format will result in the html formatted:

```bash
"description": "<div class=\"prose prose-slate\"><h2>Database Connection Failed</h2><p>Multiple connection attempts to the primary database have failed.</p><h3>Error Details</h3><ul><li><strong>Database:</strong> users-db-prod</li><li><strong>Error:</strong> Connection timeout</li><li><strong>Failed Attempts:</strong> 5</li></ul><h3>Stack Trace</h3><pre><code>ConnectionError: Failed to connect to database\nat Database.connect (/src/db.js:123)\nat Server.start (/src/server.js:45)</code></pre><blockquote>Note: This is affecting user authentication services</blockquote></div>",
"description_format": "html",
```

<img width="722" alt="image" src="https://github.com/user-attachments/assets/051993ae-528f-41f8-9b06-d2f9b2ba3f67" />
