### PR TITLE
fix: refactor add_alerts_to_incident and remove add_alerts_to_incident_by_incident_id function

### DIFF
--- a/keep/api/bl/incidents_bl.py
+++ b/keep/api/bl/incidents_bl.py
@@ -15,7 +15,7 @@ from sqlmodel import Session
 from keep.api.arq_pool import get_pool
 from keep.api.bl.enrichments_bl import EnrichmentsBl
 from keep.api.core.db import (
-    add_alerts_to_incident_by_incident_id,
+    add_alerts_to_incident,
     add_audit,
     create_incident_from_dto,
     delete_incident_by_id,
@@ -132,12 +132,20 @@ class IncidentBl:
                 "alert_fingerprints": alert_fingerprints,
             },
         )
-        incident = get_incident_by_id(tenant_id=self.tenant_id, incident_id=incident_id)
+        incident = get_incident_by_id(
+            tenant_id=self.tenant_id,
+            incident_id=incident_id,
+            session=self.session
+        )
         if not incident:
             raise HTTPException(status_code=404, detail="Incident not found")
 
-        add_alerts_to_incident_by_incident_id(
-            self.tenant_id, incident_id, alert_fingerprints, is_created_by_ai
+        add_alerts_to_incident(
+            self.tenant_id,
+            incident,
+            alert_fingerprints,
+            is_created_by_ai,
+            session=self.session
         )
         self.logger.info(
             "Alerts added to incident",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,7 +1,7 @@
 import pytest
 
 from keep.api.core.db import (
-    add_alerts_to_incident_by_incident_id,
+    add_alerts_to_incident,
     create_incident_from_dict,
 )
 from tests.fixtures.client import client, setup_api_key, test_app  # noqa
@@ -18,8 +18,8 @@ def test_add_remove_alert_to_incidents(
     valid_api_key = "valid_api_key"
     setup_api_key(db_session, valid_api_key)
 
-    add_alerts_to_incident_by_incident_id(
-        "keep", incident.id, [a.fingerprint for a in alerts]
+    add_alerts_to_incident(
+        "keep", incident, [a.fingerprint for a in alerts]
     )
 
     response = client.get("/metrics?labels=a.b", headers={"X-API-KEY": "valid_api_key"})


### PR DESCRIPTION
The function was redundant and removed to simplify the codebase. All calls were replaced with add_alerts_to_incident, improving consistency and code maintainability across modules and tests.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4204 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
