### PR TITLE
fix: incident resolution check in enrich_alert step

### DIFF
--- a/keep/providers/base/base_provider.py
+++ b/keep/providers/base/base_provider.py
@@ -288,7 +288,8 @@ class BaseProvider(metaclass=abc.ABCMeta):
                 **common_kwargs
             )
 
-            should_check_incidents_resolution = enrichments.get("status", None) == "resolved"
+            should_check_incidents_resolution = (_enrichments.get("status", None) == "resolved"
+                                                 or disposable_enrichments.get("status", None) == "resolved")
 
             if event and should_check_incidents_resolution:
                 enrichments_bl.check_incident_resolution(event)


### PR DESCRIPTION
Previously, the resolution check only considered `_enrichments`. This update expands it to also account for `disposable_enrichments` status to ensure more comprehensive incident handling logic.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4211 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
