### PR TITLE
fix: rm excessive "+ New" button from workflow builder

### DIFF
--- a/keep-ui/widgets/workflow-builder/workflow-builder-widget.tsx
+++ b/keep-ui/widgets/workflow-builder/workflow-builder-widget.tsx
@@ -6,7 +6,6 @@ import {
   ArrowUpOnSquareIcon,
   PencilIcon,
   PlayIcon,
-  PlusIcon,
 } from "@heroicons/react/20/solid";
 import { WorkflowBuilderCard } from "./workflow-builder-card";
 import { showErrorToast } from "@/shared/ui";
@@ -54,15 +53,6 @@ export function WorkflowBuilderWidget({
   function loadWorkflow() {
     if (fileInputRef.current) {
       fileInputRef.current.click();
-    }
-  }
-
-  function createNewWorkflow() {
-    const confirmed = confirm(
-      "Are you sure you want to create a new workflow?"
-    );
-    if (confirmed) {
-      window.location.reload();
     }
   }
 
@@ -120,24 +110,13 @@ export function WorkflowBuilderWidget({
                 <Button
                   color="orange"
                   size="md"
-                  onClick={createNewWorkflow}
-                  icon={PlusIcon}
-                  className="min-w-28"
-                  variant="secondary"
-                  disabled={!isInitialized}
-                >
-                  New
-                </Button>
-                <Button
-                  color="orange"
-                  size="md"
                   onClick={loadWorkflow}
                   className="min-w-28"
                   variant="secondary"
                   icon={ArrowUpOnSquareIcon}
                   disabled={!isInitialized}
                 >
-                  Load
+                  Import from YAML
                 </Button>
                 <input
                   type="file"


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3677  <!-- Issue # here -->

## Before

![image](https://github.com/user-attachments/assets/fc4c3d61-dcb6-4a6e-a63e-b38314d2b22d)


## After

No more confusing button and Load button renamed to more clean "Import from YAML"

<img width="1552" alt="Screenshot 2025-03-27 at 12 37 05" src="https://github.com/user-attachments/assets/78e53bda-eb99-4dd5-8c7a-42fe236636d3" />
