### PR TITLE
fix: Enhance column rename fallback with formatted names

### DIFF
--- a/keep-ui/app/(keep)/alerts/alert-table-column-rename.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-table-column-rename.tsx
@@ -2,6 +2,8 @@ import React, { useState, useRef, useEffect } from "react";
 import { CheckIcon, PencilIcon } from "@heroicons/react/24/outline";
 import { TextInput, Button } from "@tremor/react";
 
+import { startCase } from "lodash";
+
 // Type definition for column rename mapping
 export type ColumnRenameMapping = Record<string, string>;
 
@@ -166,5 +168,5 @@ export const getColumnDisplayName = (
   originalName: string,
   columnRenameMapping: ColumnRenameMapping
 ): string => {
-  return columnRenameMapping[columnId] || originalName;
+  return columnRenameMapping[columnId] || startCase(originalName);
 };


### PR DESCRIPTION
Improved the fallback logic for column renames by applying `lodash`'s `startCase` function to original column names. This ensures a cleaner and more readable format when no custom rename is provided.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4239 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
