### PR TITLE
feat: allow using latest providerId and alter UI display

### DIFF
--- a/keep-ui/app/(keep)/alerts/alert-sidebar.tsx
+++ b/keep-ui/app/(keep)/alerts/alert-sidebar.tsx
@@ -128,9 +128,9 @@ const AlertSidebar = ({
                       providerType={alert.source![0]}
                       width={24}
                       height={24}
-                      className="inline-block w-6 h-6"
+                      className="inline-block w-6 h-6 mr-2"
                     />
-                    {providerName}
+                    <span>{providerName}</span>
                   </p>
                   <p>
                     <FieldHeader>Description</FieldHeader>

--- a/keep-ui/app/(keep)/providers/provider-tile.tsx
+++ b/keep-ui/app/(keep)/providers/provider-tile.tsx
@@ -231,7 +231,7 @@ export default function ProviderTile({ provider, onClick }: Props) {
 
             {provider.details && provider.details.name && (
               <Subtitle className="truncate">
-                id: {provider.details.name}
+                Name: {provider.details.name}
               </Subtitle>
             )}
             {provider.last_alert_received ? (
@@ -243,7 +243,7 @@ export default function ProviderTile({ provider, onClick }: Props) {
               <p></p>
             )}
             {provider.linked && provider.id ? (
-              <Text className="truncate">Id: {provider.id}</Text>
+              <Text className="truncate">Name: {provider.id}</Text>
             ) : null}
             {renderChart()}
           </div>

--- a/keep/api/utils/enrichment_helpers.py
+++ b/keep/api/utils/enrichment_helpers.py
@@ -183,9 +183,8 @@ def convert_db_alerts_to_dto_alerts(
                 if alert_dto.status == AlertStatus.ACKNOWLEDGED.value:
                     alert_dto.firingCounter = 0
 
-                # enrich provider id when it's possible
-                if alert_dto.providerId is None:
-                    alert_dto.providerId = alert.provider_id
-                    alert_dto.providerType = alert.provider_type
+                # always update provider id and type to the new values
+                alert_dto.providerId = alert.provider_id
+                alert_dto.providerType = alert.provider_type
                 alerts_dto.append(alert_dto)
     return alerts_dto


### PR DESCRIPTION
Closes #4271

## 📑 Description

When provisioning a provider and sending an alert with an incorrect providerId (one that does not belong to the provisioned provider), the alert gets permanently associated with the wrong provider.

If the same alert is sent again (with partial deduplication) using the correct providerId, it still retains the previously assigned incorrect `providerId`. We should allow the providerId to be updated to the latest value.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
Here’s a clearer and more polished version of your text:  

I have configured alerts to be sent to Keep via a generic webhook endpoint. For the provisioned provider **A** with ID `123`, I decided to add the query parameter `?provider_id=123`.  

On the **Provider** page, each provider card was incorrectly displaying the `id` field instead of the `name` field. I have updated it to display the `name` field correctly.

**Before**

![image](https://github.com/user-attachments/assets/bc407fc0-8203-44af-8dc2-670f01d15883)

**After**

![image](https://github.com/user-attachments/assets/4b99417d-d55f-4619-bf12-294f5579af0c)

Additionally, the spacing between the icon and the provider name was too tight, affecting readability. I have added some spacing for better clarity.  

**Before**

![image](https://github.com/user-attachments/assets/1a55464f-981e-44c9-a26c-67a360174528)

**After**

![image](https://github.com/user-attachments/assets/cb16498c-f76d-4dfc-ae68-b1b3782de023)
