### PR TITLE
fix: Explicitly Use `.scalar_subquery()` to Prevent SQLAlchemy Warning  

### DIFF
--- a/keep/api/core/alerts.py
+++ b/keep/api/core/alerts.py
@@ -204,7 +204,8 @@ def get_threeshold_query(tenant_id: str):
         .where(LastAlert.tenant_id == tenant_id)
         .order_by(LastAlert.timestamp.desc())
         .limit(1)
-        .offset(alerts_hard_limit - 1),
+        .offset(alerts_hard_limit - 1)
+        .scalar_subquery(),
         datetime.datetime.min,
     )
 


### PR DESCRIPTION
#### Description  
This pull request fixes the following **SQLAlchemy warning** in Keep:  

```
/venv/lib/python3.11/site-packages/keep/api/core/alerts.py:184: SAWarning: implicitly coercing SELECT object to scalar subquery; please use the .scalar_subquery() method to produce a scalar subquery.
```  

The issue occurs because a **SELECT object is being implicitly coerced** when a scalar subquery is expected.  

#### Fix Details  
- Updated the affected query in `alerts.py` to explicitly use `.scalar_subquery()`, ensuring compatibility with SQLAlchemy’s best practices.  
- This prevents unnecessary warnings and potential future incompatibility with newer SQLAlchemy versions.  