### PR TITLE
Fix CloudSQL native IAM authentication/ADC, adds option to set CloudSQL IP type.

### DIFF
--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -60,6 +60,7 @@ Keep is highly configurable through environment variables. This allows you to cu
 |       **DATABASE_ECHO**        |    Enables SQLAlchemy echo mode for debugging     |    No    |               False               |        Boolean (True/False)        |
 |     **DB_CONNECTION_NAME**     |      Specifies the Cloud SQL connection name      |    No    | "keephq-sandbox:us-central1:keep" | Valid Cloud SQL connection string  |
 |     **DB_SERVICE_ACCOUNT**     |    Service account for database impersonation     |    No    |               None                |    Valid service account email     |
+|         **DB_IP_TYPE**         |          Specifies the Cloud SQL IP type          |    No    |              "public"             |    "public", "private" or "psc"    |
 |      **SKIP_DB_CREATION**      |      Skips database creation and migrations       |    No    |              "false"              |         "true" or "false"          |
 
 ### Resource Provisioning

--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -59,6 +59,7 @@ Keep is highly configurable through environment variables. This allows you to cu
 |   **DATABASE_MAX_OVERFLOW**    | Sets the maximum overflow for the connection pool |    No    |                10                 |          Positive integer          |
 |       **DATABASE_ECHO**        |    Enables SQLAlchemy echo mode for debugging     |    No    |               False               |        Boolean (True/False)        |
 |     **DB_CONNECTION_NAME**     |      Specifies the Cloud SQL connection name      |    No    | "keephq-sandbox:us-central1:keep" | Valid Cloud SQL connection string  |
+|           **DB_NAME**          |       Specifies the Cloud SQL database name       |    No    |             "keepdb"              |   Valid Cloud SQL database name    |
 |     **DB_SERVICE_ACCOUNT**     |    Service account for database impersonation     |    No    |               None                |    Valid service account email     |
 |         **DB_IP_TYPE**         |          Specifies the Cloud SQL IP type          |    No    |              "public"             |    "public", "private" or "psc"    |
 |      **SKIP_DB_CREATION**      |      Skips database creation and migrations       |    No    |              "false"              |         "true" or "false"          |

--- a/keep/api/core/db_utils.py
+++ b/keep/api/core/db_utils.py
@@ -35,6 +35,7 @@ def __get_conn() -> pymysql.connections.Connection:
         conn = connector.connect(
             os.environ.get("DB_CONNECTION_NAME", "keephq-sandbox:us-central1:keep"),
             "pymysql",
+            ip_type=os.environ.get("DB_IP_TYPE", "public"),
             user="keep-api",
             db="keepdb",
             enable_iam_auth=True,

--- a/keep/api/core/db_utils.py
+++ b/keep/api/core/db_utils.py
@@ -36,8 +36,8 @@ def __get_conn() -> pymysql.connections.Connection:
             os.environ.get("DB_CONNECTION_NAME", "keephq-sandbox:us-central1:keep"),
             "pymysql",
             ip_type=os.environ.get("DB_IP_TYPE", "public"),
-            user="keep-api",
-            db="keepdb",
+            user=os.environ.get("DB_SERVICE_ACCOUNT", "keep-api"),
+            db=os.environ.get("DB_NAME", "keepdb"),
             enable_iam_auth=True,
         )
     return conn
@@ -81,7 +81,7 @@ def __get_conn_impersonate() -> pymysql.connections.Connection:
             password=access_token,
             host="127.0.0.1",
             port=3306,
-            database="keepdb",
+            database=os.environ.get("DB_NAME", "keepdb"),
         )
     return conn
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keep"
-version = "0.41.0"
+version = "0.41.1"
 description = "Alerting. for developers, by developers."
 authors = ["Keep Alerting LTD"]
 packages = [{include = "keep"}]


### PR DESCRIPTION
## 📑 Description
This PR adds small fixes to the CloudSQL native IAM authentication/ADC mechanism, and adds the option of setting a DB name instead of only having the default of `keepdb`.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
