### PR TITLE
feat: add support for topic sending and inline keyboard markup in Telegram message

### DIFF
--- a/docs/snippets/providers/telegram-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/telegram-snippet-autogenerated.mdx
@@ -1,4 +1,4 @@
-{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py 
+{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py
 Do not edit it manually, as it will be overwritten */}
 
 ## Authentication
@@ -20,7 +20,10 @@ actions:
       config: "{{ provider.my_provider_name }}"
       with:
         chat_id: {value}  # Unique identifier for the target chat or username of the target channel
+        topic_id: {value}  # Unique identifier for the target message thread (topic)
         message: {value}  # Message to be sent
+        reply_markup: {value}  # Inline keyboard markup to be attached to the message
+        reply_markup_layout: {value}  # Direction of the reply markup, could be "horizontal" or "vertical"
         parse_mode: {value}  # Mode for parsing entities in the message text, could be "markdown" or "html"
 ```
 
@@ -29,4 +32,5 @@ actions:
 
 Check the following workflow examples:
 - [send-message-telegram-with-htmlmd.yaml](https://github.com/keephq/keep/blob/main/examples/workflows/send-message-telegram-with-htmlmd.yaml)
+- [telegram_advanced.yml](https://github.com/keephq/keep/blob/main/examples/workflows/telegram_advanced.yml)
 - [telegram_basic.yml](https://github.com/keephq/keep/blob/main/examples/workflows/telegram_basic.yml)

--- a/examples/workflows/telegram_advanced.yml
+++ b/examples/workflows/telegram_advanced.yml
@@ -15,6 +15,6 @@ workflow:
           topic_id: "1234"
           reply_markup:
             📌 Confluence 📖:
-              url: "https://confluence.example.com"
+              url: "confluence.example.com"
             📖 Documentation 📖:
-              url: "https://docs.example.com"
+              url: "docs.example.com"

--- a/examples/workflows/telegram_advanced.yml
+++ b/examples/workflows/telegram_advanced.yml
@@ -1,0 +1,20 @@
+workflow:
+  id: telegram-message-topic-markup
+  name: Telegram Message Sender with Topic Markup
+  description: Send messages into Telegram topic with a message containing a reply markup.
+  triggers:
+    - type: manual
+  actions:
+    - name: telegram
+      provider:
+        type: telegram
+        config: "{{ providers.telegram }}"
+        with:
+          message: "message with topic markup"
+          chat_id: "-1001234567890"
+          topic_id: "1234"
+          reply_markup:
+            📌 Confluence 📖:
+              url: "https://confluence.example.com"
+            📖 Documentation 📖:
+              url: "https://docs.example.com"

--- a/examples/workflows/telegram_basic.yml
+++ b/examples/workflows/telegram_basic.yml
@@ -11,4 +11,4 @@ workflow:
         config: "{{ providers.telegram }}"
         with:
           message: "test"
-          chat_id: " {{ os.environ['TELEGRAM_CHAT_ID'] }}"
+          chat_id: "-1001234567890"


### PR DESCRIPTION
Closes #4331

## 📑 Description

Telegram allows users to send messages within a topic and add reply markup for embedding links.

![image](https://github.com/user-attachments/assets/1c67b5de-9a7f-46a9-ac3c-632bd696483e)

![image](https://github.com/user-attachments/assets/21b450da-d85a-4bc4-bba2-85678dac4cdf)

## Usage

```yaml
workflow:
  id: telegram-message-topic-markup
  name: Telegram Message Sender with Topic Markup
  description: Send messages into Telegram topic with a message containing a reply markup.
  triggers:
    - type: manual
  actions:
    - name: telegram
      provider:
        type: telegram
        config: "{{ providers.telegram }}"
        with:
          message: "message with topic markup"
          chat_id: "-1001234567890"
          topic_id: "1234"
          reply_markup:
            📌 Confluence 📖:
              url: "https://confluence.example.com"
            📖 Documentation 📖:
              url: "https://docs.example.com"
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
