### PR TITLE
feat: add OPENAI_MODEL_NAME environment variable for configurable OpenAI model

### DIFF
--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -164,6 +164,7 @@ Keep is highly configurable through environment variables. This allows you to cu
 |           Env var           |                      Purpose                       | Required | Default Value |               Valid options               |
 | :-------------------------: | :------------------------------------------------: | :------: | :-----------: | :---------------------------------------: |
 |     **OPENAI_API_KEY**      |            API key for OpenAI services             |    No    |     None      |           Valid OpenAI API key            |
+|    **OPENAI_MODEL_NAME**    |        Model name to use for OpenAI requests       |    No    |    "gpt-4o-2024-08-06"   |        Valid OpenAI model name (e.g., "gpt-4o", "gpt-4o-mini", ...)        |
 | **OPEN_AI_ORGANIZATION_ID** |        Organization ID for OpenAI services         |    No    |     None      |       Valid OpenAI organization ID        |
 |     **OPENAI_BASE_URL**     | Base URL for OpenAI API (useful for LiteLLM proxy) |    No    |     None      | Valid URL (e.g., "http://localhost:4000") |
 

--- a/keep-ui/app/api/copilotkit/route.ts
+++ b/keep-ui/app/api/copilotkit/route.ts
@@ -12,6 +12,9 @@ export const POST = async (req: NextRequest) => {
       const openai = new OpenAI({
         organization: process.env.OPEN_AI_ORGANIZATION_ID,
         apiKey: process.env.OPEN_AI_API_KEY,
+        ...(process.env.OPENAI_MODEL_NAME
+          ? { model: process.env.OPENAI_MODEL_NAME }
+          : {}),
       });
       const serviceAdapter = new OpenAIAdapter({ openai });
       const runtime = new CopilotRuntime();

--- a/keep/api/bl/ai_suggestion_bl.py
+++ b/keep/api/bl/ai_suggestion_bl.py
@@ -10,6 +10,7 @@ from openai import OpenAI, OpenAIError
 from sqlmodel import Session
 
 from keep.api.bl.incidents_bl import IncidentBl
+from keep.api.consts import OPENAI_MODEL_NAME
 from keep.api.core.db import get_session_sync
 from keep.api.models.alert import AlertDto
 from keep.api.models.db.ai_suggestion import AIFeedback, AISuggestion, AISuggestionType
@@ -276,7 +277,7 @@ class AISuggestionBl:
                 suggestion_input=suggestion_input,
                 suggestion_type=AISuggestionType.INCIDENT_SUGGESTION,
                 suggestion_content=incident_clustering.dict(),
-                model="gpt-4o-2024-08-06",
+                model=OPENAI_MODEL_NAME,
             )
 
             # Process incidents
@@ -403,7 +404,7 @@ class AISuggestionBl:
     def _get_ai_completion(self, system_prompt: str, user_prompt: str):
         """Get completion from OpenAI."""
         return self._client.chat.completions.create(
-            model="gpt-4o-2024-08-06",
+            model=OPENAI_MODEL_NAME,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt},

--- a/keep/api/bl/incident_reports.py
+++ b/keep/api/bl/incident_reports.py
@@ -1,15 +1,18 @@
 import json
-import os
-from uuid import UUID
-from openai import OpenAI
-from pydantic import BaseModel
-from keep.api.bl.incidents_bl import IncidentBl
-from typing import Optional
 import logging
 import math
+import os
+from typing import Optional
+from uuid import UUID
 
+from openai import OpenAI
+from pydantic import BaseModel
+
+from keep.api.bl.incidents_bl import IncidentBl
+from keep.api.consts import OPENAI_MODEL_NAME
 from keep.api.models.db.incident import IncidentStatus
 from keep.api.models.incident import IncidentDto
+
 
 class IncidentMetrics(BaseModel):
     total_incidents: Optional[int] = None
@@ -71,6 +74,7 @@ Generate an incident report based on the provided incidents dataset and response
 """
 
 logger = logging.getLogger(__name__)
+
 
 class IncidentReportsBl:
     __open_ai_client = None
@@ -146,7 +150,7 @@ class IncidentReportsBl:
         incidents_json = json.dumps(incidents_minified, default=str)
 
         response = self.open_ai_client.chat.completions.create(
-            model="gpt-4o-2024-08-06",
+            model=OPENAI_MODEL_NAME,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": incidents_json},

--- a/keep/api/consts.py
+++ b/keep/api/consts.py
@@ -46,3 +46,5 @@ if REDIS:
     KEEP_ARQ_TASK_POOL = os.environ.get("KEEP_ARQ_TASK_POOL", KEEP_ARQ_TASK_POOL_ALL)
 else:
     KEEP_ARQ_TASK_POOL = os.environ.get("KEEP_ARQ_TASK_POOL", None)
+
+OPENAI_MODEL_NAME = os.environ.get("OPENAI_MODEL_NAME", "gpt-4o-2024-08-06")


### PR DESCRIPTION
Closes #4379 

## 📑 Description

Allow configuring OpenAI model by setting `OPENAI_MODEL_NAME` environment variable.

## Usage

```bash
# env
OPENAI_MODEL_NAME=gpt-4o-mini
```

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed
