### PR TITLE
fix: Allow OpenObserve to pass row name, which extends alert name

### DIFF
--- a/keep/providers/openobserve_provider/openobserve_provider.py
+++ b/keep/providers/openobserve_provider/openobserve_provider.py
@@ -375,7 +375,7 @@ class OpenobserveProvider(BaseProvider):
         event: dict, provider_instance: "BaseProvider" = None
     ) -> AlertDto | List[AlertDto]:
         logger = logging.getLogger(__name__)
-        name = event.pop("alert_name", "")
+        alert_name = event.pop("alert_name", "")
         # openoboserve does not provide severity
         severity = AlertSeverity.WARNING
         # Mapping 'stream_name' to 'environment'
@@ -435,6 +435,7 @@ class OpenobserveProvider(BaseProvider):
                         except json.JSONDecodeError:
                             logger.exception(f"Failed to parse row: {row}")
                             continue
+                    row_name = row_data.pop("name", "")
                     group_by_keys = list(row_data.keys())
                     logger.info(
                         "Formatting aggregated alert with group by keys",
@@ -454,7 +455,7 @@ class OpenobserveProvider(BaseProvider):
 
                     alert_dto = AlertDto(
                         id=f"{alert_id}",
-                        name=f"{name}",
+                        name=f"{alert_name}: {row_name}" if row_name else f"{alert_name}",
                         severity=severity,
                         environment=environment,
                         startedAt=startedAt,
@@ -494,7 +495,7 @@ class OpenobserveProvider(BaseProvider):
             }
             alert_dto = AlertDto(
                 id=alert_id,
-                name=name,
+                name=alert_name,
                 severity=severity,
                 environment=environment,
                 startedAt=startedAt,


### PR DESCRIPTION
Replaced the variable `name` with `alert_name` for improved readability and added `row_name` to construct more descriptive alert names when available. This ensures alert details are clearer and more context-specific.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4402 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
