### PR TITLE
fix: Refactor error alert retrieval and improve default handling

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -5443,7 +5443,7 @@ def enrich_incidents_with_enrichments(
         return incidents
 
 
-def get_error_alerts(tenant_id: str, limit: int = 1000) -> int:
+def get_error_alerts(tenant_id: str, limit: int = 1000) -> List[AlertRaw]:
     with Session(engine) as session:
         return (
             session.query(AlertRaw)
@@ -5452,6 +5452,7 @@ def get_error_alerts(tenant_id: str, limit: int = 1000) -> int:
                 AlertRaw.error == True,
                 AlertRaw.dismissed == False,
             )
+            .limit(limit)
             .all()
         )
 

--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -5443,7 +5443,7 @@ def enrich_incidents_with_enrichments(
         return incidents
 
 
-def get_error_alerts(tenant_id: str, limit: int = 1000) -> List[AlertRaw]:
+def get_error_alerts(tenant_id: str, limit: int = 100) -> List[AlertRaw]:
     with Session(engine) as session:
         return (
             session.query(AlertRaw)

--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -1303,7 +1303,7 @@ def get_error_alerts(
     error_alerts_dtos = [
         AlertErrorDto(
             id=str(alert.id),
-            event=alert.raw_alert,
+            event=alert.raw_alert or {},
             error_message=alert.error_message,
             timestamp=alert.timestamp,
             provider_type=alert.provider_type or "keep",


### PR DESCRIPTION
Updated `get_error_alerts` to return a list of `AlertRaw` objects instead of an integer and added a query limit for better control. Adjusted default handling in `alerts.py` to ensure `event` defaults to an empty dictionary if `raw_alert` is missing.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4406 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
