### PR TITLE
fix: Add type casting for operators requiring numerical values

### DIFF
--- a/keep-ui/app/(keep)/rules/CorrelationSidebar/RuleFields.tsx
+++ b/keep-ui/app/(keep)/rules/CorrelationSidebar/RuleFields.tsx
@@ -22,11 +22,16 @@ import { useSearchAlerts } from "utils/hooks/useSearchAlerts";
 import { CorrelationFormType } from "./types";
 import { TIMEFRAME_UNITS_TO_SECONDS } from "./timeframe-constants";
 import { useDeduplicationFields } from "@/utils/hooks/useDeduplicationRules";
+import { get } from "lodash";
 
 const DEFAULT_OPERATORS = defaultOperators.filter((operator) =>
   [
     "=",
     "!=",
+    ">",
+    "<",
+    ">=",
+    "<=",
     "contains",
     "beginsWith",
     "endsWith",
@@ -39,6 +44,13 @@ const DEFAULT_OPERATORS = defaultOperators.filter((operator) =>
     "notIn",
   ].includes(operator.name)
 );
+
+const OPERATORS_FORCE_TYPE_CAST = {
+  ">=": "number",
+  "<=": "number",
+  "<": "number",
+  ">": "number",
+}
 
 const DEFAULT_FIELDS: QueryField[] = [
   { name: "source", label: "source", datatype: "text" },
@@ -104,6 +116,11 @@ const Field = ({
     return setIsValueEnabled(true);
   };
 
+  const castValueToOperationType = (value: string) => {
+    const castTo: string = get(OPERATORS_FORCE_TYPE_CAST, ruleField.operator, "text");
+    return castTo === "number" ? Number(value) : value;
+  }
+
   return (
     <div key={ruleField.id}>
       <div className="flex items-start gap-2">
@@ -141,7 +158,7 @@ const Field = ({
           {isValueEnabled && (
             <div>
               <TextInput
-                onValueChange={(newValue) => onFieldChange("value", newValue)}
+                onValueChange={(newValue) => onFieldChange("value", castValueToOperationType(newValue))}
                 defaultValue={ruleField.value}
                 required
                 error={!ruleField.value}


### PR DESCRIPTION
Enhanced the logic to enforce correct data types for certain operators (>, <, >=, <=) by introducing a type-casting mechanism. This ensures values are appropriately cast to numbers when required, improving input handling and reducing potential errors.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4408 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
