### PR TITLE
fix: Refactor heartbeat handling to return a list of alerts

### DIFF
--- a/keep/providers/uptimekuma_provider/uptimekuma_provider.py
+++ b/keep/providers/uptimekuma_provider/uptimekuma_provider.py
@@ -106,6 +106,8 @@ class UptimekumaProvider(BaseProvider):
             if length == 0:
                 return []
 
+            heartbeats = []
+
             for key in response:
                 heartbeat = response[key][-1]
                 monitor_id = heartbeat.get("monitor_id", heartbeat.get("monitorID"))
@@ -120,18 +122,20 @@ class UptimekumaProvider(BaseProvider):
                     api = self._get_api()
                     name = api.get_monitor(monitor_id)["name"]
 
-                api.disconnect()
-                return AlertDto(
-                    id=heartbeat["id"],
-                    name=name,
-                    monitor_id=monitor_id,
-                    description=heartbeat["msg"],
-                    status=heartbeat["status"].name.lower(),
-                    lastReceived=heartbeat["time"],
-                    ping=heartbeat["ping"],
-                    source=["uptimekuma"],
+                heartbeats.append(
+                    AlertDto(
+                        id=heartbeat["id"],
+                        name=name,
+                        monitor_id=heartbeat["monitor_id"],
+                        description=heartbeat["msg"],
+                        status=heartbeat["status"].name.lower(),
+                        lastReceived=heartbeat["time"],
+                        ping=heartbeat["ping"],
+                        source=["uptimekuma"],
+                    )
                 )
-
+            api.disconnect()
+            return heartbeats
         except Exception as e:
             self.logger.error("Error getting heartbeats from UptimeKuma: %s", e)
             raise Exception(f"Error getting heartbeats from UptimeKuma: {e}")


### PR DESCRIPTION
Refactored the method to accumulate and return a list of AlertDto objects instead of a single alert. This ensures proper handling of multiple heartbeats and streamlines data processing. Also moved the `api.disconnect()` call to occur after processing all heartbeats.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4412 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
