### PR TITLE
fix: Handle 'row_name' in OpenObserve provider during parsing

### DIFF
--- a/keep/providers/openobserve_provider/openobserve_provider.py
+++ b/keep/providers/openobserve_provider/openobserve_provider.py
@@ -436,6 +436,8 @@ class OpenobserveProvider(BaseProvider):
                             logger.exception(f"Failed to parse row: {row}")
                             continue
                     row_name = row_data.pop("name", "")
+                    if row_name:
+                        row_data['row_name'] = row_name
                     group_by_keys = list(row_data.keys())
                     logger.info(
                         "Formatting aggregated alert with group by keys",


### PR DESCRIPTION
Added logic to include 'row_name' if present in row data. This ensures proper handling and formatting of aggregated alerts with accurate group-by keys.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4414 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
