### PR TITLE
fix: alignment of alert actions on incident page

### DIFF
--- a/keep-ui/app/(keep)/incidents/[id]/alerts/incident-alert-action-tray.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/alerts/incident-alert-action-tray.tsx
@@ -57,31 +57,31 @@ export function IncidentAlertActionTray({
           )}
           tooltip={expanded ? "Collapse Row" : "Expand Row"}
         />
-        <button
+        <Button
+          className={actionIconButtonClassName}
           onClick={(e) => {
             e.stopPropagation();
             onViewAlert(alert);
           }}
-          className="p-1.5 hover:bg-gray-100 rounded-md transition-colors"
-          title="View Alert Details"
-        >
-          <Icon icon={EyeIcon} size="sm" className="text-gray-500" />
-        </button>
+          variant="light"
+          icon={() => (
+            <Icon icon={EyeIcon} className="w-4 h-4 text-gray-500" />
+          )}
+          tooltip="View Alert Details"
+        />
         {!isCandidate && (
-          <button
+          <Button
+            className={actionIconButtonClassName}
             onClick={(e) => {
               e.stopPropagation();
               onUnlink(alert);
             }}
-            className="p-1.5 hover:bg-gray-100 rounded-md transition-colors"
-            title="Unlink from incident"
-          >
-            <Icon
-              icon={LinkIcon}
-              size="sm"
-              className="rotate-45 text-gray-500"
-            />
-          </button>
+            variant="light"
+            icon={() => (
+              <Icon icon={LinkIcon} className="rotate-45 w-4 h-4 text-gray-500" />
+            )}
+            tooltip="Unlink from incident"
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
Closes #3833 

## 📑 Description
Aligned the icons for alert actions on Incident page as per the expected behavior.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
Screenshot after changes:

![fix-alert-actions-icon-alignment](https://github.com/user-attachments/assets/bb7501dc-8a59-4280-b52f-bf62046f81e5)

