### PR TITLE
feat: Add support for incident enrichment and un-enrichment

### DIFF
--- a/keep-ui/app/(keep)/incidents/[id]/enrichments/EnrichmentEditableField.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/enrichments/EnrichmentEditableField.tsx
@@ -1,0 +1,168 @@
+import {useRouter} from "next/navigation";
+import React, {useState} from "react";
+import {xor} from "lodash";
+import {Badge, Icon, TextInput} from "@tremor/react";
+import {Button} from "@/components/ui";
+import {FiSave, FiTrash2, FiX} from "react-icons/fi";
+import {MdModeEdit} from "react-icons/md";
+
+interface EnrichmentEditableFieldProps {
+  name?: string,
+  value: string | string[];
+  onUpdate: (fieldName: string, newValue: string | string[]) => void;
+  onDelete?: (fieldName: string) => void;
+}
+
+export const EnrichmentEditableField = ({name, value, onUpdate, onDelete}: EnrichmentEditableFieldProps) => {
+
+  const router = useRouter();
+
+  const [editMode, setEditMode] = useState(false);
+  const [stringedValue, setStringedValue] = useState(
+    Array.isArray(value) ? value.join(", ") : value.toString()
+  );
+  const [fieldName, setFieldName] = useState<string>(name || "");
+  const [fieldNameError, setFieldNameError] = useState<boolean>(false);
+  const [valueError, setValueError] = useState<boolean>(false);
+
+  const handleSave = async () => {
+
+    const newValue = Array.isArray(value) ?
+      stringedValue.split(",").map(s => s.trim()) :
+      stringedValue.toString().trim();
+
+    if (Array.isArray(newValue) && xor(value, newValue).length === 0) {
+      return;
+    } else if (value == newValue) {
+      return;
+    }
+
+    onUpdate(fieldName, newValue);
+    setEditMode(false);
+
+    // reset if this is add form
+    resetForm();
+  }
+
+  const handleUnenrich = async () => {
+
+    if (onDelete) {
+      onDelete(fieldName);
+    }
+    setEditMode(false);
+  }
+
+  const handleCancel = () => {
+    // Reset value
+    setEditMode(false);
+    resetForm();
+  }
+
+  const resetForm = () => {
+    setStringedValue(Array.isArray(value) ? value.join(", ") : value);
+    setFieldName(name || "");
+  }
+
+  const filterBy = (key: string, value: string) => {
+    router.push(
+      `/alerts/feed?cel=${key}%3D%3D${encodeURIComponent(`"${value}"`)}`
+    );
+  };
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFieldNameError(e.target.value === "");
+    setFieldName(e.target.value);
+  }
+
+  const handleValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValueError(e.target.value === "");
+    setStringedValue(e.target.value);
+  }
+
+  if (editMode) {
+    return <div className="flex items-center flex-wrap gap-2.5 z-50">
+      {!name && <TextInput
+        value={fieldName}
+        error={fieldNameError}
+        onChange={handleNameChange}
+        placeholder='Add name'
+      />}
+      <TextInput
+        value={stringedValue}
+        error={valueError}
+        onChange={handleValueChange}
+        placeholder='Add value'
+      />
+      <Button
+        className="leading-none p-2 rounded-md"
+        variant="secondary"
+        disabled={!(fieldName && stringedValue)}
+        tooltip="Save"
+        icon={() => <Icon
+          icon={FiSave}
+          className={`w-4 h-4 text-orange-500`}
+        />}
+        onClick={handleSave}
+      />
+      <Button
+        className="leading-none p-2 rounded-md"
+        variant="destructive"
+        tooltip="Cancel"
+        icon={FiX}
+        onClick={handleCancel}
+      />
+    </div>
+  }
+
+  return <div className="flex flex-col gap-1 relative">
+
+    {name ? (
+      <div className="flex flex-wrap gap-1 group items-center">
+        {value != null && value.length > 0 ?
+          (!Array.isArray(value) ?
+            value :
+            value.map((item: string) => (
+              <Badge
+                key={item}
+                color="orange"
+                size="sm"
+                className="cursor-pointer"
+                onClick={() => filterBy(fieldName, item)}
+              >
+                {item}
+              </Badge>
+            ))) : `No data for ${name}`
+        }
+
+        <Button
+          variant="light"
+          className="text-gray-500 leading-none p-2 rounded-md prevent-row-click hover:bg-slate-200 [&>[role='tooltip']]:z-50 transition-opacity duration-100 opacity-0 group-hover:opacity-100"
+          tooltip="Edit"
+          onClick={() => setEditMode(true)}
+          icon={() => (
+            <Icon
+              icon={MdModeEdit}
+              className={`w-4 h-4 text-orange-500`}
+            />
+          )}
+        />
+
+        <Button
+          variant="light"
+          className="text-gray-500 leading-none p-2 rounded-md prevent-row-click hover:bg-slate-200 [&>[role='tooltip']]:z-50 transition-opacity duration-100 opacity-0 group-hover:opacity-100"
+          tooltip="Un-enrich"
+          onClick={handleUnenrich}
+          icon={() => (
+            <Icon
+              icon={FiTrash2}
+              className={`w-4 h-4 text-red-500`}
+            />
+          )}
+        />
+
+      </div>
+    ) : (
+      <div className="flex gap-2 items-center cursor-pointer" onClick={() => setEditMode(true)}><Badge>+</Badge> Add new field</div>
+    )}
+  </div>
+}

--- a/keep-ui/app/(keep)/incidents/[id]/enrichments/EnrichmentEditableForm.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/enrichments/EnrichmentEditableForm.tsx
@@ -1,0 +1,121 @@
+import React, {useState} from "react";
+import {Button} from "@/components/ui";
+import {Icon, TextInput} from "@tremor/react";
+import {MdModeEdit} from "react-icons/md";
+import {map, some, startCase} from "lodash";
+import {FiSave, FiTrash2, FiX} from "react-icons/fi";
+import Modal from "@/components/ui/Modal";
+import {FieldHeader} from "@/shared/ui";
+
+interface EnrichmentEditableFormProps {
+  fields: Record<string, string>;
+  title: string,
+  onUpdate: (fields: Record<string, string>) => void;
+  onDelete?: (fields: string[]) => void;
+  children: React.ReactNode;
+}
+
+export const EnrichmentEditableForm = ({fields, title, onUpdate, onDelete, children}: EnrichmentEditableFormProps) => {
+
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [newFields, setNewFields] = useState<Record<string, string>>(fields);
+
+  const handleOpenForm = () => {
+    setIsFormOpen(true);
+  }
+
+  const handleCloseForm = () => {
+    setIsFormOpen(false);
+  }
+
+  const handleValueChange = (key: string, value: string) => {
+    setNewFields({
+        ...newFields,
+        [key]: value
+      });
+  }
+
+  const handleSave = async () => {
+    onUpdate(newFields);
+    setIsFormOpen(false);
+  }
+
+  const handleCancel = () => {
+    setIsFormOpen(false);
+    setNewFields(fields);
+  }
+
+  return <>
+
+    <div className="flex gap-2 items-center group">
+
+      {children}
+
+      <Button
+        variant="light"
+        className="text-gray-500 leading-none p-2 rounded-md prevent-row-click hover:bg-slate-200 [&>[role='tooltip']]:z-50 transition-opacity duration-100 opacity-0 group-hover:opacity-100"
+        tooltip="Edit"
+        onClick={handleOpenForm}
+        icon={() => (
+          <Icon
+            icon={MdModeEdit}
+            className={`w-4 h-4 text-orange-500`}
+          />
+        )}
+      />
+
+      {(onDelete && some(Object.values(fields))) && <Button
+        variant="light"
+        className="text-gray-500 leading-none p-2 rounded-md prevent-row-click hover:bg-slate-200 [&>[role='tooltip']]:z-50 transition-opacity duration-100 opacity-0 group-hover:opacity-100"
+        tooltip="Un-enrich"
+        onClick={() => onDelete(Object.keys(fields))}
+        icon={() => (
+          <Icon
+            icon={FiTrash2}
+            className={`w-4 h-4 text-red-500`}
+          />
+        )}
+      />}
+    </div>
+
+    <Modal
+      isOpen={isFormOpen}
+      onClose={handleCloseForm}
+      className="w-[600px]"
+      title={title}
+    >
+      {map(fields, (value: string, key: string) => {
+        return <div key={key}>
+          <FieldHeader>{startCase(key)}</FieldHeader>
+          <TextInput
+            value={value}
+            onChange={(e) => handleValueChange(key, e.target.value)}
+            placeholder={`Add ${key}`}
+          />
+        </div>
+      })}
+
+      <div className="flex gap-2 justify-end">
+        <Button
+          className="leading-none p-2 rounded-md"
+          variant="secondary"
+          disabled={!some(Object.values(newFields))}
+          tooltip="Save"
+          icon={() => <Icon
+            icon={FiSave}
+            className={`w-4 h-4 text-orange-500`}
+          />}
+          onClick={handleSave}
+        />
+        <Button
+          className="leading-none p-2 rounded-md"
+          variant="destructive"
+          tooltip="Cancel"
+          icon={FiX}
+          onClick={handleCancel}
+        />
+      </div>
+
+    </Modal>
+  </>
+}

--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -3692,8 +3692,9 @@ def get_incident_by_id(
             Incident.tenant_id == tenant_id,
             Incident.id == incident_id,
         )
-        incident, enrichments = query.first()
-        if incident:
+        incident_with_enrichments = query.first()
+        if incident_with_enrichments:
+            incident, enrichments = incident_with_enrichments
             if with_alerts:
                 enrich_incidents_with_alerts(
                     tenant_id,
@@ -3702,6 +3703,8 @@ def get_incident_by_id(
                 )
             if enrichments:
                 incident.set_enrichments(enrichments.enrichments)
+        else:
+            incident = None
 
     return incident
 

--- a/keep/api/models/action_type.py
+++ b/keep/api/models/action_type.py
@@ -40,3 +40,4 @@ class ActionType(enum.Enum):
     INCIDENT_ENRICH = "Incident enriched"
     INCIDENT_STATUS_CHANGE = "Incident status changed"
     INCIDENT_ASSIGN = "Incident assigned"
+    INCIDENT_UNENRICH = "Incident enriched"

--- a/keep/api/models/alert.py
+++ b/keep/api/models/alert.py
@@ -409,3 +409,8 @@ class DeduplicationRuleRequestDto(BaseModel):
 class EnrichIncidentRequestBody(BaseModel):
     enrichments: Dict[str, Any]
     force: bool = False
+
+
+class UnEnrichIncidentRequestBody(BaseModel):
+    enrichments: list[str]
+    fingerprint: str

--- a/keep/api/models/db/incident.py
+++ b/keep/api/models/db/incident.py
@@ -202,6 +202,9 @@ class Incident(SQLModel, table=True):
     def enrichments(self):
         return getattr(self, "_enrichments", {})
 
+    def set_enrichments(self, enrichments):
+        self._enrichments = enrichments
+
 
 @retry(exceptions=(IntegrityError,), tries=3, delay=0.1, backoff=2, jitter=(0, 0.1))
 def get_next_running_number(session, tenant_id: str) -> int:

--- a/keep/api/models/incident.py
+++ b/keep/api/models/incident.py
@@ -190,6 +190,10 @@ class IncidentDto(IncidentDtoIn):
 
         # This field is required for getting alerts when required
         dto._tenant_id = db_incident.tenant_id
+
+        if db_incident.enrichments:
+            dto = dto.copy(update=db_incident.enrichments)
+
         return dto
 
     def to_db_incident(self) -> "Incident":


### PR DESCRIPTION
Introduced editable enrichments for incidents with UI components and API endpoints. Users can now add, edit, or remove enrichments dynamically, with changes propagated to the database and frontend in real-time.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3552


## 📑 Description
<!-- Add a brief description of the pr -->

https://github.com/user-attachments/assets/92802893-31a6-4a9b-9c2e-d212854ece03


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
