### PR TITLE
feat: Add support for configurable provider pulling intervals

### DIFF
--- a/keep/api/models/db/migrations/versions/2025-04-08-19-42_5abc7a12b398.py
+++ b/keep/api/models/db/migrations/versions/2025-04-08-19-42_5abc7a12b398.py
@@ -1,0 +1,27 @@
+"""Add provider pulling_interval column
+
+Revision ID: 5abc7a12b398
+Revises: 59991b568c7d
+Create Date: 2025-04-08 19:42:34.421933
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5abc7a12b398"
+down_revision = "59991b568c7d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("provider", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("pulling_interval", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+
+    with op.batch_alter_table("provider", schema=None) as batch_op:
+        batch_op.drop_column("pulling_interval")

--- a/keep/api/models/db/provider.py
+++ b/keep/api/models/db/provider.py
@@ -21,6 +21,7 @@ class Provider(SQLModel, table=True):
     )  # scope name is key and value is either True if validated or string with error message, e.g: {"read": True, "write": "error message"}
     consumer: bool = False
     pulling_enabled: bool = True
+    pulling_interval: Optional[int] = None
     last_pull_time: Optional[datetime]
     provisioned: bool = Field(default=False)
 

--- a/keep/api/models/provider.py
+++ b/keep/api/models/provider.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Literal, Any
+from typing import Literal, Any, Optional
 
 from pydantic import BaseModel, Field
 
@@ -41,6 +41,7 @@ class Provider(BaseModel):
     installation_time: datetime | None = None
     pulling_available: bool = False
     pulling_enabled: bool = True
+    pulling_interval: Optional[int] = None
     last_pull_time: datetime | None = None
     docs: str | None = None
     tags: list[

--- a/keep/api/routes/preset.py
+++ b/keep/api/routes/preset.py
@@ -88,7 +88,10 @@ def pull_data_from_providers(
         if provider.last_pull_time is not None:
             now = datetime.now()
             minutes_passed = (now - provider.last_pull_time).total_seconds() / 60
-            if minutes_passed <= PROVIDER_PULL_INTERVAL_MINUTE:
+
+            pull_interval_minutes = provider.pulling_interval or PROVIDER_PULL_INTERVAL_MINUTE
+
+            if minutes_passed <= pull_interval_minutes:
                 logger.info(
                     "Skipping provider data pulling since not enough time has passed",
                     extra={

--- a/keep/providers/providers_factory.py
+++ b/keep/providers/providers_factory.py
@@ -501,6 +501,7 @@ class ProvidersFactory:
             provider_copy.last_pull_time = p.last_pull_time
             provider_copy.provisioned = p.provisioned
             provider_copy.pulling_enabled = p.pulling_enabled
+            provider_copy.pulling_interval = p.pulling_interval
             provider_copy.installed = True
             try:
                 provider_auth = {"name": p.name}


### PR DESCRIPTION
Introduced a new `pulling_interval` field for providers to enable custom pull interval configurations. Updated models, logic, and migrations to support this change, ensuring flexible data pulling timing based on provider settings.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4472 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
