### PR TITLE
fix: Update backend enrichment to leverage `UUIDType` processing

### DIFF
--- a/keep-ui/app/(keep)/incidents/[id]/enrichments/EnrichmentEditableField.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/enrichments/EnrichmentEditableField.tsx
@@ -1,20 +1,26 @@
-import {useRouter} from "next/navigation";
-import React, {useState} from "react";
-import {xor} from "lodash";
-import {Badge, Icon, TextInput} from "@tremor/react";
-import {Button} from "@/components/ui";
-import {FiSave, FiTrash2, FiX} from "react-icons/fi";
-import {MdModeEdit} from "react-icons/md";
+import { useRouter } from "next/navigation";
+import React, { useState } from "react";
+import { xor } from "lodash";
+import { Badge, Icon, TextInput } from "@tremor/react";
+import { Button } from "@/components/ui";
+import { FiSave, FiTrash2, FiX } from "react-icons/fi";
+import { MdModeEdit } from "react-icons/md";
 
 interface EnrichmentEditableFieldProps {
-  name?: string,
+  name?: string;
   value: string | string[];
   onUpdate: (fieldName: string, newValue: string | string[]) => void;
   onDelete?: (fieldName: string) => void;
+  children?: React.ReactNode;
 }
 
-export const EnrichmentEditableField = ({name, value, onUpdate, onDelete}: EnrichmentEditableFieldProps) => {
-
+export const EnrichmentEditableField = ({
+  name,
+  value,
+  onUpdate,
+  onDelete,
+  children,
+}: EnrichmentEditableFieldProps) => {
   const router = useRouter();
 
   const [editMode, setEditMode] = useState(false);
@@ -26,10 +32,9 @@ export const EnrichmentEditableField = ({name, value, onUpdate, onDelete}: Enric
   const [valueError, setValueError] = useState<boolean>(false);
 
   const handleSave = async () => {
-
-    const newValue = Array.isArray(value) ?
-      stringedValue.split(",").map(s => s.trim()) :
-      stringedValue.toString().trim();
+    const newValue = Array.isArray(value)
+      ? stringedValue.split(",").map((s) => s.trim())
+      : stringedValue.toString().trim();
 
     if (Array.isArray(newValue) && xor(value, newValue).length === 0) {
       return;
@@ -42,26 +47,25 @@ export const EnrichmentEditableField = ({name, value, onUpdate, onDelete}: Enric
 
     // reset if this is add form
     resetForm();
-  }
+  };
 
   const handleUnenrich = async () => {
-
     if (onDelete) {
       onDelete(fieldName);
     }
     setEditMode(false);
-  }
+  };
 
   const handleCancel = () => {
     // Reset value
     setEditMode(false);
     resetForm();
-  }
+  };
 
   const resetForm = () => {
     setStringedValue(Array.isArray(value) ? value.join(", ") : value);
     setFieldName(name || "");
-  }
+  };
 
   const filterBy = (key: string, value: string) => {
     router.push(
@@ -72,97 +76,103 @@ export const EnrichmentEditableField = ({name, value, onUpdate, onDelete}: Enric
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFieldNameError(e.target.value === "");
     setFieldName(e.target.value);
-  }
+  };
 
   const handleValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValueError(e.target.value === "");
     setStringedValue(e.target.value);
-  }
+  };
 
   if (editMode) {
-    return <div className="flex items-center flex-wrap gap-2.5 z-50">
-      {!name && <TextInput
-        value={fieldName}
-        error={fieldNameError}
-        onChange={handleNameChange}
-        placeholder='Add name'
-      />}
-      <TextInput
-        value={stringedValue}
-        error={valueError}
-        onChange={handleValueChange}
-        placeholder='Add value'
-      />
-      <Button
-        className="leading-none p-2 rounded-md"
-        variant="secondary"
-        disabled={!(fieldName && stringedValue)}
-        tooltip="Save"
-        icon={() => <Icon
-          icon={FiSave}
-          className={`w-4 h-4 text-orange-500`}
-        />}
-        onClick={handleSave}
-      />
-      <Button
-        className="leading-none p-2 rounded-md"
-        variant="destructive"
-        tooltip="Cancel"
-        icon={FiX}
-        onClick={handleCancel}
-      />
-    </div>
+    return (
+      <div className="flex items-center flex-wrap gap-2.5 z-50">
+        {!name && (
+          <TextInput
+            value={fieldName}
+            error={fieldNameError}
+            onChange={handleNameChange}
+            placeholder="Add name"
+          />
+        )}
+        <TextInput
+          value={stringedValue}
+          error={valueError}
+          onChange={handleValueChange}
+          placeholder="Add value"
+        />
+        <Button
+          className="leading-none p-2 rounded-md"
+          variant="secondary"
+          disabled={!(fieldName && stringedValue)}
+          tooltip="Save"
+          icon={() => (
+            <Icon icon={FiSave} className={`w-4 h-4 text-orange-500`} />
+          )}
+          onClick={handleSave}
+        />
+        <Button
+          className="leading-none p-2 rounded-md"
+          variant="destructive"
+          tooltip="Cancel"
+          icon={FiX}
+          onClick={handleCancel}
+        />
+      </div>
+    );
   }
 
-  return <div className="flex flex-col gap-1 relative">
+  return (
+    <div className="flex flex-col gap-1 relative">
+      {name ? (
+        <div className="flex flex-wrap gap-1 group items-center">
+          {children
+            ? children
+            : value != null && value.length > 0
+              ? !Array.isArray(value)
+                ? value
+                : value.map((item: string) => (
+                    <Badge
+                      key={item}
+                      color="orange"
+                      size="sm"
+                      className="cursor-pointer"
+                      onClick={() => filterBy(fieldName, item)}
+                    >
+                      {item}
+                    </Badge>
+                  ))
+              : `No data for ${name}`}
 
-    {name ? (
-      <div className="flex flex-wrap gap-1 group items-center">
-        {value != null && value.length > 0 ?
-          (!Array.isArray(value) ?
-            value :
-            value.map((item: string) => (
-              <Badge
-                key={item}
-                color="orange"
-                size="sm"
-                className="cursor-pointer"
-                onClick={() => filterBy(fieldName, item)}
-              >
-                {item}
-              </Badge>
-            ))) : `No data for ${name}`
-        }
+          <Button
+            variant="light"
+            className="text-gray-500 leading-none p-2 rounded-md prevent-row-click hover:bg-slate-200 [&>[role='tooltip']]:z-50 transition-opacity duration-100 opacity-0 group-hover:opacity-100"
+            tooltip="Edit"
+            onClick={() => setEditMode(true)}
+            icon={() => (
+              <Icon icon={MdModeEdit} className={`w-4 h-4 text-orange-500`} />
+            )}
+          />
 
-        <Button
-          variant="light"
-          className="text-gray-500 leading-none p-2 rounded-md prevent-row-click hover:bg-slate-200 [&>[role='tooltip']]:z-50 transition-opacity duration-100 opacity-0 group-hover:opacity-100"
-          tooltip="Edit"
+          {onDelete && (
+            <Button
+              variant="light"
+              className="text-gray-500 leading-none p-2 rounded-md prevent-row-click hover:bg-slate-200 [&>[role='tooltip']]:z-50 transition-opacity duration-100 opacity-0 group-hover:opacity-100"
+              tooltip="Un-enrich"
+              onClick={handleUnenrich}
+              icon={() => (
+                <Icon icon={FiTrash2} className={`w-4 h-4 text-red-500`} />
+              )}
+            />
+          )}
+        </div>
+      ) : (
+        <div
+          className="flex gap-2 items-center cursor-pointer"
           onClick={() => setEditMode(true)}
-          icon={() => (
-            <Icon
-              icon={MdModeEdit}
-              className={`w-4 h-4 text-orange-500`}
-            />
-          )}
-        />
-
-        <Button
-          variant="light"
-          className="text-gray-500 leading-none p-2 rounded-md prevent-row-click hover:bg-slate-200 [&>[role='tooltip']]:z-50 transition-opacity duration-100 opacity-0 group-hover:opacity-100"
-          tooltip="Un-enrich"
-          onClick={handleUnenrich}
-          icon={() => (
-            <Icon
-              icon={FiTrash2}
-              className={`w-4 h-4 text-red-500`}
-            />
-          )}
-        />
-
-      </div>
-    ) : (
-      <div className="flex gap-2 items-center cursor-pointer" onClick={() => setEditMode(true)}><Badge>+</Badge> Add new field</div>
-    )}
-  </div>
-}
+        >
+          <Badge>+</Badge> Add new field
+        </div>
+      )}
+    </div>
+  );
+};

--- a/keep-ui/app/(keep)/incidents/[id]/incident-overview.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/incident-overview.tsx
@@ -39,18 +39,18 @@ import remarkGfm from "remark-gfm";
 import { useApi } from "@/shared/lib/hooks/useApi";
 import { startCase, xor, map, some } from "lodash";
 import { useConfig } from "@/utils/hooks/useConfig";
-import { MdModeEdit } from "react-icons/md";
-import { FiSave, FiX, FiTrash2 } from "react-icons/fi";
-import {EnrichmentEditableField} from "@/app/(keep)/incidents/[id]/enrichments/EnrichmentEditableField";
-import {EnrichmentEditableForm} from "@/app/(keep)/incidents/[id]/enrichments/EnrichmentEditableForm";
+import { EnrichmentEditableField } from "@/app/(keep)/incidents/[id]/enrichments/EnrichmentEditableField";
+import { EnrichmentEditableForm } from "@/app/(keep)/incidents/[id]/enrichments/EnrichmentEditableForm";
 
 const PROVISIONED_ENRICHMENTS = [
   "services",
   "incident_id",
   "incident_url",
   "incident_provider",
-  "incident_title"
-]
+  "incident_title",
+  "environments",
+  "repositories",
+];
 
 interface Props {
   incident: IncidentDto;
@@ -203,10 +203,13 @@ function MergedCallout({
 
 export function IncidentOverview({ incident: initialIncidentData }: Props) {
   const router = useRouter();
-  const { data: fetchedIncident, mutate } = useIncident(initialIncidentData.id, {
-    fallbackData: initialIncidentData,
-    revalidateOnMount: false,
-  });
+  const { data: fetchedIncident, mutate } = useIncident(
+    initialIncidentData.id,
+    {
+      fallbackData: initialIncidentData,
+      revalidateOnMount: false,
+    }
+  );
   const incident = fetchedIncident || initialIncidentData;
   const summary = incident.user_summary || incident.generated_summary;
   // Why do we have "null" in services?
@@ -219,25 +222,29 @@ export function IncidentOverview({ incident: initialIncidentData }: Props) {
     isLoading: _alertsLoading,
     error: alertsError,
   } = useIncidentAlerts(incident.id, 20, 0);
-  const environments = Array.from(
-    new Set(
-      alerts?.items
-        .filter(
-          (alert) =>
-            alert.environment &&
-            alert.environment !== "undefined" &&
-            alert.environment !== "default"
-        )
-        .map((alert) => alert.environment)
-    )
-  );
-  const repositories = Array.from(
-    new Set(
-      alerts?.items
-        .filter((alert) => (alert as any).repository)
-        .map((alert) => (alert as any).repository as string)
-    )
-  );
+  const environments =
+    incident.enrichments.environments ||
+    (Array.from(
+      new Set(
+        alerts?.items
+          .filter(
+            (alert) =>
+              alert.environment &&
+              alert.environment !== "undefined" &&
+              alert.environment !== "default"
+          )
+          .map((alert) => alert.environment)
+      )
+    ) as Array<string>);
+  const repositories =
+    incident.enrichments.repositories ||
+    (Array.from(
+      new Set(
+        alerts?.items
+          .filter((alert) => (alert as any).repository)
+          .map((alert) => (alert as any).repository as string)
+      )
+    ) as Array<string>);
 
   const filterBy = (key: string, value: string) => {
     router.push(
@@ -247,7 +254,9 @@ export function IncidentOverview({ incident: initialIncidentData }: Props) {
 
   const api = useApi();
 
-  const handleBulkEnrichmentChange = async (fields: Record<string, string | string[]>) => {
+  const handleBulkEnrichmentChange = async (
+    fields: Record<string, string | string[]>
+  ) => {
     try {
       const requestData = {
         enrichments: fields,
@@ -259,10 +268,10 @@ export function IncidentOverview({ incident: initialIncidentData }: Props) {
       // Handle unexpected error
       console.error("An unexpected error occurred");
     }
-  }
+  };
 
   const handleBulkUnEnrichment = async (fields: string[]) => {
-        try {
+    try {
       const requestData = {
         enrichments: fields,
         fingerprint: incident.id,
@@ -273,15 +282,18 @@ export function IncidentOverview({ incident: initialIncidentData }: Props) {
       // Handle unexpected error
       console.error("An unexpected error occurred");
     }
-  }
+  };
 
-  const handleEnrichmentChange = async (fieldName: string, fieldValue: string | string[]) => {
-    await handleBulkEnrichmentChange({[fieldName]: fieldValue});
-  }
+  const handleEnrichmentChange = async (
+    fieldName: string,
+    fieldValue: string | string[]
+  ) => {
+    await handleBulkEnrichmentChange({ [fieldName]: fieldValue });
+  };
 
   const handleUnEnrichment = async (fieldName: string) => {
     await handleBulkUnEnrichment([fieldName]);
-  }
+  };
 
   if (!alerts || _alertsLoading) {
     return <IncidentOverviewSkeleton />;
@@ -323,28 +335,30 @@ export function IncidentOverview({ incident: initialIncidentData }: Props) {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldHeader>Services</FieldHeader>
-                <EnrichmentEditableField name="services" value={notNullServices} onUpdate={handleEnrichmentChange} onDelete={handleUnEnrichment}/>
+                <EnrichmentEditableField
+                  name="services"
+                  value={notNullServices}
+                  onUpdate={handleEnrichmentChange}
+                  onDelete={
+                    incident.enrichments?.services
+                      ? handleUnEnrichment
+                      : undefined
+                  }
+                />
               </div>
 
               <div>
                 <FieldHeader>Environments</FieldHeader>
-                {environments.length > 0 ? (
-                  <div className="flex flex-wrap gap-1">
-                    {environments.map((env) => (
-                      <Badge
-                        key={env}
-                        size="sm"
-                        color="orange"
-                        className="cursor-pointer"
-                        onClick={() => filterBy("environment", env)}
-                      >
-                        {env}
-                      </Badge>
-                    ))}
-                  </div>
-                ) : (
-                  "No environments involved"
-                )}
+                <EnrichmentEditableField
+                  name="environments"
+                  value={environments}
+                  onUpdate={handleEnrichmentChange}
+                  onDelete={
+                    incident.enrichments?.environments
+                      ? handleUnEnrichment
+                      : undefined
+                  }
+                />
               </div>
 
               <div>
@@ -362,75 +376,89 @@ export function IncidentOverview({ incident: initialIncidentData }: Props) {
                   onDelete={handleBulkUnEnrichment}
                 >
                   <>
-                  {incident.enrichments?.incident_id &&
-                  incident.enrichments?.incident_url ? (
-                    <div className="flex flex-wrap gap-1 truncate">
-                      <Badge
-                        size="sm"
-                        color="orange"
-                        icon={
-                          incident.enrichments?.incident_provider
-                            ? (props: any) => (
-                                <DynamicImageProviderIcon
-                                  providerType={
-                                    incident.enrichments?.incident_provider
-                                  }
-                                  src={`/icons/${incident.enrichments?.incident_provider}-icon.png`}
-                                  height="24"
-                                  width="24"
-                                  {...props}
-                                />
-                              )
-                            : undefined
-                        }
-                        className="cursor-pointer text-ellipsis"
-                        onClick={() =>
-                          window.open(incident.enrichments.incident_url, "_blank")
-                        }
-                      >
-                        {incident.enrichments?.incident_title ??
-                          incident.user_generated_name}
-                      </Badge>
-                    </div>
-                  ) : (
-                    "No external incidents"
-                  )}
+                    {incident.enrichments?.incident_id &&
+                    incident.enrichments?.incident_url ? (
+                      <div className="flex flex-wrap gap-1 truncate">
+                        <Badge
+                          size="sm"
+                          color="orange"
+                          icon={
+                            incident.enrichments?.incident_provider
+                              ? (props: any) => (
+                                  <DynamicImageProviderIcon
+                                    providerType={
+                                      incident.enrichments?.incident_provider
+                                    }
+                                    src={`/icons/${incident.enrichments?.incident_provider}-icon.png`}
+                                    height="24"
+                                    width="24"
+                                    {...props}
+                                  />
+                                )
+                              : undefined
+                          }
+                          className="cursor-pointer text-ellipsis"
+                          onClick={() =>
+                            window.open(
+                              incident.enrichments.incident_url,
+                              "_blank"
+                            )
+                          }
+                        >
+                          {incident.enrichments?.incident_title ??
+                            incident.user_generated_name}
+                        </Badge>
+                      </div>
+                    ) : (
+                      "No external incidents"
+                    )}
                   </>
                 </EnrichmentEditableForm>
-
               </div>
 
               <div>
                 <FieldHeader>Repositories</FieldHeader>
-                {repositories?.length > 0 ? (
-                  <div className="flex flex-wrap gap-1">
-                    {repositories.map((repo) => {
-                      const repoName = repo.split("/").pop();
-                      return (
-                        <Badge
-                          key={repo}
-                          color="orange"
-                          size="sm"
-                          icon={(props: any) => (
-                            <DynamicImageProviderIcon
-                              providerType="github"
-                              src={`/icons/github-icon.png`}
-                              height="24"
-                              width="24"
-                              {...props}
-                            />
-                          )}
-                          className="cursor-pointer"
-                          onClick={() => window.open(repo, "_blank")}
-                        >
-                          {repoName}
-                        </Badge>
-                      );
-                    })}
-                  </div>
-                ) : (
-                  "No environments involved"
-                )}
+
+                <EnrichmentEditableField
+                  name="repositories"
+                  value={repositories}
+                  onUpdate={handleEnrichmentChange}
+                  onDelete={
+                    incident.enrichments?.repositories
+                      ? handleUnEnrichment
+                      : undefined
+                  }
+                >
+                  {repositories?.length > 0 ? (
+                    <div className="flex flex-wrap gap-1">
+                      {repositories.map((repo: any) => {
+                        const repoName = repo.split("/").pop();
+                        return (
+                          <Badge
+                            key={repo}
+                            color="orange"
+                            size="sm"
+                            icon={(props: any) => (
+                              <DynamicImageProviderIcon
+                                providerType="github"
+                                src={`/icons/github-icon.png`}
+                                height="24"
+                                width="24"
+                                {...props}
+                              />
+                            )}
+                            className="cursor-pointer"
+                            onClick={() => window.open(repo, "_blank")}
+                          >
+                            {repoName}
+                          </Badge>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    "No environments involved"
+                  )}
+                </EnrichmentEditableField>
               </div>
               <div>
                 <FieldHeader>Assignee</FieldHeader>
@@ -478,15 +506,24 @@ export function IncidentOverview({ incident: initialIncidentData }: Props) {
                 )}
               {map(incident.enrichments, (value: any, key: string) => {
                 if (PROVISIONED_ENRICHMENTS.indexOf(key) > -1) return;
-                return <div key={`incident-enrichment-${key}`}>
-                  <FieldHeader>{startCase(key)}</FieldHeader>
-                  <EnrichmentEditableField name={key} value={value} onUpdate={handleEnrichmentChange} onDelete={handleUnEnrichment}/>
-                </div>
+                return (
+                  <div key={`incident-enrichment-${key}`}>
+                    <FieldHeader>{startCase(key)}</FieldHeader>
+                    <EnrichmentEditableField
+                      name={key}
+                      value={value}
+                      onUpdate={handleEnrichmentChange}
+                      onDelete={handleUnEnrichment}
+                    />
+                  </div>
+                );
               })}
               <div>
-                <EnrichmentEditableField value={""} onUpdate={handleEnrichmentChange} />
+                <EnrichmentEditableField
+                  value={""}
+                  onUpdate={handleEnrichmentChange}
+                />
               </div>
-
             </div>
           </div>
           <div>


### PR DESCRIPTION
Introduce support for `children` in `EnrichmentEditableField` and consolidate repetitive logic for environments and repositories into reusable components. Update backend enrichment to leverage `UUIDType` processing and include database session where required.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4536 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
