### PR TITLE
feat(logging.py): added RotatingFileHandler settings for log file rollout

### DIFF
--- a/keep/api/logging.py
+++ b/keep/api/logging.py
@@ -521,9 +521,11 @@ def setup_logging():
         CONFIG["handlers"]["file"] = {
             "level": "DEBUG",
             "formatter": ("json"),
-            "class": "logging.FileHandler",
+            "class": "logging.handlers.RotatingFileHandler",
             "filename": KEEP_LOG_FILE,
             "mode": "a",
+            "maxBytes": 1024 * 1024 * 1024,  # 1GB
+            "backupCount": 5,
         }
         # Add file handler to root logger
         CONFIG["loggers"][""]["handlers"].append("file")


### PR DESCRIPTION
…lout

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4095

## 📑 Description
Replaced standard FileHandler with RotatingFileHandler to implement automatic log rotation, setting a 10MB maximum file size and keeping 5 backup files. This prevents logs from growing indefinitely while preserving recent logging history.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed
