### PR TITLE
fix: Update __save_error_alerts to handle single AlertDto input

### DIFF
--- a/keep/api/tasks/process_event_task.py
+++ b/keep/api/tasks/process_event_task.py
@@ -781,7 +781,7 @@ def process_event(
 def __save_error_alerts(
     tenant_id,
     provider_type,
-    raw_events: dict | list[dict] | list[AlertDto] | None,
+    raw_events: dict | list[dict] | list[AlertDto] | AlertDto | None,
     error_message: str,
 ):
     if not raw_events:
@@ -798,8 +798,8 @@ def __save_error_alerts(
         session = get_session_sync()
 
         # Convert to list if single dict
-        if isinstance(raw_events, dict):
-            logger.info("Converting single dict to list")
+        if not isinstance(raw_events, list):
+            logger.info("Converting single dict or AlertDto to list")
             raw_events = [raw_events]
 
         logger.info(f"Saving {len(raw_events)} error alerts")


### PR DESCRIPTION
Enhanced the function to support single AlertDto objects alongside dict or list inputs. Adjusted the conversion logic to properly wrap non-list inputs into a list for processing.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4583 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
