### PR TITLE
fix: Refactor tenant configurations handling for better robustness

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -3332,7 +3332,7 @@ def update_action(
     return found_action
 
 
-def get_tenants_configurations(only_with_config=False) -> List[Tenant]:
+def get_tenants_configurations(only_with_config=False) -> dict:
     with Session(engine) as session:
         try:
             tenants = session.exec(select(Tenant)).all()

--- a/keep/api/core/tenant_configuration.py
+++ b/keep/api/core/tenant_configuration.py
@@ -35,7 +35,12 @@ class TenantConfiguration:
         def _reload_if_needed(self):
             if datetime.now() - self.last_loaded > timedelta(minutes=self.reload_time):
                 self.logger.info("Reloading tenants configurations")
-                self.configurations = self._load_tenant_configurations()
+                updated_configurations = self._load_tenant_configurations()
+                if updated_configurations:
+                    self.configurations = updated_configurations
+                else:
+                    self.logger.warning("No tenants configurations found in db, maybe error")
+
                 self.logger.info("Tenants configurations reloaded")
 
         def get_configuration(self, tenant_id, config_name=None):

--- a/keep/api/core/tenant_configuration.py
+++ b/keep/api/core/tenant_configuration.py
@@ -38,10 +38,9 @@ class TenantConfiguration:
                 updated_configurations = self._load_tenant_configurations()
                 if updated_configurations:
                     self.configurations = updated_configurations
+                    self.logger.info("Tenants configurations reloaded")
                 else:
                     self.logger.warning("No tenants configurations found in db, maybe error")
-
-                self.logger.info("Tenants configurations reloaded")
 
         def get_configuration(self, tenant_id, config_name=None):
             self._reload_if_needed()


### PR DESCRIPTION
Change `get_tenants_configurations` return type to `dict` and ensure tenant configurations are safely updated during reload. Added a warning log for cases where no configurations are found to improve debugging.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4585 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
