### PR TITLE
fix: Handle race conditions when updating incidents in database

### DIFF
--- a/keep/rulesengine/rulesengine.py
+++ b/keep/rulesengine/rulesengine.py
@@ -157,7 +157,9 @@ class RulesEngine:
 
                                 send_created_event = incident.is_visible
 
-                            incident_id = incident
+                            # If we try to access incident.id inside except block, it will try to refresh
+                            # instance and raises PendingRollback error
+                            incident_id = incident.id
                             # Incident might change till this moment
                             for attempt in range(3):
                                 try:

--- a/keep/rulesengine/rulesengine.py
+++ b/keep/rulesengine/rulesengine.py
@@ -160,9 +160,14 @@ class RulesEngine:
                             # If we try to access incident.id inside except block, it will try to refresh
                             # instance and raises PendingRollback error
                             incident_id = incident.id
-                            # Incident might change till this moment
+
+                            # Incident instance might change till this moment (set visible for example),
+                            # so we need to commit changes
+                            # Otherwise sqlalchemy might try to do this in unpredictable moment
                             for attempt in range(3):
                                 try:
+                                    # Explicitly add incident, but it most likely already there, since it was loaded in
+                                    # same session
                                     session.add(incident)
                                     session.commit()
                                     break

--- a/keep/rulesengine/rulesengine.py
+++ b/keep/rulesengine/rulesengine.py
@@ -166,7 +166,7 @@ class RulesEngine:
                                     break
                                 except StaleDataError as ex:
                                     if "expected to update" in ex.args[0]:
-                                        self.logger.info(
+                                        self.logger.warning(
                                             f"Race condition met while updating incident `{incident_id}`, retry #{attempt}"
                                         )
                                         session.rollback()


### PR DESCRIPTION
Add retry logic to manage race conditions caused by StaleDataError during incident updates. Ensures consistent database state by rolling back and retrying up to 3 times if a conflict occurs. Logs informative messages for better traceability of retries.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4587 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
