### PR TITLE
fix: Move alert enrichment outside conditional block for get_incident_for_grouping_rule

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -2190,7 +2190,6 @@ def get_incident_for_grouping_rule(
         ]:
             is_incident_expired = True
         elif incident and incident.alerts_count > 0:
-            enrich_incidents_with_alerts(tenant_id, [incident], session)
             is_incident_expired = max(
                 alert.timestamp for alert in incident._alerts
             ) < datetime.utcnow() - timedelta(seconds=rule.timeframe)
@@ -2198,6 +2197,8 @@ def get_incident_for_grouping_rule(
         # if there is no incident with the rule_fingerprint, create it or existed is already expired
         if not incident:
             return None, None
+
+    enrich_incidents_with_alerts(tenant_id, [incident], session)
 
     return incident, is_incident_expired
 


### PR DESCRIPTION
Relocated the `enrich_incidents_with_alerts` call to ensure it runs consistently regardless of conditions. This change improves code clarity and guarantees alert enrichment is always performed when processing incidents.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4281 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
