### PR TITLE
fix(utils): convert string indices to int in index() function to prevent TypeError

### DIFF
--- a/keep/functions/__init__.py
+++ b/keep/functions/__init__.py
@@ -49,6 +49,8 @@ def split(string, delimeter) -> list:
 
 
 def index(iterable, index) -> any:
+    if isinstance(index, str) and index.isdigit():  # Если индекс — строка с числом
+        index = int(index)
     return iterable[index]
 
 


### PR DESCRIPTION
## Convert string indices to `int` in `index()` function
Closes #4591
### Description
This PR modifies the `index()` utility function to automatically convert string indices (e.g., `"0"`) to integers, preventing `TypeError: list indices must be integers or slices, not str` errors that occurred when indices were passed as strings.

### Changes
```python
def index(iterable, index) -> any:
    if isinstance(index, str) and index.isdigit():  # Safely convert string to int
        index = int(index)
    return iterable[index]