### PR TITLE
fix: workflow create/update

### DIFF
--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -14,7 +14,7 @@ class Workflow(SQLModel, table=True):
     updated_by: Optional[str] = None
     creation_time: datetime = Field(default_factory=datetime.now(tz=timezone.utc))
     interval: Optional[int]
-    workflow_raw: str = Field(sa_column=Column(TEXT))datetime.now(tz=timezone.utc)
+    workflow_raw: str = Field(sa_column=Column(TEXT))
     is_deleted: bool = Field(default=False)
     is_disabled: bool = Field(default=False)
     revision: int = Field(default=1, nullable=False)

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -14,7 +14,7 @@ class Workflow(SQLModel, table=True):
     updated_by: Optional[str] = None
     creation_time: datetime = Field(default_factory=datetime.now(tz=timezone.utc))
     interval: Optional[int]
-    workflow_raw: str = Field(sa_column=Column(TEXT))
+    workflow_raw: str = Field(sa_column=Column(TEXT))datetime.now(tz=timezone.utc)
     is_deleted: bool = Field(default=False)
     is_disabled: bool = Field(default=False)
     revision: int = Field(default=1, nullable=False)

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -19,6 +19,7 @@ class Workflow(SQLModel, table=True):
     is_disabled: bool = Field(default=False)
     revision: int = Field(default=1, nullable=False)
     last_updated: datetime = Field(
+        default_factory=datetime.utcnow,
         sa_column=Column(
             DateTime(timezone=True),
             name="last_updated",
@@ -45,6 +46,7 @@ class WorkflowVersion(SQLModel, table=True):
     workflow_raw: str = Field(sa_column=Column(TEXT))
     updated_by: str
     updated_at: datetime = Field(
+        default_factory=datetime.utcnow,
         sa_column=Column(
             DateTime(timezone=True),
             name="updated_at",

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from sqlalchemy import TEXT, DateTime, Index, PrimaryKeyConstraint, func
@@ -19,7 +19,7 @@ class Workflow(SQLModel, table=True):
     is_disabled: bool = Field(default=False)
     revision: int = Field(default=1, nullable=False)
     last_updated: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=datetime.now(tz=timezone.utc),
         sa_column=Column(
             DateTime(timezone=True),
             name="last_updated",
@@ -46,7 +46,7 @@ class WorkflowVersion(SQLModel, table=True):
     workflow_raw: str = Field(sa_column=Column(TEXT))
     updated_by: str
     updated_at: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=datetime.now(tz=timezone.utc),
         sa_column=Column(
             DateTime(timezone=True),
             name="updated_at",

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -14,7 +14,7 @@ class Workflow(SQLModel, table=True):
     updated_by: Optional[str] = None
     creation_time: datetime = Field(default_factory=datetime.now(tz=timezone.utc))
     interval: Optional[int]
-    workflow_raw: str = Field(sa_column=Column(TEXT))datetime.now(tz=timezone.utc)
+    workflow_raw: str = Field(sa_column=Column(TEXT))
     is_deleted: bool = Field(default=False)
     is_disabled: bool = Field(default=False)
     revision: int = Field(default=1, nullable=False)
@@ -130,7 +130,7 @@ class WorkflowExecution(SQLModel, table=True):
     status: str = Field(sa_column=Column(TEXT))
     is_running: int = Field(default=1)
     timeslot: int = Field(
-        default_factory=lambda: int(datetime.now(tz=timezone.utc).timestamp() / 120)
+        default_factory=lambda: int(datetime.now(tz=timezone.utc)().timestamp() / 120)
     )
     execution_number: int
     error: Optional[str] = Field(max_length=10240)

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -12,14 +12,14 @@ class Workflow(SQLModel, table=True):
     description: Optional[str]
     created_by: str = Field(sa_column=Column(TEXT))
     updated_by: Optional[str] = None
-    creation_time: datetime = Field(default_factory=datetime.now(tz=timezone.utc))
+    creation_time: datetime = Field(default_factory=datetime.utcnow)
     interval: Optional[int]
     workflow_raw: str = Field(sa_column=Column(TEXT))
     is_deleted: bool = Field(default=False)
     is_disabled: bool = Field(default=False)
     revision: int = Field(default=1, nullable=False)
     last_updated: datetime = Field(
-        default_factory=datetime.now(tz=timezone.utc),
+        default_factory=datetime.utcnow,
         sa_column=Column(
             DateTime(timezone=True),
             name="last_updated",
@@ -46,7 +46,7 @@ class WorkflowVersion(SQLModel, table=True):
     workflow_raw: str = Field(sa_column=Column(TEXT))
     updated_by: str
     updated_at: datetime = Field(
-        default_factory=datetime.now(tz=timezone.utc),
+        default_factory=datetime.utcnow,
         sa_column=Column(
             DateTime(timezone=True),
             name="updated_at",
@@ -125,12 +125,12 @@ class WorkflowExecution(SQLModel, table=True):
         default=1
     )  # Add this to track which version was executed
     tenant_id: str = Field(foreign_key="tenant.id")
-    started: datetime = Field(default_factory=datetime.now(tz=timezone.utc), index=True)
+    started: datetime = Field(default_factory=datetime.utcnow, index=True)
     triggered_by: str = Field(sa_column=Column(TEXT))
     status: str = Field(sa_column=Column(TEXT))
     is_running: int = Field(default=1)
     timeslot: int = Field(
-        default_factory=lambda: int(datetime.now(tz=timezone.utc)().timestamp() / 120)
+        default_factory=lambda: int(datetime.utcnow().timestamp() / 120)
     )
     execution_number: int
     error: Optional[str] = Field(max_length=10240)

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -14,7 +14,7 @@ class Workflow(SQLModel, table=True):
     updated_by: Optional[str] = None
     creation_time: datetime = Field(default_factory=datetime.now(tz=timezone.utc))
     interval: Optional[int]
-    workflow_raw: str = Field(sa_column=Column(TEXT))
+    workflow_raw: str = Field(sa_column=Column(TEXT))datetime.now(tz=timezone.utc)
     is_deleted: bool = Field(default=False)
     is_disabled: bool = Field(default=False)
     revision: int = Field(default=1, nullable=False)
@@ -130,7 +130,7 @@ class WorkflowExecution(SQLModel, table=True):
     status: str = Field(sa_column=Column(TEXT))
     is_running: int = Field(default=1)
     timeslot: int = Field(
-        default_factory=lambda: int(datetime.now(tz=timezone.utc)().timestamp() / 120)
+        default_factory=lambda: int(datetime.now(tz=timezone.utc).timestamp() / 120)
     )
     execution_number: int
     error: Optional[str] = Field(max_length=10240)

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from sqlalchemy import TEXT, DateTime, Index, PrimaryKeyConstraint, func

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import List, Optional
 
 from sqlalchemy import TEXT, DateTime, Index, PrimaryKeyConstraint, func

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -12,14 +12,14 @@ class Workflow(SQLModel, table=True):
     description: Optional[str]
     created_by: str = Field(sa_column=Column(TEXT))
     updated_by: Optional[str] = None
-    creation_time: datetime = Field(default_factory=datetime.utcnow)
+    creation_time: datetime = Field(default_factory=datetime.now(tz=timezone.utc))
     interval: Optional[int]
     workflow_raw: str = Field(sa_column=Column(TEXT))
     is_deleted: bool = Field(default=False)
     is_disabled: bool = Field(default=False)
     revision: int = Field(default=1, nullable=False)
     last_updated: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=datetime.now(tz=timezone.utc),
         sa_column=Column(
             DateTime(timezone=True),
             name="last_updated",
@@ -46,7 +46,7 @@ class WorkflowVersion(SQLModel, table=True):
     workflow_raw: str = Field(sa_column=Column(TEXT))
     updated_by: str
     updated_at: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=datetime.now(tz=timezone.utc),
         sa_column=Column(
             DateTime(timezone=True),
             name="updated_at",
@@ -125,12 +125,12 @@ class WorkflowExecution(SQLModel, table=True):
         default=1
     )  # Add this to track which version was executed
     tenant_id: str = Field(foreign_key="tenant.id")
-    started: datetime = Field(default_factory=datetime.utcnow, index=True)
+    started: datetime = Field(default_factory=datetime.now(tz=timezone.utc), index=True)
     triggered_by: str = Field(sa_column=Column(TEXT))
     status: str = Field(sa_column=Column(TEXT))
     is_running: int = Field(default=1)
     timeslot: int = Field(
-        default_factory=lambda: int(datetime.utcnow().timestamp() / 120)
+        default_factory=lambda: int(datetime.now(tz=timezone.utc)().timestamp() / 120)
     )
     execution_number: int
     error: Optional[str] = Field(max_length=10240)


### PR DESCRIPTION
Closes #4605

## 📑 Description
Fix workflow create/update errors:
- "null value in column "updated_at" of relation "workflowversion" violates not-null constraint"
- "null value in column "last_updated" of relation "workflow" violates not-null constraint"

This PR fix the issue with autogenerating updated_at and last_updated fields for workflowversion and workflow models made in commit 7ef6766e111af9a10853f4fbb5ba13eb1bb27fc0


