### PR TITLE
fix: Incident field cant be queried

### DIFF
--- a/keep/api/core/alerts.py
+++ b/keep/api/core/alerts.py
@@ -49,6 +49,9 @@ alert_field_configurations = [
         map_from_pattern="providerType", map_to="alert.provider_type", data_type=str
     ),
     FieldMappingConfiguration(
+        map_from_pattern="source", map_to="alert.provider_type", data_type=str
+    ),
+    FieldMappingConfiguration(
         map_from_pattern="timestamp",
         map_to="lastalert.timestamp",
         data_type=datetime.datetime,

--- a/keep/api/core/alerts.py
+++ b/keep/api/core/alerts.py
@@ -43,13 +43,13 @@ alert_field_configurations = [
         map_from_pattern="id", map_to="lastalert.alert_id", data_type=UUID
     ),
     FieldMappingConfiguration(
+        map_from_pattern="source", map_to="alert.provider_type", data_type=str
+    ),
+    FieldMappingConfiguration(
         map_from_pattern="providerId", map_to="alert.provider_id", data_type=str
     ),
     FieldMappingConfiguration(
         map_from_pattern="providerType", map_to="alert.provider_type", data_type=str
-    ),
-    FieldMappingConfiguration(
-        map_from_pattern="source", map_to="alert.provider_type", data_type=str
     ),
     FieldMappingConfiguration(
         map_from_pattern="timestamp",

--- a/keep/api/core/alerts.py
+++ b/keep/api/core/alerts.py
@@ -163,7 +163,7 @@ static_facets = [
     ),
     FacetDto(
         id="461bef05-fc20-4363-b427-9d26fe064e7f",
-        property_path="providerType",
+        property_path="source",
         name="Source",
         is_static=True,
         type=FacetType.str,

--- a/keep/api/core/alerts.py
+++ b/keep/api/core/alerts.py
@@ -160,7 +160,7 @@ static_facets = [
     ),
     FacetDto(
         id="461bef05-fc20-4363-b427-9d26fe064e7f",
-        property_path="source",
+        property_path="providerType",
         name="Source",
         is_static=True,
         type=FacetType.str,

--- a/keep/api/core/alerts.py
+++ b/keep/api/core/alerts.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 from typing import Tuple
+from uuid import UUID
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.exc import OperationalError
@@ -39,7 +40,7 @@ alerts_hard_limit = int(os.environ.get("KEEP_LAST_ALERTS_LIMIT", 50000))
 
 alert_field_configurations = [
     FieldMappingConfiguration(
-        map_from_pattern="source", map_to="alert.provider_type", data_type=str
+        map_from_pattern="id", map_to="lastalert.alert_id", data_type=UUID
     ),
     FieldMappingConfiguration(
         map_from_pattern="providerId", map_to="alert.provider_id", data_type=str
@@ -63,7 +64,7 @@ alert_field_configurations = [
         map_to=[
             "incident.id",
         ],
-        data_type=str,
+        data_type=UUID,
     ),
     FieldMappingConfiguration(
         map_from_pattern="incident.name",

--- a/keep/api/core/cel_to_sql/properties_mapper.py
+++ b/keep/api/core/cel_to_sql/properties_mapper.py
@@ -53,8 +53,10 @@ class MultipleFieldsNode(Node):
     Args:
         fields (list[PropertyAccessNode]): A list of PropertyAccessNode instances to initialize the node with.
     """
-    def __init__(self, fields: list[PropertyAccessNode]):
+    def __init__(self, fields: list[PropertyAccessNode], data_type: type = None):
         self.fields = fields
+        self.data_type = data_type
+
 
 class PropertiesMappingException(Exception):
     """
@@ -381,5 +383,7 @@ class PropertiesMapper:
             )
             result.append(property_access_node)
         return (
-            MultipleFieldsNode(result) if len(result) > 1 else result[0]
+            MultipleFieldsNode(result, property_metadata.data_type)
+            if len(result) > 1
+            else result[0]
         ), property_metadata

--- a/keep/api/core/cel_to_sql/sql_providers/base.py
+++ b/keep/api/core/cel_to_sql/sql_providers/base.py
@@ -273,7 +273,10 @@ class BaseCelToSqlProvider:
             )
 
         if isinstance(comparison_node.second_operand, ConstantNode):
-            second_operand = self._visit_constant_node(comparison_node.second_operand.value)
+            second_operand = self._visit_constant_node(
+                comparison_node.second_operand.value,
+                self._get_data_type_to_convert(comparison_node),
+            )
 
             if isinstance(comparison_node.first_operand, JsonPropertyAccessNode):
                 first_operand = self.cast(self.__build_sql_filter(comparison_node.first_operand, stack), type(comparison_node.second_operand.value))
@@ -357,7 +360,7 @@ class BaseCelToSqlProvider:
 
         if len(constant_nodes_without_none) > 0:
             or_queries.append(
-                f"{first_operand_str} in ({ ', '.join([self._visit_constant_node(c.value) for c in constant_nodes_without_none])})"
+                f"{first_operand_str} in ({ ', '.join([self._visit_constant_node(c.value, self._get_data_type_to_convert(first_operand)) for c in constant_nodes_without_none])})"
             )
 
         if is_none_found:
@@ -375,7 +378,7 @@ class BaseCelToSqlProvider:
 
     # endregion
 
-    def _visit_constant_node(self, value: Any) -> str:
+    def _visit_constant_node(self, value: Any, expected_data_type: type = None) -> str:
         if value is None:
             return "NULL"
         if isinstance(value, str):
@@ -386,6 +389,28 @@ class BaseCelToSqlProvider:
             return str(value)
 
         raise NotImplementedError(f"{type(value).__name__} constant type is not supported yet. Consider implementing this support in child class.")
+
+    def _get_data_type_to_convert(self, node: Node) -> type:
+        """
+        Extracts data type from node.
+        The data type will be used to convert the value of constant node into the expected type (SQL type).
+        """
+        property_access_node = None
+        if isinstance(node, PropertyAccessNode):
+            property_access_node = node
+
+        if isinstance(node, MultipleFieldsNode):
+            property_access_node = node.fields[0]
+
+        if isinstance(node, ComparisonNode):
+            property_access_node = node.first_operand
+
+        if property_access_node:
+            return property_access_node.data_type
+
+        raise NotImplementedError(
+            f"Cannot find data type to convert for {type(node).__name__} node"
+        )
 
     # region Member Access Visitors
     def _visit_multiple_fields_node(self, multiple_fields_node: MultipleFieldsNode, cast_to: type, stack) -> str:

--- a/keep/api/core/cel_to_sql/sql_providers/base.py
+++ b/keep/api/core/cel_to_sql/sql_providers/base.py
@@ -395,18 +395,14 @@ class BaseCelToSqlProvider:
         Extracts data type from node.
         The data type will be used to convert the value of constant node into the expected type (SQL type).
         """
-        property_access_node = None
         if isinstance(node, PropertyAccessNode):
-            property_access_node = node
+            return node.data_type
 
         if isinstance(node, MultipleFieldsNode):
-            property_access_node = node.fields[0]
+            return node.data_type
 
         if isinstance(node, ComparisonNode):
-            property_access_node = node.first_operand
-
-        if property_access_node:
-            return property_access_node.data_type
+            return self._get_data_type_to_convert(node.first_operand)
 
         raise NotImplementedError(
             f"Cannot find data type to convert for {type(node).__name__} node"

--- a/keep/api/core/cel_to_sql/sql_providers/mysql.py
+++ b/keep/api/core/cel_to_sql/sql_providers/mysql.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import List
+from uuid import UUID
 from keep.api.core.cel_to_sql.ast_nodes import ConstantNode
 from keep.api.core.cel_to_sql.properties_metadata import (
     JsonFieldMapping,
@@ -82,7 +83,17 @@ class CelToMySqlProvider(BaseCelToSqlProvider):
         else:
             return field_expressions[0]
 
-    def _visit_constant_node(self, value: str) -> str:
+    def _visit_constant_node(self, value: str, expected_data_type: type = None) -> str:
+        if expected_data_type is UUID:
+            str_value = str(value)
+            try:
+                # Because MySQL works with UUID without dashes, we need to convert it to a hex string
+                # Example: 123e4567-e89b-12d3-a456-426614174000 -> 123e4567e89b12d3a456426614174000
+                # Example2: 123e4567e89b12d3a456426614174000 -> 123e4567e89b12d3a456426614174000 (hex in CEL is also supported)
+                value = UUID(str_value).hex
+            except ValueError:
+                pass
+
         if isinstance(value, datetime):
             date_str = self.literal_proc(value.strftime("%Y-%m-%d %H:%M:%S"))
             date_exp = f"CAST({date_str} as DATETIME)"
@@ -90,7 +101,7 @@ class CelToMySqlProvider(BaseCelToSqlProvider):
         elif isinstance(value, bool):
             return "TRUE" if value else "FALSE"
 
-        return super()._visit_constant_node(value)
+        return super()._visit_constant_node(value, expected_data_type)
 
     def _visit_contains_method_calling(
         self, property_path: str, method_args: List[ConstantNode]

--- a/keep/api/core/cel_to_sql/sql_providers/sqlite.py
+++ b/keep/api/core/cel_to_sql/sql_providers/sqlite.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from types import NoneType
-from typing import Any, List
+from typing import List
 from uuid import UUID
 
 from keep.api.core.cel_to_sql.ast_nodes import ConstantNode

--- a/keep/api/core/cel_to_sql/sql_providers/sqlite.py
+++ b/keep/api/core/cel_to_sql/sql_providers/sqlite.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from types import NoneType
-from typing import List
+from typing import Any, List
+from uuid import UUID
+
 from keep.api.core.cel_to_sql.ast_nodes import ConstantNode
 from keep.api.core.cel_to_sql.sql_providers.base import BaseCelToSqlProvider
 
@@ -39,13 +41,26 @@ class CelToSqliteProvider(BaseCelToSqlProvider):
 
         return f"CAST({expression_to_cast} as {to_type_str})"
 
-    def _visit_constant_node(self, value: str) -> str:
+    def _visit_constant_node(self, value: str, expected_data_type: type = None) -> str:
+        if expected_data_type is UUID:
+            str_value = str(value)
+            try:
+                # Because SQLite works with UUID without dashes, we need to convert it to a hex string
+                # Example: 123e4567-e89b-12d3-a456-426614174000 -> 123e4567e89b12d3a456426614174000
+                # Example2: 123e4567e89b12d3a456426614174000 -> 123e4567e89b12d3a456426614174000 (hex in CEL is also supported)
+                value = UUID(str_value).hex
+            except ValueError:
+                pass
+
         if isinstance(value, datetime):
             date_str = self.literal_proc(value.strftime("%Y-%m-%d %H:%M:%S"))
             date_exp = f"datetime({date_str})"
             return date_exp
 
-        return super()._visit_constant_node(value)
+        return super()._visit_constant_node(value, expected_data_type)
+
+    def _visit_property_path(self, property_path: str) -> str:
+        pass
 
     def _visit_contains_method_calling(
         self, property_path: str, method_args: List[ConstantNode]

--- a/keep/api/core/incidents.py
+++ b/keep/api/core/incidents.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
+from uuid import UUID
 
 from sqlalchemy import and_, case, func, select
 from sqlmodel import Session, col, text
@@ -34,6 +35,9 @@ from keep.api.models.query import SortOptionsDto
 logger = logging.getLogger(__name__)
 
 incident_field_configurations = [
+    FieldMappingConfiguration(
+        map_from_pattern="id", map_to=["incident.id"], data_type=UUID
+    ),
     FieldMappingConfiguration(
         map_from_pattern="name",
         map_to=["incident.user_generated_name", "incident.ai_generated_name"],

--- a/tests/cel_to_sql/cel-to-sql-test-cases.json
+++ b/tests/cel_to_sql/cel-to-sql-test-cases.json
@@ -259,5 +259,23 @@
       "mysql": "JSON_UNQUOTE(JSON_EXTRACT(alert_event, '$.\"tagsContainer\".\"some tags.dot(&?:;\".\"tagKey\"')) = 'tag value'",
       "postgresql": "((alert_event -> 'tagsContainer' -> 'some tags.dot(&?:;') ->> 'tagKey')::TEXT = 'tag value'"
     }
+  },
+  {
+    "input_cel": "id == '123e4567-e89b-12d3-a456-426614174000'",
+    "description": "UUID property access with dashed UUID",
+    "expected_sql_dialect_based": {
+      "sqlite": "entityId = '123e4567e89b12d3a456426614174000'",
+      "mysql": "entityId = '123e4567e89b12d3a456426614174000'",
+      "postgresql": "entityId = '123e4567-e89b-12d3-a456-426614174000'"
+    }
+  },
+  {
+    "input_cel": "id == '123e4567e89b12d3a456426614174000'",
+    "description": "UUID property access with HEX UUID",
+    "expected_sql_dialect_based": {
+      "sqlite": "entityId = '123e4567e89b12d3a456426614174000'",
+      "mysql": "entityId = '123e4567e89b12d3a456426614174000'",
+      "postgresql": "entityId = '123e4567-e89b-12d3-a456-426614174000'"
+    }
   }
 ]

--- a/tests/cel_to_sql/test_cel_to_sql.py
+++ b/tests/cel_to_sql/test_cel_to_sql.py
@@ -1,5 +1,6 @@
 import json
 import os
+from uuid import UUID
 import pytest
 
 from keep.api.core.cel_to_sql.properties_metadata import (
@@ -11,6 +12,9 @@ from keep.api.core.cel_to_sql.sql_providers.get_cel_to_sql_provider_for_dialect 
 )
 
 fake_field_configurations = [
+    FieldMappingConfiguration(
+        map_from_pattern="id", map_to=["entityId"], data_type=UUID
+    ),
     FieldMappingConfiguration(
         map_from_pattern="name", map_to=["user_generated_name", "ai_generated_name"]
     ),


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4432 

## 📑 Description
- Add mechanism that will detect data type of being filtered field and perform conversion depending on dealect
- Add UUID data type support by SQLite, MySQL, PostgreSQL in CEL-to-SQL translator
- Make id (alert id) and incident.id be UUID during alert queries
- Make id (incident id) be UUID during incident queries
- Support dashed or HEX types of UUID in CEL

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
