### PR TITLE
fix: Enhance DB retry logic to handle StaleDataError

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -160,7 +160,7 @@ def __convert_to_uuid(value: str, should_raise: bool = False) -> UUID | None:
 
 def retry_on_db_error(f):
     @retry(
-        exceptions=(OperationalError, IntegrityError),
+        exceptions=(OperationalError, IntegrityError, StaleDataError),
         tries=3,
         delay=0.1,
         backoff=2,


### PR DESCRIPTION
Added StaleDataError to the list of exceptions retried by `retry_on_db_error`. This ensures better resilience in scenarios where stale data issues occur during database operations.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4637 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
