### PR TITLE
fix: Skip instance-level enrichment for elastic. Ensure enrichments are applied conditionally

### DIFF
--- a/keep/api/bl/enrichments_bl.py
+++ b/keep/api/bl/enrichments_bl.py
@@ -716,6 +716,8 @@ class EnrichmentsBl:
         alert_id = UUIDType(binary=False).process_bind_param(
             last_alert.alert_id, self.db_session.bind.dialect
         )
+        # For elastic we do not save instance-level enrichments
+        common_kwargs["should_exist"] = False
         self.enrich_entity(fingerprint=alert_id, audit_enabled=False, **common_kwargs)
 
     def enrich_entity(

--- a/keep/providers/base/base_provider.py
+++ b/keep/providers/base/base_provider.py
@@ -287,19 +287,21 @@ class BaseProvider(metaclass=abc.ABCMeta):
                 "audit_enabled": audit_enabled,
             }
 
-            # enrich the alert with _enrichments
-            enrichments_bl.enrich_entity(
-                enrichments=_enrichments,
-                action_description=f"Workflow enriched the alert with {enrichment_string}",
-                **common_kwargs,
-            )
+            if _enrichments:
+                # enrich the alert with _enrichments
+                enrichments_bl.enrich_entity(
+                    enrichments=_enrichments,
+                    action_description=f"Workflow enriched the alert with {enrichment_string}",
+                    **common_kwargs,
+                )
 
-            # enrich with disposable enrichments
-            enrichments_bl.disposable_enrich_entity(
-                enrichments=disposable_enrichments,
-                action_description=f"Workflow enriched the alert with {disposable_enrichment_string}",
-                **common_kwargs,
-            )
+            if disposable_enrichments:
+                # enrich with disposable enrichments
+                enrichments_bl.disposable_enrich_entity(
+                    enrichments=disposable_enrichments,
+                    action_description=f"Workflow enriched the alert with {disposable_enrichment_string}",
+                    **common_kwargs,
+                )
 
             should_check_incidents_resolution = (
                 _enrichments.get("status", None) == "resolved"


### PR DESCRIPTION
Added checks to confirm the presence of `_enrichments` and `disposable_enrichments` before applying them in the alert enrichment process. Also updated the enrichment logic to prevent saving instance-level enrichments for Elastic environments.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4342 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
