### PR TITLE
feat: add support for user mentions in Adaptive Cards for Teams notifications

### DIFF
--- a/docs/providers/documentation/teams-provider.mdx
+++ b/docs/providers/documentation/teams-provider.mdx
@@ -83,6 +83,7 @@ When using Adaptive Cards (`typeCard="message"`):
 - `themeColor` is ignored for Adaptive Cards
 - If no sections are provided, the message will be displayed as a simple text block
 - Both `sections` and `attachments` can be provided as JSON strings or arrays
+- You can mention users in your Adaptive Cards using the `mentions` parameter
 
 ### Workflow Example
 
@@ -112,7 +113,11 @@ actions:
         message: ""
         sections: '[{"type": "TextBlock", "text": "{{alert.name}}"}, {"type": "TextBlock", "text": "Tal from Keep"}]'
         typeCard: message
+        # Optional: Add mentions to notify specific users
+        # mentions: '[{"id": "user@example.com", "name": "User Name"}]'
 ```
+
+You can also find an example with user mentions in our [examples](https://github.com/keephq/keep/tree/main/examples/workflows/keep-teams-adaptive-cards-with-mentions.yaml) folder.
 
 <Note>
     The sections parameter is a JSON string that follows the Adaptive Cards schema, but can also be an object.
@@ -157,6 +162,71 @@ provider.notify(
         }
     }]
 )
+```
+
+### Using User Mentions in Adaptive Cards
+
+You can mention users in your Adaptive Cards using the `mentions` parameter. The text in your card should include the mention in the format `<at>User Name</at>`, and you need to provide the user's ID and name in the `mentions` parameter.
+
+Teams supports three types of user IDs for mentions:
+- Teams User ID (format: `29:1234...`)
+- Microsoft Entra Object ID (format: `49c4641c-ab91-4248-aebb-6a7de286397b`)
+- User Principal Name (UPN) (format: `user@example.com`)
+
+```python
+provider.notify(
+    typeCard="message",
+    sections=[
+        {
+            "type": "TextBlock",
+            "text": "Hello <at>John Doe</at>, please review this alert!"
+        }
+    ],
+    mentions=[
+        {
+            "id": "john.doe@example.com",  # Can be UPN, Microsoft Entra Object ID, or Teams User ID
+            "name": "John Doe"
+        }
+    ]
+)
+```
+
+You can also mention multiple users in a single card:
+
+```python
+provider.notify(
+    typeCard="message",
+    sections=[
+        {
+            "type": "TextBlock",
+            "text": "Hello <at>John Doe</at> and <at>Jane Smith</at>, please review this alert!"
+        }
+    ],
+    mentions=[
+        {
+            "id": "john.doe@example.com",
+            "name": "John Doe"
+        },
+        {
+            "id": "49c4641c-ab91-4248-aebb-6a7de286397b",  # Microsoft Entra Object ID
+            "name": "Jane Smith"
+        }
+    ]
+)
+```
+
+In YAML workflows, you can provide the mentions as a JSON string:
+
+```yaml
+actions:
+  - name: teams-action
+    provider:
+      config: "{{ providers.teams }}"
+      type: teams
+      with:
+        typeCard: message
+        sections: '[{"type": "TextBlock", "text": "Hello <at>John Doe</at>, please review this alert!"}]'
+        mentions: '[{"id": "john.doe@example.com", "name": "John Doe"}]'
 ```
 
 ## Useful Links

--- a/docs/snippets/providers/teams-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/teams-snippet-autogenerated.mdx
@@ -1,4 +1,4 @@
-{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py 
+{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py
 Do not edit it manually, as it will be overwritten */}
 
 ## Authentication
@@ -25,6 +25,7 @@ actions:
         sections: {value}  # For MessageCard: Array of custom information sections. For Adaptive Cards: Array of card elements following the Adaptive Card schema. Can be provided as a JSON string or array.
         schema: {value}  # Schema URL for Adaptive Cards. Default is "http://adaptivecards.io/schemas/adaptive-card.json"
         attachments: {value}  # Custom attachments array for Adaptive Cards (overrides default attachment structure). Can be provided as a JSON string or array.
+        mentions: {value}  # List of user mentions to include in the Adaptive Card. Each mention should be a dict with 'id' and 'name' keys. Can be provided as a JSON string or array.
 ```
 
 
@@ -33,3 +34,4 @@ actions:
 Check the following workflow examples:
 - [create_jira_ticket_upon_alerts.yml](https://github.com/keephq/keep/blob/main/examples/workflows/create_jira_ticket_upon_alerts.yml)
 - [keep-teams-adaptive-cards.yaml](https://github.com/keephq/keep/blob/main/examples/workflows/keep-teams-adaptive-cards.yaml)
+- [keep-teams-adaptive-cards-with-mentions.yaml](https://github.com/keephq/keep/blob/main/examples/workflows/keep-teams-adaptive-cards-with-mentions.yaml)

--- a/docs/snippets/providers/teams-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/teams-snippet-autogenerated.mdx
@@ -25,7 +25,8 @@ actions:
         sections: {value}  # For MessageCard: Array of custom information sections. For Adaptive Cards: Array of card elements following the Adaptive Card schema. Can be provided as a JSON string or array.
         schema: {value}  # Schema URL for Adaptive Cards. Default is "http://adaptivecards.io/schemas/adaptive-card.json"
         attachments: {value}  # Custom attachments array for Adaptive Cards (overrides default attachment structure). Can be provided as a JSON string or array.
-        mentions: {value}  # List of user mentions to include in the Adaptive Card. Each mention should be a dict with 'id' and 'name' keys. Can be provided as a JSON string or array.
+        mentions: {value}  # List of user mentions to include in the Adaptive Card. Each mention should be a dict with 'id' (user ID, Microsoft Entra Object ID, or UPN) and 'name' (display name) keys.
+Example: [{"id": "user-id-123", "name": "John Doe"}, {"id": "john.doe@example.com", "name": "John Doe"}]
 ```
 
 
@@ -33,5 +34,5 @@ actions:
 
 Check the following workflow examples:
 - [create_jira_ticket_upon_alerts.yml](https://github.com/keephq/keep/blob/main/examples/workflows/create_jira_ticket_upon_alerts.yml)
-- [keep-teams-adaptive-cards.yaml](https://github.com/keephq/keep/blob/main/examples/workflows/keep-teams-adaptive-cards.yaml)
 - [keep-teams-adaptive-cards-with-mentions.yaml](https://github.com/keephq/keep/blob/main/examples/workflows/keep-teams-adaptive-cards-with-mentions.yaml)
+- [keep-teams-adaptive-cards.yaml](https://github.com/keephq/keep/blob/main/examples/workflows/keep-teams-adaptive-cards.yaml)

--- a/examples/workflows/keep-teams-adaptive-cards-with-mentions.yaml
+++ b/examples/workflows/keep-teams-adaptive-cards-with-mentions.yaml
@@ -1,0 +1,24 @@
+workflow:
+  id: teams-adaptive-card-with-mentions
+  name: Teams Adaptive Card With Mentions
+  description: Sends Microsoft Teams notifications using Adaptive Cards with user mentions to notify specific team members.
+  disabled: false
+  triggers:
+    - type: manual
+    - filters:
+        - key: source
+          value: r".*"
+      type: alert
+  consts: {}
+  owners: []
+  services: []
+  steps: []
+  actions:
+    - name: teams-action
+      provider:
+        config: "{{ providers.teams }}"
+        type: teams
+        with:
+          typeCard: message
+          sections: '[{"type": "TextBlock", "text": "Alert: {{alert.name}}"}, {"type": "TextBlock", "text": "Hello <at>John Doe</at>, please review this alert!"}, {"type": "TextBlock", "text": "Severity: {{alert.severity}}"}]'
+          mentions: '[{"id": "john.doe@example.com", "name": "John Doe"}]'

--- a/examples/workflows/keep-teams-adaptive-cards.yaml
+++ b/examples/workflows/keep-teams-adaptive-cards.yaml
@@ -2,23 +2,23 @@ workflow:
   id: teams-adaptive-card-notifier
   name: Teams Adaptive Card Notifier
   description: Sends customized Microsoft Teams notifications using Adaptive Cards with dynamic alert information and formatted sections.
-disabled: false
-triggers:
-  - type: manual
-  - filters:
-      - key: source
-        value: r".*"
-    type: alert
-consts: {}
-owners: []
-services: []
-steps: []
-actions:
-  - name: teams-action
-    provider:
-      config: "{{ providers.teams }}"
-      type: teams
-      with:
-        message: ""
-        sections: '[{"type": "TextBlock", "text": "{{alert.name}}"}, {"type": "TextBlock", "text": "Tal from Keep"}]'
-        typeCard: message
+  disabled: false
+  triggers:
+    - type: manual
+    - filters:
+        - key: source
+          value: r".*"
+      type: alert
+  consts: {}
+  owners: []
+  services: []
+  steps: []
+  actions:
+    - name: teams-action
+      provider:
+        config: "{{ providers.teams }}"
+        type: teams
+        with:
+          message: ""
+          sections: '[{"type": "TextBlock", "text": "{{alert.name}}"}, {"type": "TextBlock", "text": "Tal from Keep"}]'
+          typeCard: message

--- a/tests/test_teams_provider.py
+++ b/tests/test_teams_provider.py
@@ -1,0 +1,206 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.models.provider_config import ProviderConfig
+from keep.providers.teams_provider.teams_provider import TeamsProvider
+
+
+@pytest.fixture
+def teams_provider():
+    """Create a Teams provider instance for testing"""
+    context_manager = ContextManager(
+        tenant_id="test-tenant", workflow_id="test-workflow"
+    )
+    config = ProviderConfig(
+        id="teams-test",
+        description="Teams Output Provider",
+        authentication={"webhook_url": "https://example.webhook.office.com/webhook"},
+    )
+    return TeamsProvider(context_manager, provider_id="teams-test", config=config)
+
+
+@pytest.fixture
+def mock_response():
+    """Create a mock response for requests.post"""
+    response = MagicMock()
+    response.ok = True
+    response.text = "Success"
+    return response
+
+
+@patch("requests.post")
+def test_notify_with_mentions(mock_post, teams_provider, mock_response):
+    """Test sending an Adaptive Card with a single user mention"""
+    # Setup mock response
+    mock_post.return_value = mock_response
+
+    # Test with mentions
+    result = teams_provider.notify(
+        typeCard="message",
+        sections=[
+            {
+                "type": "TextBlock",
+                "text": "Hello <at>John Doe</at>, please review this alert!",
+            }
+        ],
+        mentions=[{"id": "john.doe@example.com", "name": "John Doe"}],
+    )
+
+    # Verify the response
+    assert result == {"response_text": "Success"}
+
+    # Verify the request payload
+    mock_post.assert_called_once()
+    payload = mock_post.call_args[1]["json"]
+
+    # Check that the payload has the correct structure
+    assert payload["type"] == "message"
+    assert len(payload["attachments"]) == 1
+
+    # Check the attachment content
+    attachment = payload["attachments"][0]
+    assert attachment["contentType"] == "application/vnd.microsoft.card.adaptive"
+    assert attachment["contentUrl"] is None
+
+    # Check the card content
+    card_content = attachment["content"]
+    assert card_content["type"] == "AdaptiveCard"
+    assert card_content["version"] == "1.2"
+
+    # Check the body
+    assert len(card_content["body"]) == 1
+    assert card_content["body"][0]["type"] == "TextBlock"
+    assert (
+        card_content["body"][0]["text"]
+        == "Hello <at>John Doe</at>, please review this alert!"
+    )
+
+    # Check the mentions
+    assert "msteams" in card_content
+    assert "entities" in card_content["msteams"]
+    assert len(card_content["msteams"]["entities"]) == 1
+
+    entity = card_content["msteams"]["entities"][0]
+    assert entity["type"] == "mention"
+    assert entity["text"] == "<at>John Doe</at>"
+    assert entity["mentioned"]["id"] == "john.doe@example.com"
+    assert entity["mentioned"]["name"] == "John Doe"
+
+
+@patch("requests.post")
+def test_notify_with_multiple_mentions(mock_post, teams_provider, mock_response):
+    """Test sending an Adaptive Card with multiple user mentions"""
+    # Setup mock response
+    mock_post.return_value = mock_response
+
+    # Test with multiple mentions
+    result = teams_provider.notify(
+        typeCard="message",
+        sections=[
+            {
+                "type": "TextBlock",
+                "text": "Hello <at>John Doe</at> and <at>Jane Smith</at>, please review this alert!",
+            }
+        ],
+        mentions=[
+            {"id": "john.doe@example.com", "name": "John Doe"},
+            {"id": "49c4641c-ab91-4248-aebb-6a7de286397b", "name": "Jane Smith"},
+        ],
+    )
+
+    # Verify the response
+    assert result == {"response_text": "Success"}
+
+    # Verify the request payload
+    mock_post.assert_called_once()
+    payload = mock_post.call_args[1]["json"]
+
+    # Check the mentions
+    card_content = payload["attachments"][0]["content"]
+    assert "msteams" in card_content
+    assert "entities" in card_content["msteams"]
+    assert len(card_content["msteams"]["entities"]) == 2
+
+    # Check first mention
+    entity1 = card_content["msteams"]["entities"][0]
+    assert entity1["type"] == "mention"
+    assert entity1["text"] == "<at>John Doe</at>"
+    assert entity1["mentioned"]["id"] == "john.doe@example.com"
+    assert entity1["mentioned"]["name"] == "John Doe"
+
+    # Check second mention
+    entity2 = card_content["msteams"]["entities"][1]
+    assert entity2["type"] == "mention"
+    assert entity2["text"] == "<at>Jane Smith</at>"
+    assert entity2["mentioned"]["id"] == "49c4641c-ab91-4248-aebb-6a7de286397b"
+    assert entity2["mentioned"]["name"] == "Jane Smith"
+
+
+@patch("requests.post")
+def test_notify_with_invalid_mention_format(mock_post, teams_provider, mock_response):
+    """Test sending an Adaptive Card with invalid mention format"""
+    # Setup mock response
+    mock_post.return_value = mock_response
+
+    # Test with invalid mention format
+    result = teams_provider.notify(
+        typeCard="message",
+        sections=[
+            {
+                "type": "TextBlock",
+                "text": "Hello <at>John Doe</at>, please review this alert!",
+            }
+        ],
+        mentions=[{"name": "John Doe"}],  # Missing 'id' field
+    )
+
+    # Verify the response
+    assert result == {"response_text": "Success"}
+
+    # Verify the request payload
+    mock_post.assert_called_once()
+    payload = mock_post.call_args[1]["json"]
+
+    # Check that no mentions were added due to invalid format
+    card_content = payload["attachments"][0]["content"]
+    assert "msteams" not in card_content
+
+
+@patch("requests.post")
+def test_notify_with_string_mentions(mock_post, teams_provider, mock_response):
+    """Test sending an Adaptive Card with mentions provided as a JSON string"""
+    # Setup mock response
+    mock_post.return_value = mock_response
+
+    # Test with mentions as JSON string
+    result = teams_provider.notify(
+        typeCard="message",
+        sections=[
+            {
+                "type": "TextBlock",
+                "text": "Hello <at>John Doe</at>, please review this alert!",
+            }
+        ],
+        mentions='[{"id": "john.doe@example.com", "name": "John Doe"}]',
+    )
+
+    # Verify the response
+    assert result == {"response_text": "Success"}
+
+    # Verify the request payload
+    mock_post.assert_called_once()
+    payload = mock_post.call_args[1]["json"]
+
+    # Check the mentions
+    card_content = payload["attachments"][0]["content"]
+    assert "msteams" in card_content
+    assert "entities" in card_content["msteams"]
+    assert len(card_content["msteams"]["entities"]) == 1
+
+    entity = card_content["msteams"]["entities"][0]
+    assert entity["type"] == "mention"
+    assert entity["text"] == "<at>John Doe</at>"
+    assert entity["mentioned"]["id"] == "john.doe@example.com"
+    assert entity["mentioned"]["name"] == "John Doe"


### PR DESCRIPTION
Closes #3599

## 📑 Description

Add support for user mentions in Adaptive Cards for Teams notifications.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information

https://github.com/user-attachments/assets/4c5d349f-b201-4cfd-87fd-b20896f7ca24


