### PR TITLE
fix: Replace alerts_count calculation with subquery and add recalculation migration

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -42,6 +42,7 @@ from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import foreign, joinedload, subqueryload
 from sqlalchemy.orm.exc import StaleDataError
 from sqlalchemy.sql import exists, expression
+from sqlalchemy.sql.functions import count
 from sqlmodel import Session, SQLModel, col, or_, select, text
 
 from keep.api.consts import STATIC_PRESETS
@@ -4225,7 +4226,6 @@ def get_alerts_data_for_incident(
             "sources": set(sources),
             "services": set(services),
             "max_severity": max(severities) if severities else IncidentSeverity.LOW,
-            "count": len(alerts_data),
         }
 
 
@@ -4299,10 +4299,6 @@ def add_alerts_to_incident(
             if not new_fingerprints:
                 return incident
 
-            alerts_data_for_incident = get_alerts_data_for_incident(
-                tenant_id, new_fingerprints, session
-            )
-
             alert_to_incident_entries = [
                 LastAlertToIncident(
                     fingerprint=str(fingerprint),  # it may sometime be UUID...
@@ -4325,18 +4321,22 @@ def add_alerts_to_incident(
                     session.flush()
             session.commit()
 
-            incident.sources = list(
+            alerts_data_for_incident = get_alerts_data_for_incident(
+                tenant_id, new_fingerprints, session
+            )
+
+            new_sources = list(
                 set(incident.sources if incident.sources else [])
                 | set(alerts_data_for_incident["sources"])
             )
-            incident.affected_services = list(
+            new_affected_services = list(
                 set(incident.affected_services if incident.affected_services else [])
                 | set(alerts_data_for_incident["services"])
             )
             if not incident.forced_severity:
                 # If incident has alerts already, use the max severity between existing and new alerts,
                 # otherwise use the new alerts max severity
-                incident.severity = (
+                new_severity = (
                     max(
                         incident.severity,
                         alerts_data_for_incident["max_severity"].order,
@@ -4344,11 +4344,20 @@ def add_alerts_to_incident(
                     if incident.alerts_count
                     else alerts_data_for_incident["max_severity"].order
                 )
+            else:
+                new_severity = incident.severity
 
             if not override_count:
-                incident.alerts_count += alerts_data_for_incident["count"]
+                alerts_count = (
+                    select(count(LastAlertToIncident.fingerprint))
+                    .where(
+                        LastAlertToIncident.deleted_at == NULL_FOR_DELETED_AT,
+                        LastAlertToIncident.tenant_id == tenant_id,
+                        LastAlertToIncident.incident_id == incident.id,
+                    )
+                ).subquery()
             else:
-                incident.alerts_count = alerts_data_for_incident["count"]
+                alerts_count = alerts_data_for_incident["count"]
 
             last_received_field = get_json_extract_field(
                 session, Alert.event, "lastReceived"
@@ -4376,12 +4385,24 @@ def add_alerts_to_incident(
             if isinstance(last_seen_at, str):
                 last_seen_at = parse(last_seen_at)
 
-            incident.start_time = started_at
-            incident.last_seen_time = last_seen_at
             incident_id = incident.id
+
             for attempt in range(max_retries):
                 try:
-                    session.add(incident)
+                    session.exec(
+                        update(Incident)
+                        .where(
+                            Incident.id == incident_id,
+                            Incident.tenant_id == tenant_id,
+                        ).values(
+                            alerts_count = alerts_count,
+                            last_seen_time = last_seen_at,
+                            start_time = started_at,
+                            affected_services = new_affected_services,
+                            severity = new_severity,
+                            sources = new_sources,
+                        )
+                    )
                     session.commit()
                     break
                 except StaleDataError as ex:
@@ -4393,6 +4414,7 @@ def add_alerts_to_incident(
                         continue
                     else:
                         raise
+            session.add(incident)
             session.refresh(incident)
 
             return incident
@@ -4588,22 +4610,23 @@ def remove_alerts_to_incident_by_incident_id(
         ).one()
 
         # filtering removed entities from affected services and sources in the incident
-        incident.affected_services = [
+        new_affected_services = [
             service
             for service in incident.affected_services
             if service not in services_to_remove
         ]
-        incident.sources = [
+        new_sources = [
             source for source in incident.sources if source not in sources_to_remove
         ]
 
-        incident.alerts_count -= alerts_data_for_incident["count"]
         if not incident.forced_severity:
-            incident.severity = (
+            new_severity = (
                 max(updated_severities)
                 if updated_severities
                 else IncidentSeverity.LOW.order
             )
+        else:
+            new_severity = incident.severity
 
         if isinstance(started_at, str):
             started_at = parse(started_at)
@@ -4611,11 +4634,32 @@ def remove_alerts_to_incident_by_incident_id(
         if isinstance(last_seen_at, str):
             last_seen_at = parse(last_seen_at)
 
-        incident.start_time = started_at
-        incident.last_seen_time = last_seen_at
+        alerts_count = (
+            select(count(LastAlertToIncident.fingerprint))
+            .where(
+                LastAlertToIncident.deleted_at == NULL_FOR_DELETED_AT,
+                LastAlertToIncident.tenant_id == tenant_id,
+                LastAlertToIncident.incident_id == incident.id,
+            )
+        ).subquery()
 
-        session.add(incident)
+        session.exec(
+            update(Incident)
+            .where(
+                Incident.id == incident_id,
+                Incident.tenant_id == tenant_id,
+            ).values(
+                alerts_count=alerts_count,
+                last_seen_time=last_seen_at,
+                start_time=started_at,
+                affected_services=new_affected_services,
+                severity=new_severity,
+                sources=new_sources,
+            )
+        )
         session.commit()
+        session.add(incident)
+        session.refresh(incident)
 
         return deleted
 

--- a/keep/api/models/db/migrations/versions/2025-05-06-13-09_7b687c555318.py
+++ b/keep/api/models/db/migrations/versions/2025-05-06-13-09_7b687c555318.py
@@ -1,0 +1,55 @@
+"""Recalculate alerts_count for incidents
+
+Revision ID: 7b687c555318
+Revises: eddcb77eb6f3
+Create Date: 2025-05-06 13:09:27.462927
+
+"""
+from collections import defaultdict
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+import sqlmodel
+from alembic import op
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.functions import count
+
+from keep.api.models.db.alert import LastAlertToIncident
+from keep.api.models.db.incident import Incident
+
+# revision identifiers, used by Alembic.
+revision = "7b687c555318"
+down_revision = "eddcb77eb6f3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    session = Session(op.get_bind())
+    counts = session.execute(
+        select(count(LastAlertToIncident.fingerprint), LastAlertToIncident.incident_id)
+        .group_by(
+            LastAlertToIncident.incident_id
+        )
+    ).all()
+    counts_per_incident = defaultdict(int)
+    for count_, incident_id in counts:
+        counts_per_incident[incident_id] = count_
+
+    incident_ids = session.execute(select(Incident.id)).scalars().all()
+
+    for incident_id in incident_ids:
+        session.execute(
+            update(Incident)
+            .where(
+                Incident.id == str(incident_id)
+            )
+            .values(
+                alerts_count = counts_per_incident.get(incident_id, 0)
+            )
+        )
+        session.commit()
+
+def downgrade() -> None:
+    pass

--- a/keep/api/models/db/migrations/versions/2025-05-06-13-09_7b687c555318.py
+++ b/keep/api/models/db/migrations/versions/2025-05-06-13-09_7b687c555318.py
@@ -7,9 +7,6 @@ Create Date: 2025-05-06 13:09:27.462927
 """
 from collections import defaultdict
 
-import sqlalchemy as sa
-import sqlalchemy_utils
-import sqlmodel
 from alembic import op
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -68,7 +68,6 @@ def test_get_alerts_data_for_incident(db_session, create_alert):
     )
     assert data["sources"] == set([f"source_{i}" for i in range(10)])
     assert data["services"] == set([f"service_{i}" for i in range(10)])
-    assert data["count"] == unique_fingerprints
 
 
 def test_add_remove_alert_to_incidents(db_session, setup_stress_alerts_no_elastic):


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4477 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
