### PR TITLE
feat: bypass existing Grafana/Prometheus fingerprints without SHA-256 hashing

### DIFF
--- a/api/utils/fingerprint_utils.py
+++ b/api/utils/fingerprint_utils.py
@@ -1,0 +1,17 @@
+"""Utility functions for working with alert fingerprints."""
+
+import re
+
+def is_hashed_fingerprint(fingerprint: str) -> bool:
+    """
+    Check if a fingerprint appears to be a SHA256 hash.
+    
+    Args:
+        fingerprint: The fingerprint to check
+        
+    Returns:
+        bool: True if the fingerprint appears to be a SHA256 hash, False otherwise
+    """
+    # SHA256 hashes are 64 characters long and contain only hex digits
+    SHA256_PATTERN = re.compile(r'^[a-f0-9]{64}$')
+    return bool(SHA256_PATTERN.match(fingerprint)) 

--- a/keep/providers/keep_provider/keep_provider.py
+++ b/keep/providers/keep_provider/keep_provider.py
@@ -163,13 +163,19 @@ class KeepProvider(BaseProvider):
         for key, val in alert_data.items():
             if not hasattr(alert, key):
                 setattr(alert, key, val)
-        # if fingerprint_fields are not provided, use labels
-        if not fingerprint_fields:
-            fingerprint_fields = ["labels." + label for label in list(labels.keys())]
+                
+        # Check for original fingerprint in labels or alert data
+        original_fingerprint = labels.get("fingerprint") or alert_data.get("fingerprint")
+        if original_fingerprint:
+            alert.fingerprint = original_fingerprint
+        else:
+            # if fingerprint_fields are not provided, use labels
+            if not fingerprint_fields:
+                fingerprint_fields = ["labels." + label for label in list(labels.keys())]
 
-        # workflowId is used as the "rule id" - it's used to identify the rule that created the alert
-        fingerprint_fields.append("workflowId")
-        alert.fingerprint = self.get_alert_fingerprint(alert, fingerprint_fields)
+            # workflowId is used as the "rule id" - it's used to identify the rule that created the alert
+            fingerprint_fields.append("workflowId")
+            alert.fingerprint = self.get_alert_fingerprint(alert, fingerprint_fields)
         return alert
 
     def _handle_state_alerts(

--- a/scripts/cleanup_test_logs.py
+++ b/scripts/cleanup_test_logs.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import os
+import glob
+from pathlib import Path
+
+
+def cleanup_test_logs(directory: str = ".") -> tuple[int, list[str]]:
+    """
+    Clean up Playwright test log files and other test artifacts.
+    
+    Args:
+        directory: The root directory to start searching from
+        
+    Returns:
+        tuple: (number of files deleted, list of deleted files)
+    """
+    # Patterns to match test artifacts
+    patterns = [
+        "requests_playwright_dump_utils_*.log",  # Playwright request utility logs
+        "requests_playwright_dump_*.log",        # Playwright request logs
+        "playwright_dump_*.html",                # HTML dumps
+        "playwright_dump_*.png",                 # Screenshots
+        "playwright_dump_*.txt",                 # Text dumps
+        "playwright_dump_*.json",                # JSON dumps
+    ]
+    
+    deleted_files = []
+    
+    # Convert directory to absolute path
+    abs_directory = os.path.abspath(directory)
+    
+    # Find and delete files matching patterns
+    for pattern in patterns:
+        # Use recursive glob to find files in all subdirectories
+        for file_path in glob.glob(os.path.join(abs_directory, "**", pattern), recursive=True):
+            try:
+                os.remove(file_path)
+                deleted_files.append(file_path)
+            except (OSError, PermissionError) as e:
+                print(f"Error deleting {file_path}: {e}")
+    
+    return len(deleted_files), deleted_files
+
+
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Clean up Playwright test log files and artifacts")
+    parser.add_argument("--directory", "-d", default=".",
+                       help="Root directory to start searching from (default: current directory)")
+    parser.add_argument("--verbose", "-v", action="store_true",
+                       help="Print detailed information about deleted files")
+    
+    args = parser.parse_args()
+    
+    count, files = cleanup_test_logs(args.directory)
+    
+    print(f"Cleaned up {count} test artifact files")
+    if args.verbose:
+        print("\nDeleted files:")
+        for file in files:
+            print(f"  - {file}") 

--- a/tests/integration/test_prometheus_fingerprint.py
+++ b/tests/integration/test_prometheus_fingerprint.py
@@ -1,0 +1,88 @@
+import os
+import logging
+
+logging.disable(logging.CRITICAL)
+
+# ─── Disable background services BEFORE importing app ───
+os.environ["SCHEDULER"] = "false"
+os.environ["CONSUMER"] = "false"
+os.environ["KEEP_TOPOLOGY_PROCESSOR"] = "false"
+os.environ["KEEP_USE_LIMITER"] = "false"
+os.environ["KEEP_METRICS"] = "false"
+os.environ["KEEP_OTEL_ENABLED"] = "false"
+os.environ["KEEP_DISABLE_SECRETS"] = "true"
+
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from keep.api.api import get_app
+
+app = get_app()
+
+# inject the minimal state so the real exception handler won’t blow up
+@app.middleware("http")
+async def _inject_test_state(request: Request, call_next):
+    request.state.trace_id = "test-trace"
+    request.state.tenant_id = "anonymous"
+    return await call_next(request)
+
+# catch‐all override just in case
+@app.exception_handler(Exception)
+async def _test_catch_all(request: Request, exc: Exception):
+    return JSONResponse(status_code=500, content={"error": str(exc)})
+
+
+@pytest.mark.parametrize("body", [
+    # 1) explicit fingerprint at root
+    {
+      "summary": "Test Prometheus Root Fingerprint",
+      "labels": {
+        "severity": "critical",
+        "service": "test-service",
+        "alertname": "TestPrometheusRoot"
+      },
+      "status": "firing",
+      "annotations": { "summary": "Testing fingerprint at root level" },
+      "fingerprint": "explicit-root-fingerprint-123"
+    },
+    # 2) explicit fingerprint in labels
+    {
+      "summary": "Test Prometheus Label Fingerprint",
+      "labels": {
+        "severity": "critical",
+        "service": "test-service",
+        "alertname": "TestPrometheusLabel",
+        "fingerprint": "explicit-label-fingerprint-456"
+      },
+      "status": "firing",
+      "annotations": { "summary": "Testing fingerprint in labels" }
+    },
+    # 3) no fingerprint → SHA is generated internally
+    {
+      "summary": "Test Prometheus No Fingerprint",
+      "labels": {
+        "severity": "critical",
+        "service": "test-service",
+        "alertname": "TestPrometheusNoFingerprint"
+      },
+      "status": "firing",
+      "annotations": { "summary": "Testing with no fingerprint" }
+    },
+])
+def test_prometheus_event_accepted(body):
+    with TestClient(app) as client:
+        response = client.post(
+            "/alerts/event/prometheus",
+            json=body,
+            headers={"X-API-KEY": "localhost"},
+        )
+
+    # the API enqueues and returns 202
+    assert response.status_code == 202
+
+    # and returns a JSON body with a non‐empty "task_name"
+    data = response.json()
+    assert "task_name" in data
+    assert isinstance(data["task_name"], str) and data["task_name"].strip() != ""


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2312 

## 📑 Description
This PR allows bypassing incoming alert fingerprints (from Grafana or Prometheus) without applying SHA-256 hashing, ensuring the original tool-provided fingerprint is preserved for alignment between systems.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
- Default SHA-256 fingerprinting remains for alerts without an explicit `fingerprint` field
