### PR TITLE
fix: Fixed recalculate alerts_count for incidents migration

### DIFF
--- a/keep/api/models/db/migrations/versions/2025-05-06-13-09_7b687c555318.py
+++ b/keep/api/models/db/migrations/versions/2025-05-06-13-09_7b687c555318.py
@@ -6,16 +6,6 @@ Create Date: 2025-05-06 13:09:27.462927
 
 """
 
-from collections import defaultdict
-
-from alembic import op
-from sqlalchemy import select, update
-from sqlalchemy.orm import Session
-from sqlalchemy.sql.functions import count
-
-from keep.api.models.db.alert import LastAlertToIncident
-from keep.api.models.db.incident import Incident
-
 # revision identifiers, used by Alembic.
 revision = "7b687c555318"
 down_revision = "eddcb77eb6f3"
@@ -24,25 +14,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    session = Session(op.get_bind())
-    counts = session.execute(
-        select(
-            count(LastAlertToIncident.fingerprint), LastAlertToIncident.incident_id
-        ).group_by(LastAlertToIncident.incident_id)
-    ).all()
-    counts_per_incident = defaultdict(int)
-    for count_, incident_id in counts:
-        counts_per_incident[incident_id] = count_
-
-    incident_ids = session.execute(select(Incident.id)).scalars().all()
-
-    for incident_id in incident_ids:
-        session.execute(
-            update(Incident)
-            .where(Incident.id == incident_id)
-            .values(alerts_count=counts_per_incident.get(incident_id, 0))
-        )
-        session.commit()
+    pass
 
 
 def downgrade() -> None:

--- a/keep/api/models/db/migrations/versions/2025-05-12-17-49_c2f78c69e9cf.py
+++ b/keep/api/models/db/migrations/versions/2025-05-12-17-49_c2f78c69e9cf.py
@@ -1,0 +1,51 @@
+"""Recalculate alerts_count for incidents
+
+Revision ID: c2f78c69e9cf
+Revises: 7b687c555318
+Create Date: 2025-05-12 17:49:09.779088
+
+"""
+
+from collections import defaultdict
+
+from alembic import op
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.functions import count
+
+from keep.api.models.db.alert import LastAlertToIncident
+from keep.api.models.db.helpers import NULL_FOR_DELETED_AT
+from keep.api.models.db.incident import Incident
+
+# revision identifiers, used by Alembic.
+revision = "c2f78c69e9cf"
+down_revision = "7b687c555318"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    session = Session(op.get_bind())
+    counts = session.execute(
+        select(
+        count(LastAlertToIncident.fingerprint), LastAlertToIncident.incident_id
+        )
+        .where(LastAlertToIncident.deleted_at == NULL_FOR_DELETED_AT)
+        .group_by(LastAlertToIncident.incident_id)
+    ).all()
+    counts_per_incident = defaultdict(int)
+    for count_, incident_id in counts:
+        counts_per_incident[incident_id] = count_
+
+    incident_ids = session.execute(select(Incident.id)).scalars().all()
+
+    for incident_id in incident_ids:
+        session.execute(
+            update(Incident)
+            .where(Incident.id == incident_id)
+            .values(alerts_count=counts_per_incident.get(incident_id, 0))
+        )
+        session.commit()
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4477

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
