### PR TITLE
fix: use 0.01 for 0s executions and use log scale in wf graphs

### DIFF
--- a/keep-ui/app/(keep)/workflows/[workflow_id]/workflow-overview.tsx
+++ b/keep-ui/app/(keep)/workflows/[workflow_id]/workflow-overview.tsx
@@ -134,6 +134,7 @@ export default function WorkflowOverview({
           <Card>
             <Title>Executions Graph</Title>
             <WorkflowGraph
+              full
               showLastExecutionStatus={false}
               workflow={workflow}
               limit={executionPagination.limit}

--- a/keep-ui/app/(keep)/workflows/workflow-graph.tsx
+++ b/keep-ui/app/(keep)/workflows/workflow-graph.tsx
@@ -30,7 +30,9 @@ Chart.register(
   Legend
 );
 
-const baseChartOptions = {
+type BarChartOptions = Parameters<typeof Bar>[0]["options"];
+
+const baseChartOptions: BarChartOptions = {
   scales: {
     x: {
       beginAtZero: true,
@@ -43,9 +45,9 @@ const baseChartOptions = {
       border: {
         display: false,
       },
+      type: "linear",
     },
     y: {
-      beginAtZero: true,
       ticks: {
         display: false,
       },
@@ -67,12 +69,12 @@ const baseChartOptions = {
   maintainAspectRatio: false,
 };
 
-const fullChartOptions = {
+const fullChartOptions: BarChartOptions = {
   ...baseChartOptions,
   scales: {
     ...baseChartOptions.scales,
     y: {
-      ...baseChartOptions.scales.y,
+      ...baseChartOptions.scales?.y,
       grid: {
         display: true,
       },

--- a/keep-ui/app/(keep)/workflows/workflow-utils.ts
+++ b/keep-ui/app/(keep)/workflows/workflow-utils.ts
@@ -1,69 +1,9 @@
 import { differenceInSeconds } from "date-fns";
 import { LastWorkflowExecution } from "@/shared/api/workflows";
 
-const demoLabels = [
-  "Jan",
-  "Feb",
-  "Mar",
-  "Apr",
-  "May",
-  "Jun",
-  "Jul",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec",
-];
-
-const demoData = [1, 3, 2, 2, 8, 1, 3, 5, 2, 10, 1, 3, 5, 2, 10];
-
-const demoBgColors = [
-  "rgba(75, 192, 192, 0.2)", // Green
-  "rgba(255, 99, 132, 0.2)", // Red
-  "rgba(75, 192, 192, 0.2)", // Green
-  "rgba(255, 99, 132, 0.2)", // Red
-  "rgba(75, 192, 192, 0.2)", // Green
-  "rgba(255, 99, 132, 0.2)", // Red
-  "rgba(75, 192, 192, 0.2)", // Green
-  "rgba(255, 99, 132, 0.2)", // Red
-  "rgba(75, 192, 192, 0.2)", // Green
-  "rgba(255, 99, 132, 0.2)", // Red
-  "rgba(75, 192, 192, 0.2)", // Green
-  "rgba(255, 99, 132, 0.2)", // Red
-  "rgba(255, 99, 132, 0.2)", // Red
-  "rgba(75, 192, 192, 0.2)", // Green
-  "rgba(255, 99, 132, 0.2)", // Red
-];
-
-const demoColors = [
-  "rgba(75, 192, 192, 1)", // Green
-  "rgba(255, 99, 132, 1)", // Red
-  "rgba(75, 192, 192, 1)", // Green
-  "rgba(255, 99, 132, 1)", // Red
-  "rgba(75, 192, 192, 1)", // Green
-  "rgba(255, 99, 132, 1)", // Red
-  "rgba(75, 192, 192, 1)", // Green
-  "rgba(255, 99, 132, 1)", // Red
-  "rgba(75, 192, 192, 1)", // Green
-  "rgba(255, 99, 132, 1)", // Red
-  "rgba(75, 192, 192, 1)", // Green
-  "rgba(255, 99, 132, 1)", // Red
-  "rgba(255, 99, 132, 1)", // Red
-  "rgba(75, 192, 192, 1)", // Green
-  "rgba(255, 99, 132, 1)", // Red
-];
-export const getLabels = (
-  lastExecutions: LastWorkflowExecution[],
-  show_real_data?: boolean
-) => {
+export const getLabels = (lastExecutions: LastWorkflowExecution[]) => {
   if (!lastExecutions || (lastExecutions && lastExecutions.length === 0)) {
-    return show_real_data ? [] : demoLabels;
+    return [];
   }
   return lastExecutions?.map((workflowExecution) => {
     let started = workflowExecution?.started
@@ -73,21 +13,26 @@ export const getLabels = (
   });
 };
 
-export const getDataValues = (
-  lastExecutions: LastWorkflowExecution[],
-  show_real_data?: boolean
-) => {
+export const getDataValues = (lastExecutions: LastWorkflowExecution[]) => {
   if (!lastExecutions || (lastExecutions && lastExecutions.length === 0)) {
-    return show_real_data ? [] : demoData;
+    return [];
   }
   return lastExecutions?.map((workflowExecution) => {
-    return (
-      workflowExecution?.execution_time ||
-      differenceInSeconds(
+    if (
+      workflowExecution?.execution_time === undefined ||
+      workflowExecution?.execution_time === null
+    ) {
+      return differenceInSeconds(
         new Date(Date.now().toLocaleString()),
         new Date(new Date(workflowExecution?.started + "Z").toLocaleString())
-      )
-    );
+      );
+    }
+    // If the execution time is 0s, return 0.01 to avoid empty graph bars
+    // TODO: either update the backend to return float, milliseconds or decide it's not important
+    if (workflowExecution.execution_time === 0) {
+      return 0.01;
+    }
+    return workflowExecution.execution_time;
   });
 };
 
@@ -105,14 +50,11 @@ const _getColor = (status: string, opacity: number) => {
 export const getColors = (
   lastExecutions: LastWorkflowExecution[],
   status: string,
-  isBgColor?: boolean,
-  show_real_data?: boolean
+  isBgColor?: boolean
 ) => {
   const opacity = isBgColor ? 0.2 : 1;
   if (!lastExecutions || (lastExecutions && lastExecutions.length === 0)) {
-    const tempColors = isBgColor ? [...demoBgColors] : [...demoColors];
-    tempColors[tempColors.length - 1] = _getColor(status, opacity);
-    return show_real_data ? [] : tempColors;
+    return [];
   }
   return lastExecutions?.map((workflowExecution) => {
     const status = workflowExecution?.status?.toLowerCase();
@@ -130,39 +72,3 @@ export function getRandomStatus() {
   ];
   return statuses[Math.floor(Math.random() * statuses.length)];
 }
-
-export const chartOptions = {
-  scales: {
-    x: {
-      beginAtZero: true,
-      ticks: {
-        display: false,
-      },
-      grid: {
-        display: false,
-      },
-      border: {
-        display: false,
-      },
-    },
-    y: {
-      beginAtZero: true,
-      ticks: {
-        display: false,
-      },
-      grid: {
-        display: false,
-      },
-      border: {
-        display: false,
-      },
-    },
-  },
-  plugins: {
-    legend: {
-      display: false,
-    },
-  },
-  responsive: true,
-  maintainAspectRatio: false,
-};


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4778 

Problem: if workflow executed in 0s, graph will not show it as success.
Fix: return 0.01 instead of 0.

Long term we might want to change seconds to milliseconds or something like that.

## Before
<img width="2056" alt="Screenshot 2025-05-14 at 16 25 31" src="https://github.com/user-attachments/assets/fc7af140-0bbd-4386-9e64-e59cedf67afc" />
<img width="2053" alt="Screenshot 2025-05-14 at 16 30 15" src="https://github.com/user-attachments/assets/fb046f79-628a-4f30-9138-9d19ea5c6dfb" />


## After
<img width="2063" alt="Screenshot 2025-05-14 at 16 25 50" src="https://github.com/user-attachments/assets/ad50e932-cc3d-4e28-a4c2-57a34a01edd0" />
<img width="2057" alt="Screenshot 2025-05-14 at 16 25 59" src="https://github.com/user-attachments/assets/cbe09590-1464-4874-8f36-f77823dd3585" />
