### PR TITLE
fix: last executions in get_all_workflows_with_last_execution

### DIFF
--- a/keep-ui/shared/api/workflows.ts
+++ b/keep-ui/shared/api/workflows.ts
@@ -44,6 +44,7 @@ export type Trigger =
   | ManualFilter;
 
 export type LastWorkflowExecution = {
+  id: string;
   execution_time: number;
   status: string;
   started: string;

--- a/keep/api/core/workflows.py
+++ b/keep/api/core/workflows.py
@@ -326,7 +326,7 @@ def get_workflows_with_last_executions_v2(
                     "workflow_last_run_started": started,
                     "workflow_last_run_time": execution_time,
                     "workflow_last_run_status": status,
-                    "workflow_last_executions": execution_dict[workflow.id],
+                    "workflow_last_executions": execution_dict.get(workflow.id, []),
                 }
             )
 

--- a/keep/api/core/workflows.py
+++ b/keep/api/core/workflows.py
@@ -5,10 +5,10 @@ This module contains the CRUD database functions for Keep.
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import Tuple
+from typing import TypedDict, Tuple
 
 from sqlalchemy import and_, case, desc, func, literal_column, select, text
-from sqlmodel import Session, col
+from sqlmodel import Session
 
 from keep.api.core.cel_to_sql.properties_metadata import (
     FieldMappingConfiguration,
@@ -248,6 +248,14 @@ def build_workflows_query(
     return query
 
 
+class WorkflowWithLastExecutions(TypedDict):
+    workflow: Workflow
+    workflow_last_run_started: datetime
+    workflow_last_run_time: datetime
+    workflow_last_run_status: str
+    workflow_last_executions: list[WorkflowExecution]
+
+
 def get_workflows_with_last_executions_v2(
     tenant_id: str,
     cel: str,
@@ -257,7 +265,7 @@ def get_workflows_with_last_executions_v2(
     sort_dir: str,
     fetch_last_executions: int = 15,
     session: Session = None,
-):
+) -> Tuple[list[WorkflowWithLastExecutions], int]:
     with existed_or_new_session(session) as session:
         total_count_query = build_workflows_total_count_query(
             tenant_id=tenant_id, cel=cel

--- a/keep/api/routes/workflows.py
+++ b/keep/api/routes/workflows.py
@@ -232,8 +232,6 @@ def query_workflows(
             detail=f"Error parsing CEL expression: {query.cel}",
         ) from e
 
-    workflows = workflowstore.group_last_workflow_executions(workflows=workflows)
-
     # iterate workflows
     for _workflow in workflows:
         workflow = _workflow["workflow"]

--- a/keep/workflowmanager/workflowstore.py
+++ b/keep/workflowmanager/workflowstore.py
@@ -330,9 +330,7 @@ class WorkflowStore:
         # Get all existing provisioned workflows
         logger.info("Getting all already provisioned workflows")
         provisioned_workflows = get_all_provisioned_workflows(tenant_id)
-        logger.info(
-            f"Found {len(provisioned_workflows)} provisioned workflows"
-        )
+        logger.info(f"Found {len(provisioned_workflows)} provisioned workflows")
 
         if not (provisioned_workflows_dir or provisioned_workflow_yaml):
             logger.info("No workflows for provisioning found")
@@ -398,7 +396,7 @@ class WorkflowStore:
                 if not pre_parsed_workflow:
                     logger.info("No workflows to provision")
                     return []
-                
+
                 logger.info(
                     f"Provisioning workflow {pre_parsed_workflow.id} from env var"
                 )
@@ -426,7 +424,7 @@ class WorkflowStore:
 
         ### Provisioning from the directory
         if provisioned_workflows_dir is not None:
-            
+
             logger.info(
                 f"Provisioning workflows from directory {provisioned_workflows_dir}"
             )
@@ -483,9 +481,7 @@ class WorkflowStore:
                             extra={"exception": e},
                         )
                 else:
-                    logger.info(
-                        f"Skipping file {file} as it is not a YAML file"
-                    )
+                    logger.info(f"Skipping file {file} as it is not a YAML file")
 
         return provisioned_workflows
 
@@ -626,7 +622,7 @@ class WorkflowStore:
         self.logger.info(f"workflow_executions: {workflows}")
         workflow_dict = {}
         for item in workflows:
-            workflow, started, execution_time, status = item
+            workflow, started, execution_time, status, execution_id = item
             workflow_id = workflow.id
 
             # Initialize the workflow if not already in the dictionary
@@ -646,9 +642,13 @@ class WorkflowStore:
                 workflow_dict[workflow_id]["workflow_last_run_time"] = started
 
             # Add the execution to the list of executions
-            if started is not None:
+            if started is not None and execution_id not in [
+                e["execution_id"]
+                for e in workflow_dict[workflow_id]["workflow_last_executions"]
+            ]:
                 workflow_dict[workflow_id]["workflow_last_executions"].append(
                     {
+                        "execution_id": execution_id,
                         "status": status,
                         "execution_time": execution_time,
                         "started": started,

--- a/keep/workflowmanager/workflowstore.py
+++ b/keep/workflowmanager/workflowstore.py
@@ -174,7 +174,7 @@ class WorkflowStore:
         sort_by: str = None,
         sort_dir: str = None,
         session=None,
-    ) -> Tuple[list[dict], int]:
+    ):
         # list all tenant's workflows
         return get_workflows_with_last_executions_v2(
             tenant_id=tenant_id,

--- a/keep/workflowmanager/workflowstore.py
+++ b/keep/workflowmanager/workflowstore.py
@@ -614,60 +614,6 @@ class WorkflowStore:
 
         return workflows[query.offset : query.offset + query.limit], len(workflows)
 
-    def group_last_workflow_executions(self, workflows: list[dict]) -> list[dict]:
-        """
-        Group last workflow executions by workflow id
-        """
-
-        self.logger.info(f"workflow_executions: {workflows}")
-        workflow_dict = {}
-        for item in workflows:
-            workflow, started, execution_time, status, execution_id = item
-            workflow_id = workflow.id
-
-            # Initialize the workflow if not already in the dictionary
-            if workflow_id not in workflow_dict:
-                workflow_dict[workflow_id] = {
-                    "workflow": workflow,
-                    "workflow_last_run_started": None,
-                    "workflow_last_run_time": None,
-                    "workflow_last_run_status": None,
-                    "workflow_last_executions": [],
-                }
-
-            # Update the latest execution details if available
-            if workflow_dict[workflow_id]["workflow_last_run_started"] is None:
-                workflow_dict[workflow_id]["workflow_last_run_status"] = status
-                workflow_dict[workflow_id]["workflow_last_run_started"] = started
-                workflow_dict[workflow_id]["workflow_last_run_time"] = started
-
-            # Add the execution to the list of executions
-            if started is not None and execution_id not in [
-                e["execution_id"]
-                for e in workflow_dict[workflow_id]["workflow_last_executions"]
-            ]:
-                workflow_dict[workflow_id]["workflow_last_executions"].append(
-                    {
-                        "execution_id": execution_id,
-                        "status": status,
-                        "execution_time": execution_time,
-                        "started": started,
-                    }
-                )
-        # Convert the dictionary to a list of results
-        results = [
-            {
-                "workflow": workflow_info["workflow"],
-                "workflow_last_run_status": workflow_info["workflow_last_run_status"],
-                "workflow_last_run_time": workflow_info["workflow_last_run_time"],
-                "workflow_last_run_started": workflow_info["workflow_last_run_started"],
-                "workflow_last_executions": workflow_info["workflow_last_executions"],
-            }
-            for workflow_id, workflow_info in workflow_dict.items()
-        ]
-
-        return results
-
     def get_workflow_meta_data(
         self,
         tenant_id: str,

--- a/tests/test_workflow_execution.py
+++ b/tests/test_workflow_execution.py
@@ -1888,11 +1888,8 @@ def test_get_all_workflows_with_last_execution(db_session, workflow_manager):
 
     workflowstore = WorkflowStore()
     # Get all workflows with last execution
-    workflows_with_last_execution, count = (
-        workflowstore.get_all_workflows_with_last_execution(SINGLE_TENANT_UUID)
-    )
-    workflows = workflowstore.group_last_workflow_executions(
-        workflows=workflows_with_last_execution
+    workflows, _count = workflowstore.get_all_workflows_with_last_execution(
+        SINGLE_TENANT_UUID
     )
 
     # Verify that the workflow was executed twice

--- a/tests/test_workflow_execution.py
+++ b/tests/test_workflow_execution.py
@@ -1897,16 +1897,14 @@ def test_get_all_workflows_with_last_execution(db_session, workflow_manager):
     assert workflow is not None
     assert len(workflow["workflow_last_executions"]) == 2
     first_execution_wf_store = next(
-        w
-        for w in workflow["workflow_last_executions"]
-        if w["execution_id"] == first_execution.id
+        w for w in workflow["workflow_last_executions"] if w["id"] == first_execution.id
     )
     assert first_execution_wf_store is not None
     assert first_execution_wf_store["status"] == "success"
     second_execution_wf_store = next(
         w
         for w in workflow["workflow_last_executions"]
-        if w["execution_id"] == second_execution.id
+        if w["id"] == second_execution.id
     )
     assert second_execution_wf_store is not None
     assert second_execution_wf_store["status"] == "error"

--- a/tests/test_workflow_execution.py
+++ b/tests/test_workflow_execution.py
@@ -18,7 +18,7 @@ from keep.api.core.db import (
 from keep.api.core.dependencies import SINGLE_TENANT_UUID
 from keep.api.models.alert import AlertDto, AlertStatus, AlertSeverity
 from keep.api.models.db.incident import Incident, IncidentStatus
-from keep.api.models.db.workflow import Workflow, WorkflowExecution
+from keep.api.models.db.workflow import Workflow
 from keep.api.models.incident import IncidentDto
 from keep.api.utils.enrichment_helpers import convert_db_alerts_to_dto_alerts
 from keep.identitymanager.authenticatedentity import AuthenticatedEntity
@@ -119,6 +119,9 @@ workflow:
   description: Simple workflow demonstrating logging every alert
   triggers:
     - type: alert
+      filters:
+        - key: name
+          value: "server-is-upsidedown"
   actions:
     - name: log-every-alert-success
       if: "{{alert.should_fail}} == 'false'"
@@ -1899,14 +1902,14 @@ def test_get_all_workflows_with_last_execution(db_session, workflow_manager):
     first_execution_wf_store = next(
         w
         for w in workflow["workflow_last_executions"]
-        if w["started"] == first_execution.started
+        if w["execution_id"] == first_execution.id
     )
     assert first_execution_wf_store is not None
-    assert first_execution_wf_store.status == "success"
+    assert first_execution_wf_store["status"] == "success"
     second_execution_wf_store = next(
         w
         for w in workflow["workflow_last_executions"]
-        if w["started"] == second_execution.started
+        if w["execution_id"] == second_execution.id
     )
     assert second_execution_wf_store is not None
-    assert second_execution_wf_store.status == "error"
+    assert second_execution_wf_store["status"] == "error"

--- a/tests/test_workflow_execution.py
+++ b/tests/test_workflow_execution.py
@@ -112,6 +112,29 @@ on-failure:
       type: console
 """
 
+LOG_EVERY_ALERT_WORKFLOW = """
+workflow:
+  id: log-every-alert
+  name: Log every alert
+  description: Simple workflow demonstrating logging every alert
+  triggers:
+    - type: alert
+  actions:
+    - name: log-every-alert-success
+      if: "{{alert.should_fail}} == 'false'"
+      provider:
+        type: console
+        with:
+          message: "{{alert.name}} - {{alert.message}}"
+    - name: log-every-alert-failure
+      if: "{{alert.should_fail}} == 'true'"
+      provider:
+        type: console
+        with:
+          invalid-argument-to-fail-workflow: true
+          message: "{{alert.name}} - {{alert.message}}"
+"""
+
 
 MAX_WAIT_COUNT = 30
 
@@ -1680,7 +1703,7 @@ def test_workflow_executions_after_reprovisioning(
 
 
 def test_workflow_with_on_failure_succeeds_after_failing(
-    db_session, create_alert, workflow_manager, mocker
+    db_session, workflow_manager, mocker
 ):
     """Test that a workflow with an on-failure action is executed correctly."""
     # Mock the ConsoleProvider's notify method
@@ -1742,9 +1765,7 @@ def test_workflow_with_on_failure_succeeds_after_failing(
     assert "Tier 1 Alert: server-is-upsidedown" in str(mock_console.call_args_list[-1])
 
 
-def test_workflow_with_on_failure_action(
-    db_session, create_alert, workflow_manager, mocker
-):
+def test_workflow_with_on_failure_action(db_session, workflow_manager, mocker):
     """Test that a workflow with an on-failure action is executed correctly."""
     # Mock the ConsoleProvider's notify method
     mock_console = mocker.patch(
@@ -1788,18 +1809,6 @@ def test_workflow_with_on_failure_action(
         lastReceived=datetime.now(tz=pytz.utc).isoformat(),
     )
 
-    # Create a new alert to trigger the workflow
-    alert = AlertDto(
-        id="alert-2",
-        fingerprint="upsdown-2",
-        source=["grafana"],
-        name="server-is-upsidedown",
-        message="Server is upside down again",
-        status=AlertStatus.FIRING,
-        severity=AlertSeverity.CRITICAL,
-        lastReceived=datetime.now(tz=pytz.utc).isoformat(),
-    )
-
     workflow_manager.insert_events(SINGLE_TENANT_UUID, [alert])
 
     workflow_execution = wait_for_workflow_execution(SINGLE_TENANT_UUID, workflow.id)
@@ -1816,3 +1825,88 @@ def test_workflow_with_on_failure_action(
     assert "Workflow on-failure-workflow failed with errors:" in str(
         mock_console.call_args_list[-1]
     )
+
+
+def test_get_all_workflows_with_last_execution(db_session, workflow_manager):
+    workflow = Workflow(
+        id="log-every-alert",
+        name="log-every-alert",
+        tenant_id=SINGLE_TENANT_UUID,
+        description="workflow which logs every alert, and fails if alert.should_fail is true",
+        created_by="borat@keephq.dev",
+        interval=0,
+        workflow_raw=LOG_EVERY_ALERT_WORKFLOW,
+        last_updated=datetime.now(),
+    )
+    db_session.add(workflow)
+    db_session.commit()
+
+    # Create an alert to trigger the workflow
+    alert1 = AlertDto(
+        id="alert-1",
+        fingerprint="upsdown-1",
+        source=["grafana"],
+        name="server-is-upsidedown",
+        message="Server is upside down",
+        status=AlertStatus.FIRING,
+        severity=AlertSeverity.CRITICAL,
+        lastReceived=datetime.now(tz=pytz.utc).isoformat(),
+        should_fail="false",
+    )
+
+    # Create a new alert to trigger the workflow
+    alert2 = AlertDto(
+        id="alert-2",
+        fingerprint="upsdown-2",
+        source=["grafana"],
+        name="server-is-upsidedown",
+        message="Server is upside down again",
+        status=AlertStatus.FIRING,
+        severity=AlertSeverity.CRITICAL,
+        lastReceived=datetime.now(tz=pytz.utc).isoformat(),
+        should_fail="true",
+    )
+
+    workflow_manager.insert_events(SINGLE_TENANT_UUID, [alert1])
+
+    # Wait for the workflow to execute
+    first_execution = wait_for_workflow_execution(SINGLE_TENANT_UUID, workflow.id)
+    assert first_execution is not None
+    assert first_execution.status == "success"
+
+    workflow_manager.insert_events(SINGLE_TENANT_UUID, [alert2])
+
+    # Wait for the workflow to execute again
+    second_execution = wait_for_workflow_execution(
+        SINGLE_TENANT_UUID, workflow.id, exclude_ids=[first_execution.id]
+    )
+    assert second_execution is not None
+    assert second_execution.status == "error"
+
+    workflowstore = WorkflowStore()
+    # Get all workflows with last execution
+    workflows_with_last_execution, count = (
+        workflowstore.get_all_workflows_with_last_execution(SINGLE_TENANT_UUID)
+    )
+    workflows = workflowstore.group_last_workflow_executions(
+        workflows=workflows_with_last_execution
+    )
+
+    # Verify that the workflow was executed twice
+    workflow = next(w for w in workflows if w["workflow"].id == workflow.id)
+    assert workflow is not None
+    assert len(workflow["workflow_last_executions"]) == 2
+    first_execution_wf_store = next(
+        w
+        for w in workflow["workflow_last_executions"]
+        if w["started"] == first_execution.started
+    )
+    assert first_execution_wf_store is not None
+    assert first_execution_wf_store.status == "success"
+    second_execution_wf_store = next(
+        w
+        for w in workflow["workflow_last_executions"]
+        if w["started"] == second_execution.started
+    )
+    assert second_execution_wf_store is not None
+    assert second_execution_wf_store.status == "error"


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4804 

The problem:
`get_workflows_with_last_executions_v2` return list of same execution N times instead of N correct executions.

Example response from /workflows/query

```
...
            "last_executions": [
                {
                    "status": "success",
                    "execution_time": 0,
                    "started": "2025-05-19T10:40:43"
                },
                {
                    "status": "success",
                    "execution_time": 0,
                    "started": "2025-05-19T10:40:43"
                },
                {
                    "status": "success",
                    "execution_time": 0,
                    "started": "2025-05-19T10:40:43"
                },
                ...
            ],
```

The cause:
We already do an outerjoin with latest executions in `__build_base_query`:
```
.outerjoin(
            latest_executions_subquery_cte,
            and_(
                Workflow.id == latest_executions_subquery_cte.c.workflow_id,
                latest_executions_subquery_cte.c.row_num <= fetch_last_executions,
            ),
        )
```

and then again in `build_workflows_query`

I removed the second join and added execution_id to the output so we can filter duplicate executions and debug easily.


## Before
workflow graphs show the same execution 
<img width="1038" alt="Screenshot 2025-05-19 at 20 42 36" src="https://github.com/user-attachments/assets/bffdb4cb-38f6-44f2-8b27-7a4aaea7e0d0" />


## After
correct execution time shown
<img width="1059" alt="Screenshot 2025-05-19 at 23 35 19" src="https://github.com/user-attachments/assets/6b95d183-a3a3-4e62-85ad-3062e1809e5f" />

