### PR TITLE
fix: Convert alerts to JSON before returning

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -2105,19 +2105,14 @@ def save_workflow_results(tenant_id, workflow_execution_id, workflow_results):
             .where(WorkflowExecution.id == workflow_execution_id)
         ).one()
 
-        def json_serialize(obj):
-            if isinstance(obj, AlertDto):
-                return obj.dict()
-            raise TypeError("Type %s not serializable" % type(obj))
-
         try:
-            # backward comptability - try to serialize the workflow results
-            json.dumps(workflow_results, default=json_serialize)
+            # backward compatibility - try to serialize the workflow results
+            json.dumps(workflow_results)
             # if that's ok, use the original way
             workflow_execution.results = workflow_results
         except Exception:
             # if that's not ok, use the Keep way (e.g. alerdto is not json serializable)
-            logger.warning(
+            logger.debug(
                 "Failed to serialize workflow results, using fastapi encoder",
             )
             # use some other way to serialize the workflow results

--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -61,7 +61,7 @@ from keep.api.models.ai_external import (
     ExternalAIConfigAndMetadata,
     ExternalAIConfigAndMetadataDto,
 )
-from keep.api.models.alert import AlertStatus
+from keep.api.models.alert import AlertStatus, AlertDto
 from keep.api.models.db.action import Action
 from keep.api.models.db.ai_external import *  # pylint: disable=unused-wildcard-import
 from keep.api.models.db.alert import *  # pylint: disable=unused-wildcard-import
@@ -2105,9 +2105,14 @@ def save_workflow_results(tenant_id, workflow_execution_id, workflow_results):
             .where(WorkflowExecution.id == workflow_execution_id)
         ).one()
 
+        def json_serialize(obj):
+            if isinstance(obj, AlertDto):
+                return obj.dict()
+            raise TypeError("Type %s not serializable" % type(obj))
+
         try:
             # backward comptability - try to serialize the workflow results
-            json.dumps(workflow_results)
+            json.dumps(workflow_results, default=json_serialize)
             # if that's ok, use the original way
             workflow_execution.results = workflow_results
         except Exception:

--- a/keep/providers/keep_provider/keep_provider.py
+++ b/keep/providers/keep_provider/keep_provider.py
@@ -620,10 +620,7 @@ class KeepProvider(BaseProvider):
         self.logger.info(
             "Alerts processed successfully", extra={"alert_count": len(alerts)}
         )
-        alert_jsons = []
-        for alert in alerts:
-            alert_jsons.append(alert.json())
-        return alert_jsons
+        return alerts
 
     def _delete_workflows(self, except_workflow_id=None):
         self.logger.info("Deleting all workflows")

--- a/keep/providers/keep_provider/keep_provider.py
+++ b/keep/providers/keep_provider/keep_provider.py
@@ -620,7 +620,10 @@ class KeepProvider(BaseProvider):
         self.logger.info(
             "Alerts processed successfully", extra={"alert_count": len(alerts)}
         )
-        return alerts
+        alert_jsons = []
+        for alert in alerts:
+            alert_jsons.append(alert.json())
+        return alert_jsons
 
     def _delete_workflows(self, except_workflow_id=None):
         self.logger.info("Deleting all workflows")


### PR DESCRIPTION
Updated the return value of the `process_alerts` method to return alerts as JSON objects instead of raw alert instances. This ensures consistent data serialization and simplifies downstream processing.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4882 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
