### PR TITLE
fix: improve dashboard widget column sizing and prevent cutoff

### DIFF
--- a/keep-ui/app/(keep)/dashboard/widget-types/preset/widget-alerts-table.tsx
+++ b/keep-ui/app/(keep)/dashboard/widget-types/preset/widget-alerts-table.tsx
@@ -90,17 +90,17 @@ const WidgetAlertsTable: React.FC<WidgetAlertsTableProps> = ({
         ),
       },
       name: {
-        columnTemplate: "1fr",
+        gridColumnTemplate: "minmax(100px, 1fr)",
         renderValue: (alert: any) => (
-          <div title={alert.name} className="max-w-full truncate">
+          <div title={alert.name} className="truncate overflow-hidden text-ellipsis">
             {alert.name}
           </div>
         ),
       },
       description: {
-        gridColumnTemplate: "1fr",
+        gridColumnTemplate: "minmax(100px, 1fr)",
         renderValue: (alert: any) => (
-          <div title={alert.description} className="max-w-full truncate">
+          <div title={alert.description} className="truncate overflow-hidden text-ellipsis">
             {alert.description}
           </div>
         ),
@@ -165,7 +165,7 @@ const WidgetAlertsTable: React.FC<WidgetAlertsTableProps> = ({
             columnValue = columnMeta.renderValue(alert);
           } else {
             columnValue = (
-              <div className="max-w-32 truncate">{getNestedValue(alert, column)}</div>
+              <div className="truncate overflow-hidden text-ellipsis">{getNestedValue(alert, column)}</div>
             );
           }
           const _columnsGapClass =
@@ -196,6 +196,9 @@ const WidgetAlertsTable: React.FC<WidgetAlertsTableProps> = ({
 
           if (columnMeta?.gridColumnTemplate) {
             gridColumnTemplate = columnMeta.gridColumnTemplate;
+          } else {
+            // Default sizing for arbitrary columns
+            gridColumnTemplate = "minmax(auto, 1fr)";
           }
 
           return gridColumnTemplate;
@@ -206,14 +209,16 @@ const WidgetAlertsTable: React.FC<WidgetAlertsTableProps> = ({
 
   return (
     <div
-      style={{
-        background,
-        gridTemplateColumns: gridTemplateColumns,
-      }}
-      className="bg-opacity-25 grid max-w-full overflow-y-auto overflow-x-hidden border rounded-md px-2"
+      style={{ background }}
+      className="bg-opacity-25 max-w-full overflow-x-auto border rounded-md"
     >
-      {renderHeaders()}
-      {renderTableBody()}
+      <div
+        style={{ gridTemplateColumns }}
+        className="grid min-w-fit px-2"
+      >
+        {renderHeaders()}
+        {renderTableBody()}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4888 

## 📑 Description
<!-- Add a brief description of the pr -->

Fixes dashboard widget column sizing issues where columns were being cut off when widgets were resized and improves space utilization.

### Changes:
- Fixed column cutoff by replacing `overflow-x-hidden` with scrollable wrapper
- Fixed name column configuration typo (`columnTemplate` → `gridColumnTemplate`)
- Added minimum widths to text columns while preserving flexible growth
- Improved unknown column sizing to better utilize available space
- Aligned overflow handling with parent-child component architecture

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
### Implementation Details:
- Name/Description columns now use `minmax(100px, 1fr)` for widget-appropriate minimum sizing. This is similar to the alerts table implementation, just scaled down a bit given that widgets are typically smaller.
- Unknown columns use `minmax(auto, 1fr)` to stay narrow when empty but expand when needed
- Two-div structure separates scroll container from grid layout
- Respects existing overflow patterns (parent handles Y-axis, child handles X-axis)

### Before/After:
| Issue | Before | After |
|-------|--------|-------|
| Column Access | Rightmost columns cut off | All columns accessible via scroll |
| Name Column | Used `auto` (due to typo) | Uses `minmax(100px, 1fr)` |
| Space Usage | Poor distribution | Columns expand to use available space |


https://github.com/user-attachments/assets/152281fb-0260-4dd3-a70c-a08ef04d3a07

If the intent is to have the Name/Description fields take a larger share when expanded, perhaps increasing the fr value is a reasonable option. 