### PR TITLE
fix: startedAt field mapping

### DIFF
--- a/keep/api/core/alerts.py
+++ b/keep/api/core/alerts.py
@@ -68,7 +68,9 @@ alert_field_configurations = [
         data_type=DataType.STRING,
     ),
     FieldMappingConfiguration(
-        map_from_pattern="startedAt", map_to="startedAt", data_type=DataType.DATETIME
+        map_from_pattern="startedAt",
+        map_to="lastalert.first_timestamp",
+        data_type=DataType.DATETIME
     ),
     FieldMappingConfiguration(
         map_from_pattern="incident.id",


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4927 

## 📑 Description
Fixes incorrect mapping for startedAt. It's attempting to target a non-existent DB column. I have confirmed it resolves the issue, and i can now sort by startedAt as expected.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
