### PR TITLE
fix: workflow `consts` could be of many types

### DIFF
--- a/examples/workflows/consts_and_dict.yml
+++ b/examples/workflows/consts_and_dict.yml
@@ -1,17 +1,33 @@
 workflow:
-  id: severity-mapping-example
-  name: Severity Mapping Example
-  description: Demonstrates how to use constant mappings to standardize alert severity levels.
+  id: consts-severity-queries-mapping
+  name: Severity and Queries Mapping Example
+  description: Demonstrates how to use constant mappings to standardize alert severity levels and queries.
   triggers:
     - type: manual
-
   consts:
-    severities: '{"s1": "critical","s2": "error","s3": "warning","s4": "info","critical": "critical","error": "error","warning": "warning","info": "info"}'
-
+    ts: 1748465504
+    queries:
+      get-all-tables:
+        query: "SELECT table_name FROM information_schema.tables;"
+      user-query:
+        query: "select * from user where user.id == %user_id%;"
+    severities:
+      s1: critical
+      s2: error
+      s3: warning
+      s4: info
+      critical: critical
+      error: error
+  steps:
+    - name: print-user-query
+      provider:
+        type: console
+        with:
+          message: keep.replace('{{consts.queries.user-query.query}}', '%user_id%', '999') # will print "select * from user where user.id == 999;"
   actions:
     - name: echo
       provider:
         type: console
         with:
           logger: true
-          message: keep.dictget( '{{ consts.severities }}', '{{ alert.severity }}', 'info')
+          message: keep.dictget({{ consts.severities }}, '{{ alert.severity }}', 'info')

--- a/keep-ui/entities/workflows/lib/__tests__/parseWorkflowYamlToJSON.test.ts
+++ b/keep-ui/entities/workflows/lib/__tests__/parseWorkflowYamlToJSON.test.ts
@@ -387,4 +387,37 @@ describe("parseWorkflowYamlToJSON", () => {
     expect(result.success).toBe(true);
     expect(result.data).toBeDefined();
   });
+
+  it("should validate different types of constants", () => {
+    const yamlWithVars = `
+  workflow:
+    id: test-workflow
+    name: Test Workflow
+    description: Test workflow
+    triggers:
+      - type: manual
+    steps:
+      - name: print
+        provider:
+          type: mock
+          with:
+            message: "{{ consts.string }}"
+    consts:
+      string: "string"
+      number: 1
+      boolean: true
+      object: { key: "value" }
+      list: [1, 2, 3]
+      object-as-yaml:
+        key: value
+        key1: value1
+`;
+
+    const result = parseWorkflowYamlToJSON(
+      yamlWithVars,
+      workflowSchemaWithProviders
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+  });
 });

--- a/keep-ui/entities/workflows/model/schema.ts
+++ b/keep-ui/entities/workflows/model/schema.ts
@@ -2,6 +2,18 @@ import { z } from "zod";
 
 const ManualTriggerValueSchema = z.literal("true");
 
+export const WorkflowConstsSchema = z.record(
+  z.string(),
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.record(z.string(), z.any()),
+    z.object({}),
+    z.array(z.any()),
+  ])
+);
+
 const TriggerSchemaBase = z.object({
   id: z.string(),
   name: z.string(),

--- a/keep-ui/entities/workflows/model/yaml.schema.ts
+++ b/keep-ui/entities/workflows/model/yaml.schema.ts
@@ -5,6 +5,7 @@ import {
   IncidentEventEnum,
   OnFailureSchema,
   WithSchema,
+  WorkflowConstsSchema,
   WorkflowInputSchema,
 } from "./schema";
 import { Provider } from "@/shared/api/providers";
@@ -216,7 +217,7 @@ export const YamlWorkflowDefinitionSchema = z.object({
       debug: z.boolean().optional(),
       triggers: z.array(TriggerSchema).min(1),
       inputs: z.array(WorkflowInputSchema).optional(),
-      consts: z.record(z.string(), z.string()).optional(),
+      consts: WorkflowConstsSchema.optional(),
       strategy: WorkflowStrategySchema.optional(),
       "on-failure": YamlStepOrActionSchema.partial({
         id: true,
@@ -284,7 +285,7 @@ export function getYamlWorkflowDefinitionSchema(
       debug: z.boolean().optional(),
       triggers: z.array(TriggerSchema).min(1),
       inputs: z.array(WorkflowInputSchema).optional(),
-      consts: z.record(z.string(), z.string()).optional(),
+      consts: WorkflowConstsSchema.optional(),
       owners: z.array(z.string()).optional(),
       // [doe.john@example.com, doe.jane@example.com, NOC]
       permissions: z.array(z.string()).optional(),

--- a/keep/api/routes/workflows.py
+++ b/keep/api/routes/workflows.py
@@ -38,7 +38,8 @@ from keep.api.core.workflows import (
     get_workflow_facets_data,
     get_workflow_potential_facet_fields,
 )
-from keep.api.models.alert import AlertDto
+from keep.api.models.alert import AlertDto, AlertSeverity
+from keep.api.models.db.incident import IncidentSeverity
 from keep.api.models.facet import FacetOptionsQueryDto
 from keep.api.models.incident import IncidentDto
 from keep.api.models.query import QueryDto
@@ -319,8 +320,20 @@ def get_event_from_body(body: dict, tenant_id: str):
     # Handle UI triggered events
     if event_class == AlertDto:
         event_body["id"] = event_body.get("fingerprint", "manual-run")
+        if "severity" in event_body:
+            try:
+                event_body["severity"] = AlertSeverity(event_body["severity"].lower())
+            except ValueError:
+                pass
     elif event_class == IncidentDto:
         event_body["id"] = event_body.get("id", "manual-run")
+        if "severity" in event_body:
+            try:
+                event_body["severity"] = IncidentSeverity(
+                    event_body["severity"].lower()
+                )
+            except ValueError:
+                pass
     event_body["name"] = event_body.get("name", "manual-run")
     event_body["lastReceived"] = event_body.get(
         "lastReceived", datetime.datetime.now(tz=datetime.timezone.utc).isoformat()


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4954 