### PR TITLE
fix: query for workflowexecution and logs separately

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -1179,24 +1179,46 @@ def push_logs_to_db(log_entries):
 
 
 def get_workflow_execution(
-    tenant_id: str, workflow_execution_id: str, is_test_run: bool | None = None
+    tenant_id: str,
+    workflow_execution_id: str,
+    is_test_run: bool | None = None,
 ):
     with Session(engine) as session:
-        base_query = session.query(WorkflowExecution)
+        base_query = select(WorkflowExecution)
         if is_test_run is not None:
-            base_query = base_query.filter(
+            base_query = base_query.where(
                 WorkflowExecution.is_test_run == is_test_run,
             )
-        base_query = base_query.filter(
+        base_query = base_query.where(
             WorkflowExecution.id == workflow_execution_id,
             WorkflowExecution.tenant_id == tenant_id,
         )
-        execution_with_logs = base_query.options(
-            joinedload(WorkflowExecution.logs),
+        execution_with_relations = base_query.options(
             joinedload(WorkflowExecution.workflow_to_alert_execution),
             joinedload(WorkflowExecution.workflow_to_incident_execution),
-        ).one()
-    return execution_with_logs
+        )
+        result = session.exec(execution_with_relations).first()
+        return result
+
+
+def get_workflow_execution_with_logs(
+    tenant_id: str,
+    workflow_execution_id: str,
+    is_test_run: bool | None = None,
+):
+    with Session(engine) as session:
+        execution = get_workflow_execution(
+            tenant_id, workflow_execution_id, is_test_run
+        )
+        if not execution:
+            # todo: raise an exception
+            return None, []
+        logs = session.exec(
+            select(WorkflowExecutionLog).where(
+                WorkflowExecutionLog.workflow_execution_id == workflow_execution_id
+            )
+        ).all()
+        return execution, logs
 
 
 def get_last_workflow_executions(tenant_id: str, limit=20):

--- a/keep/api/routes/workflows.py
+++ b/keep/api/routes/workflows.py
@@ -1070,7 +1070,7 @@ def get_workflow_execution_status(
 ) -> WorkflowExecutionDTO:
     tenant_id = authenticated_entity.tenant_id
     workflowstore = WorkflowStore()
-    workflow_execution = workflowstore.get_workflow_execution(
+    workflow_execution, logs = workflowstore.get_workflow_execution_with_logs(
         workflow_execution_id=workflow_execution_id,
         tenant_id=tenant_id,
     )
@@ -1097,7 +1097,7 @@ def get_workflow_execution_status(
         event_id = workflow_execution.workflow_to_incident_execution.incident_id
         event_type = "incident"
 
-    workflow_execution_dto = WorkflowExecutionDTO(
+    return WorkflowExecutionDTO(
         id=workflow_execution.id,
         workflow_name=workflow.name if workflow else None,
         workflow_id=workflow_execution.workflow_id,
@@ -1114,13 +1114,12 @@ def get_workflow_execution_status(
                 message=log.message,
                 context=log.context if log.context else {},
             )
-            for log in workflow_execution.logs
+            for log in logs
         ],
         results=workflow_execution.results,
         event_id=event_id,
         event_type=event_type,
     )
-    return workflow_execution_dto
 
 
 @router.put(

--- a/keep/workflowmanager/workflowstore.py
+++ b/keep/workflowmanager/workflowstore.py
@@ -19,6 +19,7 @@ from keep.api.core.db import (
     get_all_workflows_yamls,
     get_workflow_by_id,
     get_workflow_execution,
+    get_workflow_execution_with_logs,
 )
 from keep.api.core.workflows import get_workflows_with_last_executions_v2
 from keep.api.models.db.workflow import Workflow as WorkflowModel
@@ -43,6 +44,16 @@ class WorkflowStore:
         is_test_run: bool | None = None,
     ):
         return get_workflow_execution(tenant_id, workflow_execution_id, is_test_run)
+
+    def get_workflow_execution_with_logs(
+        self,
+        tenant_id: str,
+        workflow_execution_id: str,
+        is_test_run: bool | None = None,
+    ):
+        return get_workflow_execution_with_logs(
+            tenant_id, workflow_execution_id, is_test_run
+        )
 
     def create_workflow(
         self,


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4852

# Context
Now the "/{workflow_id}/runs/{workflow_execution_id}" route calls ORM like this:

```python
def get_workflow_execution(
    tenant_id: str, workflow_execution_id: str, is_test_run: bool | None = None
):
    with Session(engine) as session:
        base_query = session.query(WorkflowExecution)
        if is_test_run is not None:
            base_query = base_query.filter(
                WorkflowExecution.is_test_run == is_test_run,
            )
        base_query = base_query.filter(
            WorkflowExecution.id == workflow_execution_id,
            WorkflowExecution.tenant_id == tenant_id,
        )
        execution_with_logs = base_query.options(
            joinedload(WorkflowExecution.logs),
            joinedload(WorkflowExecution.workflow_to_alert_execution),
            joinedload(WorkflowExecution.workflow_to_incident_execution),
        ).one()
    return execution_with_logs
```

Generated SQL
```sql
SELECT workflowexecution.id,
       workflowexecution.workflow_id,
       workflowexecution.workflow_revision,
       workflowexecution.tenant_id,
       workflowexecution.started,
       workflowexecution.triggered_by,
       workflowexecution.status,
       workflowexecution.is_running,
       workflowexecution.timeslot,
       workflowexecution.execution_number,
       workflowexecution.error,
       workflowexecution.execution_time,
       workflowexecution.results,
       workflowexecution.is_test_run,
       workflowexecutionlog_1.id                           AS id_1,
       workflowexecutionlog_1.workflow_execution_id,
       workflowexecutionlog_1.timestamp,
       workflowexecutionlog_1.message,
       workflowexecutionlog_1.context,
       workflowtoalertexecution_1.id                       AS id_2,
       workflowtoalertexecution_1.workflow_execution_id    AS
       workflow_execution_id_1,
       workflowtoalertexecution_1.alert_fingerprint,
       workflowtoalertexecution_1.event_id,
       workflowtoincidentexecution_1.id                    AS id_3,
       workflowtoincidentexecution_1.workflow_execution_id AS
       workflow_execution_id_2,
       workflowtoincidentexecution_1.incident_id
FROM   workflowexecution
       LEFT OUTER JOIN workflowexecutionlog AS workflowexecutionlog_1
                    ON workflowexecution.id =
                       workflowexecutionlog_1.workflow_execution_id
       LEFT OUTER JOIN workflowtoalertexecution AS workflowtoalertexecution_1
                    ON workflowexecution.id =
                       workflowtoalertexecution_1.workflow_execution_id
       LEFT OUTER JOIN workflowtoincidentexecution AS
                       workflowtoincidentexecution_1
                    ON workflowexecution.id =
                       workflowtoincidentexecution_1.workflow_execution_id
WHERE  workflowexecution.id = '<>'
       AND workflowexecution.tenant_id = '<>'; 
 ```
    
## Root cause
The query joins `workflowexecution` with N logs, where `workflowexecution.results` can be 500kb+, so we end up with holy bunch of rows each having this 500kb+ results. 
<img width="2168" alt="Screenshot 2025-06-03 at 14 56 25" src="https://github.com/user-attachments/assets/269d4074-360a-443e-8e07-bef667a055f6" />

this alone db can perform under one sec with enough RAM, however loading it into ORM takes most of the time and leads to Out of Memory error for heavy executions.

## Hotfix
Split the request, request execution just once and separately query logs.

## Long-term solution
Save results to individual steps, separate "/{workflow_id}/runs/{workflow_execution_id}" and "/{workflow_id}/runs/{workflow_execution_id}/logs/{step_id}", add pagination to the later. 