### PR TITLE
feat: support OPENAI_MODEL_NAME override and fix Copilot runtime init syntax

### DIFF
--- a/keep-ui/app/api/copilotkit/route.ts
+++ b/keep-ui/app/api/copilotkit/route.ts
@@ -12,11 +12,13 @@ export const POST = async (req: NextRequest) => {
       const openai = new OpenAI({
         organization: process.env.OPEN_AI_ORGANIZATION_ID,
         apiKey: process.env.OPEN_AI_API_KEY,
+      });
+      const serviceAdapter = new OpenAIAdapter({
+        openai,
         ...(process.env.OPENAI_MODEL_NAME
           ? { model: process.env.OPENAI_MODEL_NAME }
           : {}),
       });
-      const serviceAdapter = new OpenAIAdapter({ openai });
       const runtime = new CopilotRuntime();
       return { runtime, serviceAdapter };
     } catch (error) {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #<issue_number>

## 📑 Description
This PR refactors the Copilot runtime initialization in `route.ts` to:

- **Close the `new OpenAI()` constructor call properly** before instantiating the adapter, fixing a misplaced bracket.  
- **Add support for an optional model override** via the `OPENAI_MODEL_NAME` environment variable by spreading `{ model: process.env.OPENAI_MODEL_NAME }` into the `OpenAIAdapter` constructor only when it’s set.

These changes ensure the service adapter can target a specific model if desired, and that our client initialization is syntactically correct.

## ✅ Checks
- [x] My pull request adheres to the code style of this project  
- [ ] My code requires changes to the documentation  
- [ ] I have updated the documentation as required  
- [x] All the tests have passed

## ℹ Additional Information
- **Breaking Changes**: None. Default behavior remains unchanged if `OPENAI_MODEL_NAME` is unset.  
- **Dependencies Added**: None.  
- **Testing**: Verified that runtime initialization and request handling continue to work as before, and that setting `OPENAI_MODEL_NAME` correctly selects the desired model.  
- **Screenshots / Before & After**: N/A  
