### PR TITLE
fix: get_all_workflows_with_last_execution shouldn't return dummy workflows

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -895,6 +895,7 @@ def get_workflow_versions(tenant_id: str, workflow_id: str):
             .where(Workflow.tenant_id == tenant_id)
             .where(Workflow.id == workflow_id)
             .where(Workflow.is_deleted == False)
+            .where(Workflow.is_test == False)
             .join(WorkflowVersion, WorkflowVersion.workflow_id == Workflow.id)
             .order_by(WorkflowVersion.revision.desc())
         ).all()
@@ -910,6 +911,7 @@ def get_workflow_version(tenant_id: str, workflow_id: str, revision: int):
             .where(Workflow.tenant_id == tenant_id)
             .where(Workflow.id == workflow_id)
             .where(Workflow.is_deleted == False)
+            .where(Workflow.is_test == False)
             .join(WorkflowVersion, WorkflowVersion.workflow_id == Workflow.id)
             .where(WorkflowVersion.revision == revision)
         ).first()
@@ -1009,7 +1011,9 @@ def get_workflow_executions(
     is_test_run: bool = False,
 ):
     with Session(engine) as session:
-        query = session.query(WorkflowExecution,).filter(
+        query = session.query(
+            WorkflowExecution,
+        ).filter(
             WorkflowExecution.tenant_id == tenant_id,
             WorkflowExecution.workflow_id == workflow_id,
             WorkflowExecution.is_test_run == False,
@@ -1109,6 +1113,7 @@ def get_workflow_id(tenant_id, workflow_name):
             .where(Workflow.tenant_id == tenant_id)
             .where(Workflow.name == workflow_name)
             .where(Workflow.is_deleted == False)
+            .where(Workflow.is_test == False)
         ).first()
 
         if workflow:
@@ -2158,6 +2163,7 @@ def get_workflow_by_name(tenant_id, workflow_name):
             .where(Workflow.tenant_id == tenant_id)
             .where(Workflow.name == workflow_name)
             .where(Workflow.is_deleted == False)
+            .where(Workflow.is_test == False)
         ).first()
 
         return workflow
@@ -3911,7 +3917,9 @@ def get_last_incidents(
         List[Incident]: A list of Incident objects.
     """
     with Session(engine) as session:
-        query = session.query(Incident,).filter(
+        query = session.query(
+            Incident,
+        ).filter(
             Incident.tenant_id == tenant_id,
             Incident.is_candidate == is_candidate,
             Incident.is_visible == True,

--- a/keep/api/core/workflows.py
+++ b/keep/api/core/workflows.py
@@ -190,6 +190,7 @@ def __build_base_query(
         )
         .where(Workflow.tenant_id == tenant_id)
         .where(Workflow.is_deleted == False)
+        .where(Workflow.is_test == False)
     )
 
     return workflows_with_last_executions_query

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keep"
-version = "0.45.2"
+version = "0.45.3"
 description = "Alerting. for developers, by developers."
 authors = ["Keep Alerting LTD"]
 packages = [{include = "keep"}]


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5012 