### PR TITLE
fix: Set EKS Provider Credentials Default to None

### DIFF
--- a/keep/providers/eks_provider/eks_provider.py
+++ b/keep/providers/eks_provider/eks_provider.py
@@ -39,7 +39,7 @@ class EksProviderAuthConfig:
     )
 
     access_key: str = dataclasses.field(
-        default=True,
+        default=None,
         metadata={
             "required": False,
             "description": "AWS access key (Leave empty if using IAM role at EC2)",
@@ -48,7 +48,7 @@ class EksProviderAuthConfig:
     )
 
     secret_access_key: str = dataclasses.field(
-        default=True,
+        default=None,
         metadata={
             "required": False,
             "description": "AWS secret access key (Leave empty if using IAM role at EC2)",


### PR DESCRIPTION

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes https://github.com/keephq/keep/issues/5090 <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Changes the default values for `access_key` and `secret_access_key` from `True` to `None`, allowing `boto3` to use IAM credentials attached to the AWS infrastructure running Keep. 

Previously, users received an `UnrecognizedClientException` error when using attached IAM credentials (and leaving the optional credentials blank) because `boto3` was passing in empty strings for credentials. 

Changing the values to None causes `boto3` to search for credentials elsewhere, such as those attached the infrastructure.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
