### PR TITLE
fix: Sort dict keys before generating the hash

### DIFF
--- a/keep/api/alert_deduplicator/alert_deduplicator.py
+++ b/keep/api/alert_deduplicator/alert_deduplicator.py
@@ -65,7 +65,7 @@ class AlertDeduplicator:
 
         # calculate the hash
         alert_hash = hashlib.sha256(
-            json.dumps(alert_copy.dict(), default=str).encode()
+            json.dumps(alert_copy.dict(), default=str, sort_keys=True).encode()
         ).hexdigest()
         alert.alert_hash = alert_hash
         # Check if the hash is already in the database.


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5131 

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
For an alert to be considered for full deduplication, it's hash should match with the hash of the last seen alert of the same fingerprint. When prometheus sends multiple notifications for the same alert, there is a possibility for the field order to change. When this happens, the hash that gets generated for the alert with changed field order doesn't match with the one that has the original field order. This results in new alert not being considered for full deduplication.

I have updated the code to sort the dictionary fields before computing the hash in order to get consistent hash values for the alerts with out of order fields.
