### PR TITLE
fix: Use integer severities for zabbix provider

### DIFF
--- a/docs/snippets/providers/zabbix-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/zabbix-snippet-autogenerated.mdx
@@ -1,4 +1,4 @@
-{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py 
+{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py
 Do not edit it manually, as it will be overwritten */}
 
 ## Authentication
@@ -39,7 +39,13 @@ The provider exposes the following [Provider Methods](/providers/provider-method
 - **change_severity** No description. (action, scopes: event.acknowledge)
 
     - `id`: The problem id.
-    - `new_severity`: The new severity, can be one of the following: Not classified, Information, Warning, Average, High, Disaster
+    - `new_severity`: The new severity. Can be an integer (0-5) or string:
+- 0 or "Not classified"
+- 1 or "Information"
+- 2 or "Warning"
+- 3 or "Average"
+- 4 or "High"
+- 5 or "Disaster"
 - **surrpress_problem** No description. (action, scopes: event.acknowledge)
 
     - `id`: The problem id.

--- a/keep/providers/zabbix_provider/zabbix_provider.py
+++ b/keep/providers/zabbix_provider/zabbix_provider.py
@@ -364,7 +364,7 @@ class ZabbixProvider(BaseProvider):
         # Handle integer input
         severity = 0
         if isinstance(new_severity, int):
-            if 0 < new_severity <= 5:
+            if 0 <= new_severity <= 5:
                 severity = new_severity
         else:
             # Handle string input

--- a/keep/providers/zabbix_provider/zabbix_provider.py
+++ b/keep/providers/zabbix_provider/zabbix_provider.py
@@ -214,6 +214,7 @@ class ZabbixProvider(BaseProvider):
     }
 
     SEVERITY_NAME_TO_ID_MAP = {
+        "not_classified": 0,
         "not classified": 0,
         "information": 1,
         "warning": 2,


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5139 

## 📑 Description
Keep uses a severity map to translate zabbix severity to Keep severity. Currently it references zabbix severities using names. When the severity names are updated in zabbix, keep is unable to map the new names correctly. Hence, it classifies the alerts with changed severities as INFO level alerts. 

Solution: Add support for integer severities to Zabbix provider.


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
Also, updated the change_severity method to accept integers in addition to severity names for better usability.

