### PR TITLE
fix: support Zabbix 6.0.5 by improving error matching

### DIFF
--- a/keep/providers/zabbix_provider/zabbix_provider.py
+++ b/keep/providers/zabbix_provider/zabbix_provider.py
@@ -388,7 +388,10 @@ class ZabbixProvider(BaseProvider):
                     validated_scopes[scope.name] = "Permission denied"
                     continue
                 else:
-                    if error and "invalid parameter" in error.lower():
+                    if error and any(phrase in error.lower() for phrase in [
+                        "invalid parameter",
+                        "incorrect arguments"
+                    ]):
                         # This is OK, it means the request is broken but we have access to the endpoint.
                         pass
                     else:


### PR DESCRIPTION
Closes #5135 

## 📑 Description
Zabbix 6.0.5 returns error responses like:
```
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32602,
    "message": "Invalid params.",
    "data": "Incorrect arguments passed to function."
  },
  "id": 1234
}

```
for the event.acknowledge method. These errors are not caught by the original logic that only checks for "Invalid parameter". This commit broadens the error matching to also handle "Incorrect arguments", ensuring the endpoint accessibility validation works correctly across Zabbix versions.
