### PR TITLE
[📃 Docs]: missing doc redis sentinel

### DIFF
--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -239,10 +239,26 @@ Keep is highly configurable through environment variables. This allows you to cu
 
 |      Env var       |        Purpose        | Required | Default Value |        Valid options         |
 | :----------------: | :-------------------: | :------: | :-----------: | :--------------------------: |
+|      **REDIS**     |    Redis enabled      |    No    |     false     |        true or false         |
 |   **REDIS_HOST**   | Redis server hostname |    No    |  "localhost"  | Valid hostname or IP address |
 |   **REDIS_PORT**   |   Redis server port   |    No    |     6379      |      Valid port number       |
 | **REDIS_USERNAME** |    Redis username     |    No    |     None      |    Valid username string     |
 | **REDIS_PASSWORD** |    Redis password     |    No    |     None      |    Valid password string     |
+
+#### Redis Sentinel
+<Info>
+  Redis sentinel configuration specifies the connection details for Keep's Redis sentinel
+  instance. Redis sentinel is used when you have a redis cluster and it acts as a broker.
+</Info>
+
+|               Env var               |        Purpose              | Required |    Default Value    |                Valid options                |
+| :---------------------------------: | :----------------------:    | :------: | :-----------------: | :-----------------------------------------: |
+|             **REDIS**               |        Redis enabled        |    No    |       false         |              true or false                  |
+|      **REDIS_SENTINEL_HOSTS**       |   Redis sentinel server(s)  |    No    |  "localhost:26379"  | "host1:port1,host2:port2" (comma-separated) |
+|   **REDIS_SENTINEL_SERVICE_NAME**   | Redis sentinel service name |    No    |    "mymaster"       |         Valid service name string           |
+|         **REDIS_USERNAME**          |      Redis username         |    No    |       None          |           Valid username string             |
+|         **REDIS_PASSWORD**          |      Redis password         |    No    |       None          |           Valid password string             |
+
 
 ### ARQ
 

--- a/keep/api/redis_settings.py
+++ b/keep/api/redis_settings.py
@@ -12,21 +12,22 @@ from keep.api.core.config import config
 def get_redis_settings() -> RedisSettings:
     """
     Get Redis configuration, supporting both direct Redis and Redis Sentinel.
-    
+
     For Redis Sentinel, set:
+    - REDIS=true
     - REDIS_SENTINEL_ENABLED=true
     - REDIS_SENTINEL_HOSTS=host1:port1,host2:port2 (comma-separated)
     - REDIS_SENTINEL_SERVICE_NAME=mymaster (default: mymaster)
-    
+
     For direct Redis (default):
     - REDIS_HOST=localhost (default: localhost)
     - REDIS_PORT=6379 (default: 6379)
-    
+
     Returns:
         RedisSettings: Configured Redis settings for ARQ
     """
     sentinel_enabled = config("REDIS_SENTINEL_ENABLED", cast=bool, default=False)
-    
+
     if sentinel_enabled:
         # Parse sentinel hosts from comma-separated string
         sentinel_hosts_str = config("REDIS_SENTINEL_HOSTS", default="localhost:26379")
@@ -38,9 +39,9 @@ def get_redis_settings() -> RedisSettings:
                 sentinel_hosts.append((host.strip(), int(port.strip())))
             else:
                 sentinel_hosts.append((host_port, 26379))
-        
+
         service_name = config("REDIS_SENTINEL_SERVICE_NAME", default="mymaster")
-        
+
         return RedisSettings(
             host=sentinel_hosts,
             sentinel=True,


### PR DESCRIPTION
Closes #5154

## 📑 Description
Add documentation for use of redis sentinel

## Additional Information
Based on the following code:
https://github.com/keephq/keep/blob/4e9f63e3d1d4c9e20d63dcb3763727cd946cd7cb/keep/api/redis_settings.py#L17-L19