### PR TITLE
Fixed dismissed bug

### DIFF
--- a/keep-ui/features/alerts/dismiss-alert/ui/alert-dismiss-modal.tsx
+++ b/keep-ui/features/alerts/dismiss-alert/ui/alert-dismiss-modal.tsx
@@ -47,7 +47,6 @@ export function AlertDismissModal({
   const revalidateMultiple = useRevalidateMultiple();
   const presetsMutator = () => revalidateMultiple(["/preset"]);
   const { alertsMutator } = useAlerts();
-
   const api = useApi();
   // Ensuring that the useEffect hook is called consistently
   useEffect(() => {
@@ -89,18 +88,16 @@ export function AlertDismissModal({
     const dismissUntil =
       selectedTab === 0 ? null : selectedDateTime?.toISOString();
 
-    const enrichments: {
-      dismissed: boolean;
-      note: string;
-      dismissUntil: string;
-    } = {
-      dismissed: !alerts[0]?.dismissed,
+    const enrichmentsArray = alerts.map((alert: AlertDto) => ({
+      dismissed: !alert.dismissed,
       note: dismissComment,
       dismissUntil: dismissUntil || "",
-    };
+      previous_status: alert.status, // save actual status
+    }));
+
 
     const requestData = {
-      enrichments: enrichments,
+      enrichments: enrichmentsArray,
       fingerprints: alerts.map((alert: AlertDto) => alert.fingerprint),
     };
 
@@ -149,7 +146,7 @@ export function AlertDismissModal({
       beforeTitle={alerts?.[0]?.name}
       title="Dismiss Alert"
     >
-      {alerts && alerts.length == 1 && alerts[0].dismissed ? (
+      {alerts && alerts.every((alert) => alert.dismissed) ? (
         <>
           <Subtitle className="text-center">
             Are you sure you want to restore this alert?

--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -233,6 +233,12 @@ def query_alerts(
     enriched_alerts_dto = convert_db_alerts_to_dto_alerts(
         db_alerts, with_incidents=True
     )
+
+    # Cleanup of disposable fields if applicable
+    enrichment_bl = EnrichmentsBl(tenant_id)
+    for alert in enriched_alerts_dto:
+        enrichment_bl.dispose_dismiss_disposables(alert.fingerprint)
+
     logger.info(
         "Fetched alerts from DB",
         extra={
@@ -269,6 +275,12 @@ def get_all_alerts(
     )
     db_alerts = get_last_alerts(tenant_id=tenant_id, limit=limit)
     enriched_alerts_dto = convert_db_alerts_to_dto_alerts(db_alerts)
+
+    # Cleanup of disposable fields if applicable
+    enrichment_bl = EnrichmentsBl(tenant_id)
+    for alert in enriched_alerts_dto:
+        enrichment_bl.dispose_dismiss_disposables(alert.fingerprint)
+
     logger.info(
         "Fetched alerts from DB",
         extra={
@@ -424,7 +436,7 @@ def assign_alert(
     enrichment_bl = EnrichmentsBl(tenant_id)
     enrichment_bl.enrich_entity(
         fingerprint=fingerprint,
-        enrichments=enrichments,
+        enrichments_list=enrichments,
         action_type=ActionType.ACKNOWLEDGE,
         action_description=f"Alert assigned to {user_email}, status: {status}",
         action_callee=user_email,
@@ -897,7 +909,7 @@ def batch_enrich_alerts(
 
         enrichment_bl.batch_enrich(
             fingerprints=fingerprints,
-            enrichments=enrichments,
+            enrichments_list=enrichments, 
             action_type=action_type,
             action_callee=authenticated_entity.email,
             action_description=action_description,
@@ -921,7 +933,7 @@ def batch_enrich_alerts(
             ]
             enrichment_bl.batch_enrich(
                 fingerprints=formatted_alert_ids,
-                enrichments=enrichments,
+                enrichments_list=enrichments,
                 action_type=action_type,
                 action_callee=authenticated_entity.email,
                 action_description=action_description,


### PR DESCRIPTION
…, and also fix the restore/dismiss bug from the ui



<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5047 

## 📑 Description
This pull request addresses two main points:
- Fixes the bug related to cleaning the `dismissed`, `dismissUntil`, and `disposable_*` fields of an alert after `dismissUntil` expiration, and also restores the alert's previous status (sent in `batch_enrich` now) when dismissUntil expires.
- Fixes the bug in the UI where selecting two alerts in the feed, even if both are dismissed, triggers the dismiss pop-up, instead of the restore one in that case.



## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
It has been tested both with dedicated tests and via direct alert sending through API, dismissing them with a workflow, and also via the UI tool. It works correctly for single or multiple alerts, as needed.
