### PR TITLE
fix: cleaning of fields after dismissUntil expiration

### DIFF
--- a/keep-ui/features/alerts/dismiss-alert/ui/alert-dismiss-modal.tsx
+++ b/keep-ui/features/alerts/dismiss-alert/ui/alert-dismiss-modal.tsx
@@ -47,7 +47,6 @@ export function AlertDismissModal({
   const revalidateMultiple = useRevalidateMultiple();
   const presetsMutator = () => revalidateMultiple(["/preset"]);
   const { alertsMutator } = useAlerts();
-
   const api = useApi();
   // Ensuring that the useEffect hook is called consistently
   useEffect(() => {
@@ -89,18 +88,16 @@ export function AlertDismissModal({
     const dismissUntil =
       selectedTab === 0 ? null : selectedDateTime?.toISOString();
 
-    const enrichments: {
-      dismissed: boolean;
-      note: string;
-      dismissUntil: string;
-    } = {
-      dismissed: !alerts[0]?.dismissed,
+    const enrichmentsArray = alerts.map((alert: AlertDto) => ({
+      dismissed: !alert.dismissed,
       note: dismissComment,
       dismissUntil: dismissUntil || "",
-    };
+      previous_status: alert.status, // save actual status
+    }));
+
 
     const requestData = {
-      enrichments: enrichments,
+      enrichments: enrichmentsArray,
       fingerprints: alerts.map((alert: AlertDto) => alert.fingerprint),
     };
 
@@ -149,7 +146,7 @@ export function AlertDismissModal({
       beforeTitle={alerts?.[0]?.name}
       title="Dismiss Alert"
     >
-      {alerts && alerts.length == 1 && alerts[0].dismissed ? (
+      {alerts && alerts.every((alert) => alert.dismissed) ? (
         <>
           <Subtitle className="text-center">
             Are you sure you want to restore this alert?

--- a/keep/api/bl/enrichments_bl.py
+++ b/keep/api/bl/enrichments_bl.py
@@ -733,7 +733,7 @@ class EnrichmentsBl:
 
     def enrich_entity(
         self,
-        fingerprint: str,
+        fingerprint: str | UUID,
         enrichments: dict,
         action_type: ActionType,
         action_callee: str,

--- a/keep/api/bl/enrichments_bl.py
+++ b/keep/api/bl/enrichments_bl.py
@@ -643,14 +643,14 @@ class EnrichmentsBl:
         )
 
     def batch_enrich(
-            self,
-            fingerprints: list[str],
-            enrichments_list: list[dict],
-            action_type: ActionType,
-            action_callee: str,
-            action_description: str,
-            dispose_on_new_alert=False,
-            audit_enabled=True,
+        self,
+        fingerprints: list[str],
+        enrichments_list: list[dict],
+        action_type: ActionType,
+        action_callee: str,
+        action_description: str,
+        dispose_on_new_alert=False,
+        audit_enabled=True,
     ):
         self.logger.debug(
             "enriching multiple fingerprints",
@@ -751,6 +751,10 @@ class EnrichmentsBl:
         Enrich the alert with extraction and mapping rules
         """
         # enrich db
+        if isinstance(fingerprint, UUID):
+            fingerprint = UUIDType(binary=False).process_bind_param(
+                fingerprint, self.db_session.bind.dialect
+            )
         self.logger.debug(
             "enriching alert db",
             extra={"fingerprint": fingerprint, "tenant_id": self.tenant_id},

--- a/keep/api/bl/enrichments_bl.py
+++ b/keep/api/bl/enrichments_bl.py
@@ -36,10 +36,7 @@ from keep.api.models.alert import (
     AlertDto,
     AlertStatus,
 )
-from keep.api.models.db.alert import (
-    Alert,
-    AlertEnrichment,
-)
+from keep.api.models.db.alert import Alert
 from keep.api.models.db.enrichment_event import (
     EnrichmentEvent,
     EnrichmentLog,
@@ -931,9 +928,10 @@ class EnrichmentsBl:
 
         # Create AlertDto to validate and parse previous_status
         try:
-            alert = AlertDto(**enrichments.enrichments)
-        except:
-            return  # Failed to create AlertDto, exit
+            _ = AlertDto(**enrichments.enrichments)
+        except Exception:
+            self.logger.warning("Error creating AlertDTO")
+            return
 
         # Convert previous_status to lowercase string if it's a string
         prev_status_str = previous_status.lower() if isinstance(previous_status, str) else previous_status

--- a/keep/api/bl/incidents_bl.py
+++ b/keep/api/bl/incidents_bl.py
@@ -498,8 +498,8 @@ class IncidentBl:
             raise HTTPException(status_code=404, detail="Incident not found")
 
         if new_status in [IncidentStatus.RESOLVED, IncidentStatus.ACKNOWLEDGED]:
-            enrichments = {"status": new_status.value}
             fingerprints = [alert.fingerprint for alert in incident.alerts]
+            enrichments = [{"status": new_status.value} for _ in fingerprints]
             enrichments_bl = EnrichmentsBl(self.tenant_id, db=self.session)
             (
                 action_type,

--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -233,6 +233,12 @@ def query_alerts(
     enriched_alerts_dto = convert_db_alerts_to_dto_alerts(
         db_alerts, with_incidents=True
     )
+
+    # Cleanup of disposable fields if applicable
+    enrichment_bl = EnrichmentsBl(tenant_id)
+    for alert in enriched_alerts_dto:
+        enrichment_bl.dispose_dismiss_disposables(alert.fingerprint)
+
     logger.info(
         "Fetched alerts from DB",
         extra={
@@ -269,6 +275,12 @@ def get_all_alerts(
     )
     db_alerts = get_last_alerts(tenant_id=tenant_id, limit=limit)
     enriched_alerts_dto = convert_db_alerts_to_dto_alerts(db_alerts)
+
+    # Cleanup of disposable fields if applicable
+    enrichment_bl = EnrichmentsBl(tenant_id)
+    for alert in enriched_alerts_dto:
+        enrichment_bl.dispose_dismiss_disposables(alert.fingerprint)
+
     logger.info(
         "Fetched alerts from DB",
         extra={
@@ -424,7 +436,7 @@ def assign_alert(
     enrichment_bl = EnrichmentsBl(tenant_id)
     enrichment_bl.enrich_entity(
         fingerprint=fingerprint,
-        enrichments=enrichments,
+        enrichments_list=enrichments,
         action_type=ActionType.ACKNOWLEDGE,
         action_description=f"Alert assigned to {user_email}, status: {status}",
         action_callee=user_email,
@@ -897,7 +909,7 @@ def batch_enrich_alerts(
 
         enrichment_bl.batch_enrich(
             fingerprints=fingerprints,
-            enrichments=enrichments,
+            enrichments_list=enrichments, 
             action_type=action_type,
             action_callee=authenticated_entity.email,
             action_description=action_description,
@@ -921,7 +933,7 @@ def batch_enrich_alerts(
             ]
             enrichment_bl.batch_enrich(
                 fingerprints=formatted_alert_ids,
-                enrichments=enrichments,
+                enrichments_list=enrichments,
                 action_type=action_type,
                 action_callee=authenticated_entity.email,
                 action_description=action_description,

--- a/tests/test_enrichments.py
+++ b/tests/test_enrichments.py
@@ -21,7 +21,7 @@ from keep.workflowmanager.workflowmanager import WorkflowManager
 from tests.fixtures.client import client, setup_api_key, test_app
 from tests.fixtures.workflow_manager import (
     wait_for_workflow_execution,
-   # wait_for_workflow_in_run_queue,
+    wait_for_workflow_in_run_queue,
 )  # noqa
 
 


### PR DESCRIPTION
Closes https://github.com/keephq/keep/issues/5047

📑 Description
This pull request addresses two main points:

Fixes the bug related to cleaning the dismissed, dismissUntil, and disposable_* fields of an alert after dismissUntil expiration, and also restores the alert's previous status (sent in batch_enrich now) when dismissUntil expires.
Fixes the bug in the UI where selecting two alerts in the feed, even if both are dismissed, triggers the dismiss pop-up, instead of the restore one in that case.
✅ Checks
 My pull request adheres to the code style of this project
 My code requires changes to the documentation
 I have updated the documentation as required
 All the tests have passed
ℹ Additional Information
It has been tested both with dedicated tests and via direct alert sending through API, dismissing them with a workflow, and also via the UI tool. It works correctly for single or multiple alerts, as needed.