### PR TITLE
docs: fix doc redis sentinel

### DIFF
--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -245,7 +245,7 @@ Keep is highly configurable through environment variables. This allows you to cu
 | **REDIS_USERNAME** |    Redis username     |    No    |     None      |    Valid username string     |
 | **REDIS_PASSWORD** |    Redis password     |    No    |     None      |    Valid password string     |
 
-#### Redis Sentinel
+### Redis Sentinel
 <Info>
   Redis sentinel configuration specifies the connection details for Keep's Redis sentinel
   instance. Redis sentinel is used when you have a redis cluster and it acts as a broker.


### PR DESCRIPTION
Fix documentation for use of redis sentinel:
wrong title level, 4th level unsupported by mintlify https://mintlify.com/

Closes #5154