### PR TITLE
fix: Rename pyproject name from 'keep' to 'keephq'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "keep"
+name = "keephq"
 version = "0.46.1"
 description = "Alerting. for developers, by developers."
 authors = ["Keep Alerting LTD"]


### PR DESCRIPTION
fix: Rename project from 'keep' to 'keephq' to avoid security scanner confusion

- Changes the project name in pyproject.toml from 'keep' to 'keephq'
- Prevents false positive CVE associations with unrelated PyPI package

Closes #5198

## 📑 Description

This PR addresses a security scanning issue where the project name "keep" in pyproject.toml causes confusion with an unrelated PyPI package of the same name that has had previous CVEs.

By renaming the project to "keephq", security scanners will no longer mistakenly associate this project with the other package's vulnerabilities.

### Changes made:
- [x] Changed project name from `keep` to `keephq` in pyproject.toml

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

### Impact
- This is a metadata change only and should not affect the functionality of the project
- The package directory remains `keep` (as specified in `packages = [{include = "keep"}]`)
- This change only affects how the project is identified by package managers and security scanners

### Before
```toml
[tool.poetry]
name = "keep"
```

### After
```toml
[tool.poetry]
name = "keephq"
```