### PR TITLE
Address github issue 5224

### DIFF
--- a/keep/providers/base/base_provider.py
+++ b/keep/providers/base/base_provider.py
@@ -84,7 +84,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
         context_manager: ContextManager,
         provider_id: str,
         config: ProviderConfig,
-        webhooke_template: Optional[str] = None,
+        webhook_template: Optional[str] = None,
         webhook_description: Optional[str] = None,
         webhook_markdown: Optional[str] = None,
         provider_description: Optional[str] = None,
@@ -99,7 +99,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
         self.provider_id = provider_id
 
         self.config = config
-        self.webhooke_template = webhooke_template
+        self.webhook_template = webhook_template
         self.webhook_description = webhook_description
         self.webhook_markdown = webhook_markdown
         self.provider_description = provider_description


### PR DESCRIPTION
Fix `TypeError` during provider initialization by correcting a typo in `BaseProvider` constructor.

The `webhooke_template` parameter was misspelled, leading to a `TypeError` when providers (like Jira) were initialized, manifesting as "Configuration problem while trying to initialize the provider".

---
<a href="https://cursor.com/background-agent?bcId=bc-81fd8c83-7bfb-4581-bbe0-51dcb05631f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81fd8c83-7bfb-4581-bbe0-51dcb05631f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>