### PR TITLE
Solve keep github issue 5180

### DIFF
--- a/keep/api/core/alerts.py
+++ b/keep/api/core/alerts.py
@@ -106,6 +106,7 @@ alert_field_configurations = [
     FieldMappingConfiguration(
         map_from_pattern="lastReceived",
         map_to=[
+            "lastalert.timestamp",
             "JSON(alertenrichment.enrichments).*",
             "JSON(alert.event).*",
         ],


### PR DESCRIPTION
Map `lastReceived` to `lastalert.timestamp` to fix `time_delta` filtering in the Keep Provider.

Previously, the `lastReceived` field was only mapped to JSON paths within enrichments and event data, not to the actual database timestamp column (`lastalert.timestamp`). This prevented the `time_delta` parameter in the Keep Provider from correctly filtering alerts based on their last received timestamp, as the CEL-to-SQL conversion couldn't properly apply the filter.

---
<a href="https://cursor.com/background-agent?bcId=bc-6927278d-78a7-4324-b4ae-2fc3db15a25c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6927278d-78a7-4324-b4ae-2fc3db15a25c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

