### PR TITLE
feat: pagerduty provider override routing key in workflow #5242

### DIFF
--- a/docs/snippets/providers/http-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/http-snippet-autogenerated.mdx
@@ -1,4 +1,4 @@
-{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py 
+{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py
 Do not edit it manually, as it will be overwritten */}
 
 
@@ -50,6 +50,7 @@ Check the following workflow examples:
 - [http_enrich.yml](https://github.com/keephq/keep/blob/main/examples/workflows/http_enrich.yml)
 - [ifelse.yml](https://github.com/keephq/keep/blob/main/examples/workflows/ifelse.yml)
 - [incident-enrich.yaml](https://github.com/keephq/keep/blob/main/examples/workflows/incident-enrich.yaml)
+- [pagerduty.yml](https://github.com/keephq/keep/blob/main/examples/workflows/pagerduty.yml)
 - [permissions_example.yml](https://github.com/keephq/keep/blob/main/examples/workflows/permissions_example.yml)
 - [send-message-telegram-with-htmlmd.yaml](https://github.com/keephq/keep/blob/main/examples/workflows/send-message-telegram-with-htmlmd.yaml)
 - [simple_http_request_ntfy.yml](https://github.com/keephq/keep/blob/main/examples/workflows/simple_http_request_ntfy.yml)

--- a/docs/snippets/providers/pagerduty-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/pagerduty-snippet-autogenerated.mdx
@@ -1,4 +1,4 @@
-{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py 
+{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py
 Do not edit it manually, as it will be overwritten */}
 
 ## Authentication
@@ -42,6 +42,7 @@ actions:
         title: {value}  # Title of the alert or incident
         dedup: {value}  # String used to deduplicate alerts for events API, max 255 chars
         service_id: {value}  # ID of the service for incidents
+        routing_key: {value}  # API routing_key (optional), if not specified, fallbacks to the one provided in provider
         requester: {value}  # Email of the user requesting the incident creation
         incident_id: {value}  # Key to identify the incident. UUID generated if not provided
         event_type: {value}  # Event type for events API (trigger/acknowledge/resolve)
@@ -57,11 +58,12 @@ actions:
 
 
 
-Check the following workflow example:
+Check the following workflow examples:
 - [ifelse.yml](https://github.com/keephq/keep/blob/main/examples/workflows/ifelse.yml)
+- [pagerduty.yml](https://github.com/keephq/keep/blob/main/examples/workflows/pagerduty.yml)
 
 
 ## Topology
-This provider pulls [topology](/overview/servicetopology) to Keep. It could be used in [correlations](/overview/correlation-topology) 
-and [mapping](/overview/enrichment/mapping#mapping-with-topology-data), and as a context 
+This provider pulls [topology](/overview/servicetopology) to Keep. It could be used in [correlations](/overview/correlation-topology)
+and [mapping](/overview/enrichment/mapping#mapping-with-topology-data), and as a context
 for [alerts](/alerts/sidebar#7-alert-topology-view) and [incidents](/overview#17-incident-topology).

--- a/examples/workflows/pagerduty.yml
+++ b/examples/workflows/pagerduty.yml
@@ -1,0 +1,55 @@
+workflow:
+  id: pagerduty-example
+  name: PagerDuty workflow example
+  description: retrieve PagerDuty incident, create event and incident
+  triggers:
+    - type: manual
+  steps:
+    - name: check-incident-exist-pd-fingerprint
+      if: "{{ incident.fingerprint }} != ''"
+      provider:
+        type: pagerduty
+        config: "{{ providers.PagerDuty }}"
+        with:
+          incident_id: "{{ incident.fingerprint }}"
+  actions:
+    - name: pd-create-event
+      provider:
+        type: pagerduty
+        config: "{{ providers.PagerDuty }}"
+        with:
+          routing_key: 'your_routing_key'
+          severity: critical
+          source: keep
+          component: job_service
+          group: job
+          class: job
+          custom_details:
+            environment: 'production'
+            url: 'https://keep.example.org'
+          links:
+            - href: "https://keep.example.com/"
+              text: "View in Keep"
+          dedup: "{{ incident.id }}"
+          event_type: trigger
+          title: "TestEvent"
+    - name: pd-create-inc
+      provider:
+        type: pagerduty
+        config: "{{ providers.PagerDuty }}"
+        with:
+          source: keep
+          alert_body:
+            details:
+              client: keep
+              client_url: "https://keep.example.com/incidents/{{ incident.id }}"
+              description: "{{ incident.user_summary }}"
+              alert_count: "{{ incident.alerts_count }}"
+              alerts: "{{ incident.alerts }}"
+            type: incident_body
+          dedup: "{{ incident.id }}"
+          status: "triggered"
+          service_id: "{{ incident.service_id }}"
+          requester: email@example.com
+          severity: "{{ incident.severity }}"
+          title: "{{ incident.user_generated_name }}"

--- a/examples/workflows/pagerduty.yml
+++ b/examples/workflows/pagerduty.yml
@@ -18,7 +18,7 @@ workflow:
         type: pagerduty
         config: "{{ providers.PagerDuty }}"
         with:
-          routing_key: 'your_routing_key'
+          routing_key: 'your_routing_key' # optional, otherwise it will take from provider configuration$
           severity: critical
           source: keep
           component: job_service

--- a/keep/providers/pagerduty_provider/pagerduty_provider.py
+++ b/keep/providers/pagerduty_provider/pagerduty_provider.py
@@ -402,7 +402,6 @@ class PagerdutyProvider(
                 "severity": severity,
             },
         }
-
         custom_details = kwargs.get("custom_details", {})
         if isinstance(custom_details, str):
             custom_details = json.loads(custom_details)
@@ -435,7 +434,6 @@ class PagerdutyProvider(
             if isinstance(links, str):
                 links = json.loads(links)
             payload["payload"]["links"] = links
-
         return payload
 
     def _send_alert(

--- a/keep/providers/pagerduty_provider/pagerduty_provider.py
+++ b/keep/providers/pagerduty_provider/pagerduty_provider.py
@@ -345,6 +345,7 @@ class PagerdutyProvider(
     def _build_alert(
         self,
         title: str,
+        routing_key: str,
         dedup: str | None = None,
         severity: typing.Literal["critical", "error", "warning", "info"] | None = None,
         event_type: typing.Literal["trigger", "acknowledge", "resolve"] | None = None,
@@ -392,7 +393,7 @@ class PagerdutyProvider(
                 source = self.context_manager.event_context.service or "custom_event"
 
         payload = {
-            "routing_key": self.authentication_config.routing_key,
+            "routing_key": routing_key,
             "event_action": event_type,
             "dedup_key": dedup,
             "payload": {
@@ -440,6 +441,7 @@ class PagerdutyProvider(
     def _send_alert(
         self,
         title: str,
+        routing_key: str,
         dedup: str | None = None,
         severity: typing.Literal["critical", "error", "warning", "info"] | None = None,
         event_type: typing.Literal["trigger", "acknowledge", "resolve"] | None = None,
@@ -458,7 +460,7 @@ class PagerdutyProvider(
         url = "https://events.pagerduty.com/v2/enqueue"
 
         payload = self._build_alert(
-            title, dedup, severity, event_type, source, **kwargs
+            title, routing_key, dedup, severity, event_type, source, **kwargs
         )
         result = requests.post(url, json=payload)
         result.raise_for_status()
@@ -468,7 +470,7 @@ class PagerdutyProvider(
             extra={
                 "status_code": result.status_code,
                 "response_text": result.text,
-                "routing_key": self.authentication_config.routing_key,
+                "routing_key": routing_key,
             },
         )
         return result.json()
@@ -685,6 +687,7 @@ class PagerdutyProvider(
         title: str = "",
         dedup: str = "",
         service_id: str = "",
+        routing_key: str = "",
         requester: str = "",
         incident_id: str = "",
         event_type: typing.Literal["trigger", "acknowledge", "resolve"] | None = None,
@@ -704,6 +707,7 @@ class PagerdutyProvider(
             title (str): Title of the alert or incident
             dedup (str | None): String used to deduplicate alerts for events API, max 255 chars
             service_id (str): ID of the service for incidents
+            routing_key (str): API routing_key (optional), if not specified, fallbacks to the one provided in provider
             body (dict): Body of the incident as per https://developer.pagerduty.com/api-reference/a7d81b0e9200f-create-an-incident#request-body
             requester (str): Email of the user requesting the incident creation
             incident_id (str | None): Key to identify the incident. UUID generated if not provided
@@ -715,11 +719,14 @@ class PagerdutyProvider(
             resolution (str): Resolution note for resolved incidents
             kwargs (dict): Additional event/incident fields
         """
-        if self.authentication_config.routing_key:
+        if not routing_key: # If routing_key not specified in workflow, fallback to config routing_key
+            routing_key = self.authentication_config.routing_key
+        if  routing_key:
             return self._send_alert(
                 title,
                 dedup=dedup,
                 event_type=event_type,
+                routing_key=routing_key,
                 source=source,
                 severity=severity,
                 **kwargs,


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5242

## 📑 Description
Be able to override routing_key in workflow

Currently, the only way to send to multiples PagerDuty routing_key (integration key) is to have one PagerDuty provider per routing_key.
And the issue is, you cannot use variable in workflow provider property (will open a different issue on this)


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required (provided example workflow)
- [ ] All the tests have passed

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Use case is the following:
We have multiples customer platform/environment and we have one PagerDuty service per each.

Sadly, when you create PagerDuty event thru their API, you cannot specify service_id.
The other solution would be to directly incident rather than event but incident would be automatically resolve after x hours and there's not way extend it.
