### PR TITLE
feat: PagerDuty incident API support incident_key (dedup_key) #5246

### DIFF
--- a/docs/snippets/providers/pagerduty-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/pagerduty-snippet-autogenerated.mdx
@@ -29,6 +29,7 @@ steps:
       config: "{{ provider.my_provider_name }}"
       with:
         incident_id: {value}  
+        incident_key: {value}  
 ```
 
 

--- a/examples/workflows/pagerduty.yml
+++ b/examples/workflows/pagerduty.yml
@@ -12,6 +12,12 @@ workflow:
         config: "{{ providers.PagerDuty }}"
         with:
           incident_id: "{{ incident.fingerprint }}"
+    - name: check-incident-exist-pd-incident-key-dedup-key
+      provider:
+        type: pagerduty
+        config: "{{ providers.PagerDuty }}"
+        with:
+          incident_key: "7f3baa50-e7ef-4891-bd4a-d1ee310dff8f"
   actions:
     - name: pd-create-event
       provider:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keep"
-version = "0.46.5"
+version = "0.47.0"
 description = "Alerting. for developers, by developers."
 authors = ["Keep Alerting LTD"]
 packages = [{include = "keep"}]


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5246

## 📑 Description
Current implementation for incident API is missing incident_key, that's usefull for searching incident with dedup_key.
use case: you create a PD event with a dedup_key and you want to find the created incident.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
 PagerDuty Incident API reference: https://developer.pagerduty.com/api-reference/9d0b4b12e36f9-list-incidents
