### PR TITLE
Feature/Add onelogin authentication support

### DIFF
--- a/docs/deployment/authentication/onelogin-auth.mdx
+++ b/docs/deployment/authentication/onelogin-auth.mdx
@@ -1,0 +1,64 @@
+---
+title: "OneLogin Authentication"
+---
+
+This document provides comprehensive information about the OneLogin integration in Keep
+
+## Overview
+
+Keep supports OneLogin as an authentication provider, enabling:
+- Single Sign-On (SSO) via OneLogin
+- OAuth2/OIDC authentication flow
+- Token refresh capabilities
+- Role-based access control through custom claims
+- Session management through NextAuth.js
+
+## Environment Variables
+
+### Backend Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `AUTH_TYPE` | Set to `"ONELOGIN"` to enable OneLogin authentication | `ONELOGIN` |
+| `ONELOGIN_ISSUER` | The issuer URL for your OneLogin application | `https://company.onelogin.com/oidc/2` |
+| `ONELOGIN_CLIENT_ID` | Client ID of your OneLogin application | `abc123def456ghi789` |
+| `ONELOGIN_CLIENT_SECRET` | Client Secret of your OneLogin application | `abcd1234efgh5678ijkl9012` |
+| `ONELOGIN_ADMIN_ROLE` | Role to be mapped to a keep admin role | `KeepAdmin` |
+| `ONELOGIN_NOC_ROLE` | Role to be mapped to a keep noc role | `KeepNoc` |
+| `ONELOGIN_WEBHOOK_ROLE` | Role to be mapped to a keep webhook role | `KeepWebhook` |
+| `ONELOGIN_AUTO_CREATE_USER` | Whether to try and create autocreate users in keep | `True` |
+
+### Frontend Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `AUTH_TYPE` | Set to `"ONELOGIN"` to enable OneLogin authentication | `ONELOGIN` |
+| `ONELOGIN_ISSUER` | The issuer URL for your OneLogin application | `https://company.onelogin.com/oidc/2` |
+| `ONELOGIN_CLIENT_ID` | Client ID of your OneLogin application | `abc123def456ghi789` |
+| `ONELOGIN_CLIENT_SECRET` | Client Secret of your OneLogin application | `abcd1234efgh5678ijkl9012` |
+
+## OneLogin Configuration
+
+### Creating a OneLogin Application
+
+1. Sign in to your OneLogin Admin Console
+2. Navigate to **Applications**
+3. Click **Add App**
+4. Search for **OpenId Connect (OIDC)** and select it
+5. Click **Save**
+
+### Application Settings
+
+1. **Display Name**: Enter a name for your application (e.g., "Keep")
+2. **Redirect URIs**: Enter your app's callback URL, e.g., `https://your-keep-domain.com/api/auth/callback/onelogin`
+3. **Login URL**: Enter your app's login URL, e.g., `https://your-keep-domain.com/signin`
+4. **Role Mapping**:
+    - Go to the Parameters tab
+    - Map the groups to user roles or groups with the default value being semicolon delimited input values
+5. Go to the **SSO** tab and configure:
+   - **Application Type**: Web
+   - **Token Endpoint**: Client Secret Post
+6. **Access**:
+   - Assign to appropriate roles or users
+7. Click **Save**
+8. Copy the client id, client secret and issuer URL from the SSO tab

--- a/docs/deployment/authentication/overview.mdx
+++ b/docs/deployment/authentication/overview.mdx
@@ -15,6 +15,7 @@ Keep supports various authentication providers and architectures to accommodate 
 - [**Keycloak**](/deployment/authentication/keycloak-auth) - Utilize Keycloak for enterprise authentication methods such as SSO/SAML/OIDC, advanced RBAC with custom roles, resource-level permissions, and integration with user directories (LDAP).
 - [**AzureAD**](/deployment/authentication/azuread-auth) - Utilize Azure AD for SSO/SAML/OIDC nterprise authentication.
 - [**Okta**](/deployment/authentication/okta-auth) - Utilize Okta for SSO/OIDC authentication.
+- [**OneLogin**](/deployment/authentication/onelogin-auth) - Utilize OneLogin for SSO/OIDC authentication.
 
 Choosing the right authentication strategy depends on your specific use case, security requirements, and deployment environment. You can read more about each authentication provider.
 
@@ -31,6 +32,7 @@ Choosing the right authentication strategy depends on your specific use case, se
 | **Oauth2Proxy**       |  ✅ <br />(Predefiend roles)  |     ✅     |  ❌   |             ❌            |        N/A        |         N/A         |    ✅    |   **OSS**   |
 | **Azure AD**       |  ✅ <br />(Predefiend roles)  |     ✅     |  ❌   |             ❌            |        By Azure AD        |         By Azure AD         |    ✅    |   **EE**   |
 | **Okta**           |  ✅ <br />(Predefiend roles)  |     ✅     |  ❌   |             ✅            |        ❌        |         ❌         |    ✅    |   **OSS**   |
+| **OneLogin**           |  ✅ <br />(Predefiend roles)  |     ✅     |  ❌   |             ✅            |        ❌        |         ❌         |    ✅    |   **OSS**   |
 ### How To Configure
 <Tip>
 Some authentication providers require additional environment variables. These will be covered in detail on the specific authentication provider pages.
@@ -47,5 +49,6 @@ The authentication scheme on Keep is controlled with environment variables both 
 | **Oauth2Proxy** | `AUTH_TYPE=OAUTH2PROXY` | `OAUTH2_PROXY_USER_HEADER`, `OAUTH2_PROXY_ROLE_HEADER`, `OAUTH2_PROXY_AUTO_CREATE_USER` |
 | **AzureAD** | `AUTH_TYPE=AZUREAD` | See [AzureAD Configuration](/deployment/authentication/azuread-auth) |
 | **Okta** | `AUTH_TYPE=OKTA` | `OKTA_DOMAIN`, `OKTA_CLIENT_ID`, `OKTA_CLIENT_SECRET` |
+| **OneLogin** | `AUTH_TYPE=ONELOGIN` | See [OneLogin Configuration](/deployment/authentication/onelogin-auth) |
 
 For more details on each authentication strategy, including setup instructions and implications, refer to the respective sections.

--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -94,7 +94,7 @@ Keep is highly configurable through environment variables. This allows you to cu
 
 |                Env var                |                              Purpose                              | Required | Default Value |                   Valid options                    |
 | :-----------------------------------: | :---------------------------------------------------------------: | :------: | :-----------: | :------------------------------------------------: |
-|             **AUTH_TYPE**             |                 Specifies the authentication type                 |    No    |   "NOAUTH"    | "AUTH0", "KEYCLOAK", "DB", "NOAUTH", "OAUTH2PROXY", "OKTA" |
+|             **AUTH_TYPE**             |                 Specifies the authentication type                 |    No    |   "NOAUTH"    | "AUTH0", "KEYCLOAK", "DB", "NOAUTH", "OAUTH2PROXY", "OKTA", "ONELOGIN" |
 |          **KEEP_JWT_SECRET**          | Secret key for JWT token generation and validation (DB auth only) |   Yes    |     None      |              Any strong secret string              |
 |       **KEEP_DEFAULT_USERNAME**       |        Default username for the admin user (DB auth only)         |    No    |    "keep"     |             Any valid username string              |
 |       **KEEP_DEFAULT_PASSWORD**       |        Default password for the admin user (DB auth only)         |    No    |    "keep"     |             Any strong password string             |
@@ -331,7 +331,7 @@ These endpoints are rate-limited according to the `KEEP_LIMIT_CONCURRENCY` setti
 
 |       Env var       |              Purpose              | Required | Default Value |                   Valid options                    |
 | :-----------------: | :-------------------------------: | :------: | :-----------: | :------------------------------------------------: |
-|    **AUTH_TYPE**    | Specifies the authentication type |    No    |   "noauth"    | "auth0", "keycloak", "db", "noauth", "oauth2proxy", "okta" |
+|    **AUTH_TYPE**    | Specifies the authentication type |    No    |   "NOAUTH"    | "AUTH0", "KEYCLOAK", "DB", "NOAUTH", "OAUTH2PROXY", "OKTA", "ONELOGIN" |
 |  **NEXTAUTH_URL**   |  URL for NextAuth authentication  |   Yes    |     None      |                     Valid URL                      |
 | **NEXTAUTH_SECRET** |      Secret key for NextAuth      |   Yes    |     None      |                Strong secret string                |
 

--- a/keep-ui/app/(signin)/error/authEnvUtils.tsx
+++ b/keep-ui/app/(signin)/error/authEnvUtils.tsx
@@ -37,6 +37,12 @@ export function getAuthTypeEnvVars(authType: string | undefined): AuthEnvVars {
         OKTA_ISSUER: maskValue(process.env.OKTA_ISSUER),
         OKTA_DOMAIN: maskValue(process.env.OKTA_DOMAIN),
       };
+    case AuthType.ONELOGIN:
+      return {
+        ONELOGIN_CLIENT_ID: maskValue(process.env.ONELOGIN_CLIENT_ID),
+        ONELOGIN_CLIENT_SECRET: maskValue(process.env.ONELOGIN_CLIENT_SECRET),
+        ONELOGIN_ISSUER: maskValue(process.env.ONELOGIN_ISSUER),
+      };
     case AuthType.DB:
       return {
         API_URL: maskValue(process.env.API_URL),

--- a/keep-ui/app/(signin)/signin/SignInForm.tsx
+++ b/keep-ui/app/(signin)/signin/SignInForm.tsx
@@ -22,6 +22,7 @@ export interface Providers {
   keycloak?: Provider;
   "microsoft-entra-id"?: Provider;
   okta?: Provider;
+  onelogin?: Provider
 }
 
 interface SignInFormInputs {
@@ -81,6 +82,9 @@ export default function SignInForm({
       } else if (providers["microsoft-entra-id"]) {
         console.log("Signing in with Azure AD provider");
         signIn("microsoft-entra-id", { callbackUrl: "/" });
+      } else if (providers.onelogin) {
+        console.log("Signing in with OneLogin provider");
+        signIn("onelogin", { callbackUrl: "/" });
       } else if (
         providers.credentials &&
         providers.credentials.name == "NoAuth"

--- a/keep-ui/utils/authenticationType.ts
+++ b/keep-ui/utils/authenticationType.ts
@@ -7,6 +7,7 @@ export enum AuthType {
   OAUTH2PROXY = "OAUTH2PROXY",
   AZUREAD = "AZUREAD",
   OKTA = "OKTA",
+  ONELOGIN = "ONELOGIN",
   NOAUTH = "NOAUTH", // Default
 }
 

--- a/keep/identitymanager/identity_managers/onelogin/onelogin_authverifier.py
+++ b/keep/identitymanager/identity_managers/onelogin/onelogin_authverifier.py
@@ -1,0 +1,161 @@
+import logging
+import jwt
+from fastapi import Depends, HTTPException
+from keep.api.core.config import config
+from keep.api.core.db import user_exists, create_user, update_user_last_sign_in, update_user_role
+from keep.api.core.dependencies import SINGLE_TENANT_UUID
+
+from keep.identitymanager.authenticatedentity import AuthenticatedEntity
+from keep.identitymanager.authverifierbase import AuthVerifierBase, oauth2_scheme
+from keep.identitymanager.rbac import get_role_by_role_name
+
+logger = logging.getLogger(__name__)
+
+class OneLoginAuthVerifier(AuthVerifierBase):
+    """Handles SSO authentication for OneLogin"""
+
+    def __init__(self, scopes: list[str] = []) -> None:
+        super().__init__(scopes)
+        self.logger.info(f"Initializing OneLogin AuthVerifier with scopes: {scopes}")
+        self.onelogin_issuer = config("ONELOGIN_ISSUER")
+        self.onelogin_client_id = config("ONELOGIN_CLIENT_ID")
+        self.auto_create_user = config("ONELOGIN_AUTO_CREATE_USER", default=True)
+
+        self.role_mappings = {
+            config("ONELOGIN_ADMIN_ROLE", default="keep_admin"): "admin",
+            config("ONELOGIN_NOC_ROLE", default="keep_noc"): "noc",
+            config("ONELOGIN_WEBHOOK_ROLE", default="keep_webhook"): "webhook",
+        }
+
+        if (
+            not self.onelogin_issuer
+            or not self.onelogin_client_id
+        ):
+            raise Exception("Missing ONELOGIN_ISSUER or ONELOGIN_CLIENT_ID environment variable")
+
+        # Remove trailing slash if present on issuer
+        if self.onelogin_issuer.endswith("/"):
+            self.onelogin_issuer = self.onelogin_issuer[:-1]
+
+        self.jwks_url = f"{self.onelogin_issuer}/certs"
+        self.jwks_client = jwt.PyJWKClient(self.jwks_url)
+        self.logger.info(f"Initialized OneLogin JWKS client with URL: {self.jwks_url}")
+
+        self.logger.info("OneLogin Auth Verifier initialized")
+
+    def _verify_bearer_token(self, token: str = Depends(oauth2_scheme)) -> AuthenticatedEntity:
+        if not token:
+            raise HTTPException(status_code=401, detail="No token provided")
+        try:
+            # Get the signing key directly from the JWT
+            signing_key = self.jwks_client.get_signing_key_from_jwt(token).key
+
+            # Decode and verify the token
+            payload = jwt.decode(
+                token,
+                key=signing_key,
+                algorithms=["RS256"],
+                audience= self.onelogin_client_id,
+                issuer=self.onelogin_issuer,
+                options={"verify_exp": True}
+            )
+
+            user_name = payload.get("email") or payload.get("sub") or payload.get("preferred_username")
+
+            onelogin_groups = payload.get("groups", [])
+            # When one configures basic roles on OneLogin it comes as a list but when you perform a role mapping it comes as comma separated string
+            if type(onelogin_groups) is str:
+                onelogin_groups = onelogin_groups.split(",")
+
+            onelogin_groups = [g.strip() for g in onelogin_groups]
+
+            self.logger.debug(f"OneLogin Groups: {onelogin_groups}")
+
+            # Define the priority order of roles
+            role_priority = ["admin", "noc", "webhook"]
+            mapped_role = None
+
+            self.logger.debug(f"OneLogin to Keep Role Mapping: {self.role_mappings}")
+
+            for role in role_priority:
+                self.logger.debug(f"Checking for role {role}")
+                for onelogin_grp in onelogin_groups:
+                    self.logger.debug(f"Checking for onelogin group {onelogin_grp}")
+                    mapped_role_name=self.role_mappings.get(onelogin_grp, "")
+                    self.logger.debug(f"Checking for mapped role name {mapped_role_name}")
+                    if role == mapped_role_name:
+                        try:
+                            self.logger.debug(f"Getting role {mapped_role_name}")
+                            mapped_role = get_role_by_role_name(mapped_role_name)
+                            self.logger.debug(f"Role {mapped_role_name} found")
+                            break
+                        except HTTPException:
+                            self.logger.debug(f"Role {mapped_role_name} not found")
+                            continue
+                if mapped_role:
+                    self.logger.debug(f"Role {mapped_role.get_name()} found")
+                    break
+            # if no valid role was found, throw a 403 exception
+            if not mapped_role:
+                self.logger.warning(f"No valid role-group mapping found among {onelogin_groups}")
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"No valid role found among {onelogin_groups}",
+                )
+
+            # auto provision user
+            if self.auto_create_user and not user_exists(
+                    tenant_id=SINGLE_TENANT_UUID, username=user_name
+            ):
+                self.logger.info(f"Auto provisioning user: {user_name}")
+                create_user(
+                    tenant_id=SINGLE_TENANT_UUID,
+                    username=user_name,
+                    role=mapped_role.get_name(),
+                    password="",
+                )
+                self.logger.info(f"User {user_name} created")
+            elif user_exists(tenant_id=SINGLE_TENANT_UUID, username=user_name):
+                # update last login
+                self.logger.debug(f"Updating last login for user: {user_name}")
+                try:
+                    update_user_last_sign_in(
+                        tenant_id=SINGLE_TENANT_UUID, username=user_name
+                    )
+                    self.logger.debug(f"Last login updated for user: {user_name}")
+                except Exception:
+                    self.logger.warning(f"Failed to update last login for user: {user_name}")
+                    pass
+                # update role
+                self.logger.debug(f"Updating role for user: {user_name}")
+                try:
+                    update_user_role(
+                        tenant_id=SINGLE_TENANT_UUID,
+                        username=user_name,
+                        role=mapped_role.get_name(),
+                    )
+                    self.logger.debug(f"Role updated for user: {user_name}")
+                except Exception:
+                    self.logger.warning(f"Failed to update role for user: {user_name}")
+                    pass
+
+            self.logger.info(f"User {user_name} authenticated with role {mapped_role.get_name()}")
+            return AuthenticatedEntity(
+                tenant_id=SINGLE_TENANT_UUID,
+                email=user_name,
+                role=mapped_role.get_name(),
+                token=token
+            )
+
+        except jwt.exceptions.InvalidKeyError as e:
+            self.logger.error(f"Invalid key error during token validation: {str(e)}")
+            raise HTTPException(status_code=401, detail="Invalid signing key - token validation failed")
+        except jwt.ExpiredSignatureError:
+            self.logger.warning("Token has expired")
+            raise HTTPException(status_code=401, detail="Token has expired")
+        except jwt.InvalidTokenError as e:
+            self.logger.warning(f"Invalid token: {str(e)}")
+            raise HTTPException(status_code=401, detail=f"Invalid token: {str(e)}")
+        except Exception as e:
+            self.logger.exception("Failed to validate token")
+            raise HTTPException(status_code=401, detail=f"Token validation failed: {str(e)}")

--- a/keep/identitymanager/identity_managers/onelogin/onelogin_identitymanager.py
+++ b/keep/identitymanager/identity_managers/onelogin/onelogin_identitymanager.py
@@ -1,0 +1,123 @@
+import os
+
+
+from keep.api.models.user import Group, Role, User
+from keep.contextmanager.contextmanager import ContextManager
+from keep.identitymanager.authenticatedentity import AuthenticatedEntity
+from keep.identitymanager.authverifierbase import AuthVerifierBase
+from keep.identitymanager.identity_managers.onelogin.onelogin_authverifier import OneLoginAuthVerifier
+from keep.identitymanager.identitymanager import BaseIdentityManager
+
+
+class OneLoginIdentityManager(BaseIdentityManager):
+    """
+    Identity manager implementation for OneLogin SSO.
+    Only handles SSO authentication - all user management is disabled.
+    """
+
+    def __init__(self, tenant_id, context_manager: ContextManager, **kwargs):
+        super().__init__(tenant_id, context_manager, **kwargs)
+
+        self.logger.info("OneLoginIdentityManager initialized")
+
+        self.onelogin_issuer = os.environ.get("ONELOGIN_ISSUER")
+        self.onelogin_client_id = os.environ.get("ONELOGIN_CLIENT_ID")
+        self.onelogin_client_secret = os.environ.get("ONELOGIN_CLIENT_SECRET")
+
+        # Only require the essential variables for SSO
+        if not all([self.onelogin_issuer, self.onelogin_client_id, self.onelogin_client_secret]):
+            missing_vars = []
+            if not self.onelogin_issuer:
+                missing_vars.append("ONELOGIN_ISSUER")
+            if not self.onelogin_client_id:
+                missing_vars.append("ONELOGIN_CLIENT_ID")
+            if not self.onelogin_client_secret:
+                missing_vars.append("ONELOGIN_CLIENT_SECRET")
+
+            self.logger.error(f"Missing environment variables: {', '.join(missing_vars)}")
+            raise Exception(f"Missing environment variables: {', '.join(missing_vars)}")
+
+        # Remove any trailing slash from issuer
+        if self.onelogin_issuer.endswith("/"):
+            self.onelogin_issuer = self.onelogin_issuer[:-1]
+
+        self.logger.info("OneLogin Identity Manager initialized for SSO authentication only")
+
+    def on_start(self, app) -> None:
+        """
+        Initialize the identity manager on application startup.
+        No-op for SSO-only implementation.
+        """
+        self.logger.info("OneLogin Identity Manager started (SSO authentication only)")
+
+    @property
+    def support_sso(self) -> bool:
+        """Indicate that OneLogin supports SSO"""
+        return True
+
+    def get_sso_providers(self) -> list[str]:
+        """Get the list of SSO providers"""
+        return ["onelogin"]
+
+    def get_sso_wizard_url(self, authenticated_entity: AuthenticatedEntity) -> str:
+        """Get the URL for the SSO wizard - redirect to OneLogin login"""
+        return f"{self.onelogin_issuer}/auth"
+
+    def get_users(self) -> list[User]:
+        """Get all users from OneLogin - disabled"""
+        self.logger.info("get_users called but management functions are disabled")
+        return []
+
+    def create_user(self, user_email: str, user_name: str, password: str, role: str, groups: list[str] = []) -> dict:
+        """Create a new user in OneLogin - disabled"""
+        self.logger.info("create_user called but management functions are disabled")
+        return {"status": "not_implemented", "message": "User management is disabled"}
+
+    def update_user(self, user_email: str, update_data: dict) -> dict:
+        """Update an existing user in OneLogin - disabled"""
+        self.logger.info("update_user called but management functions are disabled")
+        return {"status": "not_implemented", "message": "User management is disabled"}
+
+    def delete_user(self, user_email: str) -> dict:
+        """Delete a user from OneLogin - disabled"""
+        self.logger.info("delete_user called but management functions are disabled")
+        return {"status": "not_implemented", "message": "User management is disabled"}
+
+    def get_auth_verifier(self, scopes: list) -> AuthVerifierBase:
+        """Get the auth verifier for OneLogin - this still works"""
+        return OneLoginAuthVerifier(scopes)
+
+    def get_groups(self) -> list[Group]:
+        """Get all groups from OneLogin - disabled"""
+        self.logger.info("get_groups called but management functions are disabled")
+        return []
+
+    def create_group(self, group_name: str, members: list[str], roles: list[str]) -> None:
+        """Create a new group in OneLogin - disabled"""
+        self.logger.info("create_group called but management functions are disabled")
+        return None
+
+    def update_group(self, group_name: str, members: list[str], roles: list[str]) -> None:
+        """Update an existing group in OneLogin - disabled"""
+        self.logger.info("update_group called but management functions are disabled")
+        return None
+
+    def delete_group(self, group_name: str) -> None:
+        """Delete a group from OneLogin - disabled"""
+        self.logger.info("delete_group called but management functions are disabled")
+        return None
+
+    def create_role(self, role: Role, predefined=False) -> str:
+        """Create a role in OneLogin - disabled"""
+        self.logger.info("create_role called but management functions are disabled")
+        return ""
+
+    def get_roles(self) -> list[Role]:
+        """Get all roles from OneLogin - disabled"""
+        self.logger.info("get_roles called but management functions are disabled")
+        return []
+
+    def delete_role(self, role_id: str) -> None:
+        """Delete a role from OneLogin - disabled"""
+        self.logger.info("delete_role called but management functions are disabled")
+        return None

--- a/keep/identitymanager/identitymanagerfactory.py
+++ b/keep/identitymanager/identitymanagerfactory.py
@@ -21,6 +21,7 @@ class IdentityManagerTypes(enum.Enum):
     AUTH0 = "auth0"
     KEYCLOAK = "keycloak"
     OKTA = "okta"
+    ONELOGIN = "onelogin"
     DB = "db"
     NOAUTH = "noauth"
     OAUTH2PROXY = "oauth2proxy"


### PR DESCRIPTION
- Add onelogin authentication support
- Add OneloginAuthVerifier for JWT token validation with JWKS
- Add OneloginIdentityManager with basic SSO support (management functions disabled)
- Add comprehensive Onelogin integration documentation

Closes: https://github.com/keephq/keep/issues/5228

## 📑 Description

This enables OneLogin SSO authentication with:
- JWKS-based token verification with caching
- Configurable role extraction from tokens
- Automatic key refresh on validation failure
- NextAuth.js integration for seamless authentication flow

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

