### PR TITLE
Add workflow trigger for incident called 'alert_association_changed'

### DIFF
--- a/keep-ui/entities/workflows/model/schema.ts
+++ b/keep-ui/entities/workflows/model/schema.ts
@@ -48,7 +48,7 @@ export const V2StepAlertTriggerSchema = TriggerSchemaBase.extend({
     .optional(),
 });
 
-export const IncidentEventEnum = z.enum(["created", "updated", "deleted"]);
+export const IncidentEventEnum = z.enum(["created", "updated", "deleted", "alert_association_changed"]);
 
 const IncidentTriggerValueSchema = z.object({
   events: z.array(IncidentEventEnum),

--- a/keep-ui/features/workflows/builder/ui/Editor/TriggerEditor.tsx
+++ b/keep-ui/features/workflows/builder/ui/Editor/TriggerEditor.tsx
@@ -199,7 +199,7 @@ export function TriggerEditor() {
         return (
           <>
             <Subtitle className="mt-2.5">Incident events</Subtitle>
-            {Array("created", "updated", "deleted").map((event) => (
+            {Array("created", "updated", "deleted", "alert_association_changed").map((event) => (
               <div key={`incident-${event}`} className="flex">
                 <Switch
                   id={event}

--- a/keep/api/bl/incidents_bl.py
+++ b/keep/api/bl/incidents_bl.py
@@ -21,6 +21,7 @@ from keep.api.core.db import (
     delete_incident_by_id,
     enrich_alerts_with_incidents,
     get_all_alerts_by_fingerprints,
+    get_enrichment,
     get_incident_by_id,
     get_incident_unique_fingerprint_count,
     is_all_alerts_resolved,
@@ -159,6 +160,10 @@ class IncidentBl:
                 "alert_fingerprints": alert_fingerprints,
             },
         )
+
+        incident_dto = IncidentDto.from_db_incident(incident)
+        self.send_workflow_event(incident_dto, "alert_association_changed")
+
         self.__postprocess_alerts_change(incident, alert_fingerprints)
         await self.__generate_summary(incident_id, incident)
         self.logger.info(
@@ -268,6 +273,10 @@ class IncidentBl:
         remove_alerts_to_incident_by_incident_id(
             self.tenant_id, incident_id, alert_fingerprints
         )
+
+        incident_dto = IncidentDto.from_db_incident(incident)
+        self.send_workflow_event(incident_dto, "alert_association_changed")
+
         self.__postprocess_alerts_change(incident, alert_fingerprints)
 
     def delete_incident(self, incident_id: UUID) -> None:

--- a/keep/rulesengine/rulesengine.py
+++ b/keep/rulesengine/rulesengine.py
@@ -200,6 +200,10 @@ class RulesEngine:
                                     self.tenant_id, session, incident_dto, "updated"
                                 )
 
+                            RulesEngine.send_workflow_event(
+                                self.tenant_id, session, incident_dto, "alert_association_changed"
+                            )
+
                             incidents_dto[incident.id] = incident_dto
 
                 else:

--- a/keep/topologies/topology_processor.py
+++ b/keep/topologies/topology_processor.py
@@ -377,3 +377,7 @@ class TopologyProcessor:
             # Trigger the workflow event
             RulesEngine.send_workflow_event(tenant_id, session, incident_dto, "created")
             self.logger.info(f"Created new incident for application {application.name}")
+
+            RulesEngine.send_workflow_event(
+                tenant_id, session, incident_dto, "alert_association_changed"
+            )

--- a/tests/test_workflowmanager.py
+++ b/tests/test_workflowmanager.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import uuid
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 import pytest
@@ -6,6 +8,9 @@ from fastapi import HTTPException
 
 from keep.api.routes.workflows import get_event_from_body
 from keep.parser.parser import Parser
+from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
+from keep.api.models.incident import IncidentDto
+from keep.api.models.db.incident import IncidentSeverity, IncidentStatus
 
 # Assuming WorkflowParser is the class containing the get_workflow_from_dict method
 from keep.workflowmanager.workflow import Workflow
@@ -182,3 +187,102 @@ def test_handle_manual_event_workflow_test_run():
         )
         assert workflow_scheduler.workflows_to_run[0]["test_run"] == True
         assert workflow_scheduler.workflows_to_run[0]["workflow"] == mock_workflow
+
+def test_insert_incident_alert_association_changed_adds_linked_alerts():
+    """Test that linked_alerts key is present when workflow trigger is alert_association_changed."""
+
+    # Create mock alerts that would be associated with the incident
+    mock_alert_1 = AlertDto(
+        id="alert-1",
+        name="Test Alert 1",
+        status=AlertStatus.FIRING,
+        severity=AlertSeverity.HIGH,
+        lastReceived="2025-01-30T10:00:00Z",
+        description="Test alert 1 description\nThis is a multiline description\nWith multiple lines of content\nTo test the split behavior"
+    )
+
+    mock_alert_2 = AlertDto(
+        id="alert-2",
+        name="Test Alert 2",
+        status=AlertStatus.RESOLVED,
+        severity=AlertSeverity.CRITICAL,
+        lastReceived="2025-01-30T11:00:00Z",
+        description="Test alert 2 description"
+    )
+
+    # Create incident DTO with mock alerts
+    incident_dto = IncidentDto(
+        id=uuid.uuid4(),
+        user_generated_name="Test Incident",
+        alerts_count=2,
+        alert_sources=["prometheus", "grafana"],
+        services=["web-service"],
+        severity=IncidentSeverity.HIGH,
+        status=IncidentStatus.FIRING,
+        is_predicted=False,
+        is_candidate=False,
+        creation_time=datetime.utcnow()
+    )
+
+    # Mock the alerts property to return our test alerts
+    incident_dto._alerts = [mock_alert_1, mock_alert_2]
+
+    # Create a mock workflow with alert_association_changed trigger
+    mock_workflow = Mock(spec=Workflow)
+    mock_workflow.workflow_triggers = [
+        {
+            "type": "incident",
+            "events": ["alert_association_changed"]
+        }
+    ]
+
+    # Create mock workflow model
+    mock_workflow_model = Mock()
+    mock_workflow_model.id = "test-workflow-id"
+    mock_workflow_model.name = "test-workflow"
+    mock_workflow_model.tenant_id = "test-tenant"
+    mock_workflow_model.is_disabled = False
+
+    # Create WorkflowManager and mock dependencies
+    workflow_manager = WorkflowManager()
+
+    with patch.object(workflow_manager.workflow_store, 'get_all_workflows') as mock_get_workflows, \
+         patch.object(workflow_manager, '_get_workflow_from_store') as mock_get_workflow, \
+         patch('keep.workflowmanager.workflowmanager.get_enrichment') as mock_get_enrichment:
+
+        # Set up mocks
+        mock_get_workflows.return_value = [mock_workflow_model]
+        mock_get_workflow.return_value = mock_workflow
+        mock_get_enrichment.return_value = None
+
+        # Mock the scheduler
+        workflow_manager.scheduler = Mock()
+        workflow_manager.scheduler.lock = Mock()
+        workflow_manager.scheduler.lock.__enter__ = Mock(return_value=None)
+        workflow_manager.scheduler.lock.__exit__ = Mock(return_value=None)
+        workflow_manager.scheduler.workflows_to_run = []
+
+        # Call insert_incident with alert_association_changed trigger
+        workflow_manager.insert_incident("test-tenant", incident_dto, "alert_association_changed")
+
+        # Verify workflow was added to run
+        assert len(workflow_manager.scheduler.workflows_to_run) == 1
+
+        # Get the workflow execution event
+        workflow_execution = workflow_manager.scheduler.workflows_to_run[0]
+        executed_incident = workflow_execution["event"]
+
+        # Verify that linked_alerts attribute was added to the incident
+        assert hasattr(executed_incident, 'linked_alerts'), "linked_alerts attribute should be present"
+
+        # Verify the content of linked_alerts
+        linked_alerts = executed_incident.linked_alerts
+        assert isinstance(linked_alerts, list), "linked_alerts should be a list"
+        assert len(linked_alerts) == 2, "Should have 2 linked alerts"
+
+        # Verify the format of linked alerts entries
+        expected_alert_1 = "Firing 2025-01-30T10:00:00.000Z [high] Test alert 1 description"
+        expected_alert_2 = "Resolved 2025-01-30T11:00:00.000Z [critical] Test alert 2 description"
+
+        assert expected_alert_1 in linked_alerts, f"Expected '{expected_alert_1}' in linked_alerts"
+        assert expected_alert_2 in linked_alerts, f"Expected '{expected_alert_2}' in linked_alerts"


### PR DESCRIPTION
Closes #5253

## 📑 Description
This PR adds a new workflow trigger event for incident called "alert_association_changed". This helps user configure workflows that trigger whenever incident alert association changes.

Following events cause the incident alert association to change:
1. Alert addition/linkage to an incident
2. Alert unlinking from an incident.

Whenever this event takes place, an additional key called "linked_alerts" is added to the incident object that's passed to the workflow. The linked_alerts key is basically a list of alert strings currently linked to the incident sorted in descending order of timestamp. Each alert string present in the list is of the following form:
{status} {lastReceived} [{severity}] {description}
e.g.
Firing 2025-01-30T10:00:00.000Z [high] Test alert 1 description

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
