### PR TITLE
feat: maint windows

### DIFF
--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -298,6 +298,19 @@ These endpoints are rate-limited according to the `KEEP_LIMIT_CONCURRENCY` setti
 
 </Note>
 
+
+### Maintenance Windows
+
+<Info>
+  The strategy enables the ability to manage how the alerts are handled
+  in case of a match with the Maintenance Windows Rules.
+</Info>
+
+|             Env var              |                      Purpose                |        Required         | Default Value |               Valid options                       |
+| :------------------------------: | :-----------------------------------------: | :---------------------: | :-----------: | :-----------------------------------------------: |
+| **MAINTENANCE_WINDOW_STRATEGY**  |          Choose the strategy                |           No            |    "default"  |      "default" or "recover_previous_status"       |
+| **WATCHER_LAPSED_TIME**          | Time in seconds to execute the alert review |           No            |       60      |             Valid positive integer                |
+
 ## Frontend Environment Variables
 
 <Info>

--- a/docs/overview/maintenance-windows.mdx
+++ b/docs/overview/maintenance-windows.mdx
@@ -87,7 +87,7 @@ The following actions will therefore be taken with a new alert:
 Every WATCHER_LAPSED_TIME seconds, the watcher will check whether there is any active Maintenance Window for every alert with a Maintenance status.
 If so, the following actions will be taken:
 - The alert will swap its status, and previous status.
-- Workflows, Incidents handling, Pusher and Presents notifications will be launched in the same way as a new alert.
+- Workflows, Incidents handling, Pusher and Presets notifications will be launched in the same way as a new alert.
 
 #### 2.1 What is an expired Maintenance Window?
 

--- a/docs/overview/maintenance-windows.mdx
+++ b/docs/overview/maintenance-windows.mdx
@@ -70,7 +70,7 @@ In order to handle the alerts during Maintenance Windows, Keep provides some Str
 
 ### 1. Default
 
-The default behaviour of Maintenance Windows is to **Supressed** alerts that match the defined conditions.
+The default behaviour of Maintenance Windows is to **Suppressed** alerts that match the defined conditions.
 
 ### 2. Recover status
 

--- a/docs/overview/maintenance-windows.mdx
+++ b/docs/overview/maintenance-windows.mdx
@@ -39,6 +39,7 @@ In Keep, certain alert statuses are automatically ignored by Maintenance Window 
 ### Why Are Some Statuses Ignored?
 
     •	RESOLVED Alerts: These alerts indicate that an issue has been resolved. By allowing these alerts to bypass Maintenance Window rules, Keep ensures that any active incidents related to the alert can be properly closed, maintaining the integrity of the alert lifecycle.
+    
     •	ACKNOWLEDGED Alerts: These alerts have been acknowledged by an operator, signaling that they are being addressed. Ignoring these alerts in Maintenance Windows ensures that operators can track the progress of incidents and take necessary actions without interference.
 
 By excluding these statuses from Maintenance Window suppression, Keep allows for the continuous and accurate management of alerts, even during Maintenance Window periods, ensuring that resolution processes are not disrupted.
@@ -61,3 +62,40 @@ To create a Maintenance Window rule:
 - **Plan Maintenance Windows in Advance**: Schedule Maintenance Window periods in advance for known maintenance windows to prevent unnecessary alerts.
 - **Use Specific Conditions**: Define precise CEL queries to ensure only the intended alerts are suppressed.
 - **Review and Update Maintenance Windows**: Regularly review active Maintenance Window rules to ensure they are still relevant and adjust them as necessary.
+
+
+## Strategies
+
+In order to handle the alerts during Maintenance Windows, Keep provides some Strategies to handle how these alerts are treated:
+
+### 1. Default
+
+The default behaviour of Maintenance Windows is to **Supressed** alerts that match the defined conditions.
+
+### 2. Recover status
+
+This strategy relies on the following premise:
+<Tip>
+   An alert received inside the Maintenance Window must be inhibited and once the Maintenance Window is over, the alert must recover its previous flow.
+</Tip>
+
+The following actions will therefore be taken with a new alert:
+- When an alert is received, it will be checked against the Maintenance Window rules.
+- If the alert matches any Maintenance Window rule, its status will be set to **Maintenance**.
+- Workflows and Incidents handling are skipped.
+
+Every WATCHER_LAPSED_TIME seconds, the watcher will check whether there is any active Maintenance Window for every alert with a Maintenance status.
+If so, the following actions will be taken:
+- The alert will swap its status, and previous status.
+- Workflows, Incidents handling, Pusher and Presents notifications will be launched in the same way as a new alert.
+
+#### 2.1 What is an expired Maintenance Window?
+
+For a maintenance window to be considered expired, the following conditions must be met:
+- The **End Time** must be earlier than the current time.
+- The **Enabled** flag must be set to **False**.
+
+#### 2.2 What are the specific conditions to use the Recover Status Strategy?
+- Set **MAINTENANCE_WINDOW_STRATEGY** environment variable to **recover_previous_status**.
+- "Alerts will show in suppressed status" option must be set to **True** in the Maintenance Window rule configuration.
+- **Enabled** flag must be set to **True** in the Maintenance Window rule configuration.

--- a/keep/api/arq_worker.py
+++ b/keep/api/arq_worker.py
@@ -157,7 +157,7 @@ class WorkerSettings:
     redis_settings = get_redis_settings()
     timeout = 30
     functions: list = FUNCTIONS
-    cron_jobs: list = [cron("keep.api.tasks.process_watcher_task.async_process_watcher", second=WATCHER_LAPSED_TIME-1)]
+    cron_jobs: list = [cron("keep.api.tasks.process_watcher_task.async_process_watcher", second=max(0, WATCHER_LAPSED_TIME-1))]
     queue_name: str
     health_check_interval: int = 10
     health_check_key: str

--- a/keep/api/arq_worker.py
+++ b/keep/api/arq_worker.py
@@ -6,7 +6,7 @@ from typing import Optional
 from uuid import uuid4
 
 import redis
-from arq import Worker
+from arq import Worker, cron
 from arq.worker import create_worker
 from dotenv import find_dotenv, load_dotenv
 from pydantic.utils import import_string
@@ -18,6 +18,7 @@ from keep.api.consts import (
     KEEP_ARQ_TASK_POOL,
     KEEP_ARQ_TASK_POOL_ALL,
     KEEP_ARQ_TASK_POOL_BASIC_PROCESSING,
+    WATCHER_LAPSED_TIME,
 )
 from keep.api.core.config import config
 from keep.api.redis_settings import get_redis_settings
@@ -120,6 +121,7 @@ async def process_event_in_worker(
 FUNCTIONS.append(process_event_in_worker)
 
 
+
 async def startup(ctx):
     """ARQ worker startup callback"""
     EVENT_WORKERS = int(config("KEEP_EVENT_WORKERS", default=5, cast=int))
@@ -155,6 +157,7 @@ class WorkerSettings:
     redis_settings = get_redis_settings()
     timeout = 30
     functions: list = FUNCTIONS
+    cron_jobs: list = [cron("keep.api.tasks.process_watcher_task.async_process_watcher", second=WATCHER_LAPSED_TIME-1)]
     queue_name: str
     health_check_interval: int = 10
     health_check_key: str

--- a/keep/api/bl/maintenance_windows_bl.py
+++ b/keep/api/bl/maintenance_windows_bl.py
@@ -5,14 +5,20 @@ import logging
 import celpy
 from sqlmodel import Session
 
-from keep.api.consts import MAINTENANCE_WINDOW_ALERT_STRATEGY
-from keep.api.core.db import get_session_sync
+from keep.api.consts import KEEP_CORRELATION_ENABLED, MAINTENANCE_WINDOW_ALERT_STRATEGY
+from opentelemetry import trace
+from keep.api.core.db import add_audit, get_alerts_by_status, get_all_presets_dtos, get_maintenance_windows_started, get_session_sync, recover_prev_alert_status
+from keep.api.core.dependencies import get_pusher_client
 from keep.api.models.action_type import ActionType
 from keep.api.models.alert import AlertDto, AlertStatus
 from keep.api.models.db.alert import Alert, AlertAudit
 from keep.api.models.db.maintenance_window import MaintenanceWindowRule
+from keep.api.tasks.notification_cache import get_notification_cache
 from keep.api.utils.cel_utils import preprocess_cel_expression
+from keep.rulesengine.rulesengine import RulesEngine
+from keep.workflowmanager.workflowmanager import WorkflowManager
 
+tracer = trace.get_tracer(__name__)
 
 class MaintenanceWindowsBl:
 
@@ -133,3 +139,150 @@ class MaintenanceWindowsBl:
                 extra={**logger_extra_info, "maintenance_rule_id": maintenance_window.id},
             )
             return False
+
+    @staticmethod
+    def recover_strategy(
+        logger: logging.Logger,
+        session: Session | None = None,
+    ):
+        """
+
+        This strategy will try to recover the previous status of the alerts that were in maintenance windows,
+        once the maintenance windows are over, i.e they were deleted.
+
+        For recovering the previous status, the maintenance windows shouldn't exist and the alerts
+        should accomplish the following:
+
+            - The alert is in [inhibited_status] status.
+            - The alert timestamp is before the maintenance window end time.
+            - The alert timestamp is after the maintenance window start time.
+            - The CEL expression should match with the both alert and maintenance window.
+
+        Once the status is recovered, Workflows, Correlations/Incidents and Presets will be launched, in the
+        same way that a new alert.
+
+
+        Args:
+            logger (logging.Logger): The logger to use.
+            session (Session | None): The SQLAlchemy session to use. If None, a new session will be created.
+        """
+        logger.info("Starting recover strategy for maintenance windows review.")
+        env = celpy.Environment()
+        windows = get_maintenance_windows_started(session)
+        alerts_in_maint = get_alerts_by_status(AlertStatus.MAINTENANCE, session)
+        for alert in alerts_in_maint:
+            active = False
+            for window in windows:
+                w_start = window.start_time
+                w_end = window.end_time
+                is_enable = window.enabled
+                if window.tenant_id != alert.tenant_id:
+                    continue
+                # Check active windows
+                if w_start < alert.timestamp and alert.timestamp < w_end and is_enable:
+                    logger.info("Checking alert %s in maintenance window %s", alert.id, window.id)
+                    is_in_cel = MaintenanceWindowsBl.evaluate_cel(
+                                window, alert, env, logger, {"tenant_id": alert.tenant_id, "alert_id": alert.id}
+                                )
+                    if is_in_cel:
+                        active = True
+                        logger.info("Alert %s is blocked due to the maintenance window: %s.", alert.id, window.id)
+                        break
+            if not active:
+                recover_prev_alert_status(alert, session)
+                add_audit(
+                    tenant_id=alert.tenant_id,
+                    fingerprint=alert.fingerprint,
+                    user_id="system",
+                    action=ActionType.MAINTENANCE_EXPIRED,
+                    description=(
+                        f"Alert {alert.id} has recover its previous status, "
+                        f"from {alert.event.get('status')} to {alert.event.get('previous_status')}"
+                    ),
+                )
+
+                alert_dto = AlertDto(**alert.event)
+                with tracer.start_as_current_span("mw_recover_strategy_push_to_workflows"):
+                    try:
+                        # Now run any workflow that should run based on this alert
+                        # TODO: this should publish event
+                        workflow_manager = WorkflowManager.get_instance()
+                        # insert the events to the workflow manager process queue
+                        logger.info("Adding event to the workflow manager queue")
+                        workflow_manager.insert_events(alert.tenant_id, [alert_dto])
+                        logger.info("Added event to the workflow manager queue")
+                    except Exception:
+                        logger.exception(
+                            "Failed to run workflows based on alerts",
+                            extra={
+                                "provider_type": alert_dto.providerType,
+                                "provider_id": alert_dto.providerId,
+                                "tenant_id": alert.tenant_id,
+                            },
+                        )
+
+                with tracer.start_as_current_span("mw_recover_strategy_run_rules_engine"):
+                    # Now we need to run the rules engine
+                    if KEEP_CORRELATION_ENABLED:
+                        incidents = []
+                        try:
+                            rules_engine = RulesEngine(tenant_id=alert.tenant_id)
+                            # handle incidents, also handle workflow execution as
+                            incidents = rules_engine.run_rules(
+                                [alert_dto], session=session
+                            )
+                        except Exception:
+                            logger.exception(
+                                "Failed to run rules engine",
+                                extra={
+                                    "provider_type": alert_dto.providerType,
+                                    "provider_id": alert_dto.providerId,
+                                    "tenant_id": alert.tenant_id,
+                                },
+                            )
+                        pusher_cache = get_notification_cache()
+                        if incidents and pusher_cache.should_notify(alert.tenant_id, "incident-change"):
+                            pusher_client = get_pusher_client()
+                            try:
+                                pusher_client.trigger(
+                                    f"private-{alert.tenant_id}",
+                                    "incident-change",
+                                    {},
+                                )
+                            except Exception:
+                                logger.exception("Failed to tell the client to pull incidents")
+
+                    try:
+                        presets = get_all_presets_dtos(alert.tenant_id)
+                        rules_engine = RulesEngine(tenant_id=alert.tenant_id)
+                        presets_do_update = []
+                        for preset_dto in presets:
+                            # filter the alerts based on the search query
+                            filtered_alerts = rules_engine.filter_alerts(
+                                [alert_dto], preset_dto.cel_query
+                            )
+                            # if not related alerts, no need to update
+                            if not filtered_alerts:
+                                continue
+                            presets_do_update.append(preset_dto)
+                        if pusher_cache.should_notify(alert.tenant_id, "poll-presets"):
+                            try:
+                                pusher_client.trigger(
+                                    f"private-{alert.tenant_id}",
+                                    "poll-presets",
+                                    json.dumps(
+                                        [p.name.lower() for p in presets_do_update], default=str
+                                    ),
+                                )
+                            except Exception:
+                                logger.exception("Failed to send presets via pusher")
+                    except Exception:
+                        logger.exception(
+                            "Failed to send presets via pusher",
+                            extra={
+                                "provider_type": alert_dto.providerType,
+                                "provider_id": alert_dto.providerId,
+                                "tenant_id": alert.tenant_id,
+                            },
+                        )
+        logger.info("Finished recover strategy for maintenance windows review.")

--- a/keep/api/bl/maintenance_windows_bl.py
+++ b/keep/api/bl/maintenance_windows_bl.py
@@ -7,7 +7,14 @@ from sqlmodel import Session
 
 from keep.api.consts import KEEP_CORRELATION_ENABLED, MAINTENANCE_WINDOW_ALERT_STRATEGY
 from opentelemetry import trace
-from keep.api.core.db import add_audit, get_alerts_by_status, get_all_presets_dtos, get_maintenance_windows_started, get_session, get_session_sync, recover_prev_alert_status
+from keep.api.core.db import (
+    add_audit,
+    get_alerts_by_status,
+    get_all_presets_dtos,
+    get_maintenance_windows_started,
+    get_session_sync,
+    recover_prev_alert_status,
+)
 from keep.api.core.dependencies import get_pusher_client
 from keep.api.models.action_type import ActionType
 from keep.api.models.alert import AlertDto, AlertStatus

--- a/keep/api/consts.py
+++ b/keep/api/consts.py
@@ -51,3 +51,6 @@ else:
     KEEP_ARQ_TASK_POOL = os.environ.get("KEEP_ARQ_TASK_POOL", None)
 
 OPENAI_MODEL_NAME = os.environ.get("OPENAI_MODEL_NAME", "gpt-4o-2024-08-06")
+
+
+KEEP_CORRELATION_ENABLED = os.environ.get("KEEP_CORRELATION_ENABLED", "true") == "true"

--- a/keep/api/consts.py
+++ b/keep/api/consts.py
@@ -42,6 +42,7 @@ KEEP_ARQ_TASK_POOL_BASIC_PROCESSING = "basic_processing"  # Everything except AI
 # Define queues for different task types
 KEEP_ARQ_QUEUE_BASIC = "basic_processing"
 KEEP_ARQ_QUEUE_WORKFLOWS = "workflows"
+KEEP_ARQ_QUEUE_MAINTENANCE = "maintenance"
 
 REDIS = os.environ.get("REDIS", "false") == "true"
 

--- a/keep/api/consts.py
+++ b/keep/api/consts.py
@@ -28,7 +28,10 @@ STATIC_PRESETS = {
         tags=[],
     )
 }
-
+MAINTENANCE_WINDOW_ALERT_STRATEGY = os.environ.get(
+    "KEEP_MAINTENANCE_WINDOW_ALERT_STRATEGY", "default"
+)  # recover_previous_status or default
+WATCHER_LAPSED_TIME = int(os.environ.get("KEEP_WATCHER_LAPSED_TIME", 60))  # in seconds
 ###
 # Set ARQ_TASK_POOL_TO_EXECUTE to "none", "all", "basic_processing" or "ai"
 # to split the tasks between the workers.

--- a/keep/api/consts.py
+++ b/keep/api/consts.py
@@ -53,5 +53,4 @@ else:
 
 OPENAI_MODEL_NAME = os.environ.get("OPENAI_MODEL_NAME", "gpt-4o-2024-08-06")
 
-
 KEEP_CORRELATION_ENABLED = os.environ.get("KEEP_CORRELATION_ENABLED", "true") == "true"

--- a/keep/api/consts.py
+++ b/keep/api/consts.py
@@ -29,7 +29,7 @@ STATIC_PRESETS = {
     )
 }
 MAINTENANCE_WINDOW_ALERT_STRATEGY = os.environ.get(
-    "KEEP_MAINTENANCE_WINDOW_ALERT_STRATEGY", "default"
+    "MAINTENANCE_WINDOW_STRATEGY", "default"
 )  # recover_previous_status or default
 WATCHER_LAPSED_TIME = int(os.environ.get("KEEP_WATCHER_LAPSED_TIME", 60))  # in seconds
 ###

--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -5941,17 +5941,18 @@ def recover_prev_alert_status(alert: Alert, session: Optional[Session] = None):
     It'll restore the previous status of the alert.
     """
     with existed_or_new_session(session) as session:
-        event_updated = copy.deepcopy(alert.event)
         try:
-            event_updated["previous_status"] = alert.event.get("status")
-            event_updated["status"] = alert.event.get("previous_status")
+            status = alert.event.get("status")
+            prev_status = alert.event.get("previous_status")
+            alert.event["status"] = prev_status
+            alert.event["previous_status"] = status
         except KeyError:
             logger.warning(f"Alert {alert.id} does not have previous status.")
         query = (
             update(Alert)
             .where(Alert.id == alert.id)
             .values(
-                event = event_updated
+                event = alert.event
             )
         )
         session.exec(query)

--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -9,7 +9,6 @@ import json
 import logging
 import random
 import uuid
-import copy
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone

--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -9,11 +9,12 @@ import json
 import logging
 import random
 import uuid
+import copy
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from functools import wraps
-from typing import Any, Callable, Dict, Iterator, List, Tuple, Type, Union
+from typing import Any, Callable, Dict, Iterator, List, Tuple, Type, Union, Optional
 from uuid import UUID, uuid4
 
 from dateutil.parser import parse
@@ -2013,6 +2014,18 @@ def get_previous_alert_by_fingerprint(tenant_id: str, fingerprint: str) -> Alert
     else:
         # no previous alert
         return None
+
+
+def get_alerts_by_status(
+    status: AlertStatus, session: Optional[Session] = None
+) -> List[Alert]:
+    with existed_or_new_session(session) as session:
+        status_field = get_json_extract_field(session, Alert.event, "status")
+        query = (
+            select(Alert).
+            where(status_field == status.value)
+        )
+        return session.exec(query).all()
 
 
 def get_api_key(api_key: str) -> TenantApiKey:
@@ -5911,3 +5924,35 @@ def create_single_tenant_for_e2e(tenant_id: str) -> None:
         except Exception:
             logger.exception("Failed to create single tenant")
             pass
+
+def get_maintenance_windows_started(session: Optional[Session] = None) -> List[MaintenanceWindowRule]:
+    """
+    It will return all windows started, i.e start_time < currentTime
+    """
+    with existed_or_new_session(session) as session:
+        query = (
+            select(MaintenanceWindowRule)
+            .where(MaintenanceWindowRule.start_time <= datetime.now(tz=timezone.utc))
+        )
+        return session.exec(query).all()
+
+def recover_prev_alert_status(alert: Alert, session: Optional[Session] = None):
+    """
+    It'll restore the previous status of the alert.
+    """
+    with existed_or_new_session(session) as session:
+        event_updated = copy.deepcopy(alert.event)
+        try:
+            event_updated["previous_status"] = alert.event.get("status")
+            event_updated["status"] = alert.event.get("previous_status")
+        except KeyError:
+            logger.warning(f"Alert {alert.id} does not have previous status.")
+        query = (
+            update(Alert)
+            .where(Alert.id == alert.id)
+            .values(
+                event = event_updated
+            )
+        )
+        session.exec(query)
+        session.commit()

--- a/keep/api/models/action_type.py
+++ b/keep/api/models/action_type.py
@@ -36,6 +36,7 @@ class ActionType(enum.Enum):
     COMMENT = "a comment was added to the alert"
     UNCOMMENT = "a comment was removed from the alert"
     MAINTENANCE = "Alert is in maintenance window"
+    MAINTENANCE_EXPIRED = "Alert has been removed from maintenance window"
     INCIDENT_COMMENT = "A comment was added to the incident"
     INCIDENT_ENRICH = "Incident enriched"
     INCIDENT_STATUS_CHANGE = "Incident status changed"

--- a/keep/api/models/alert.py
+++ b/keep/api/models/alert.py
@@ -52,6 +52,8 @@ class AlertStatus(Enum):
     SUPPRESSED = "suppressed"
     # No Data
     PENDING = "pending"
+    #Affected by Maintenance Windows
+    MAINTENANCE = "maintenance"
 
 
 class DismissAlertRequest(BaseModel):

--- a/keep/api/tasks/process_watcher_task.py
+++ b/keep/api/tasks/process_watcher_task.py
@@ -40,6 +40,6 @@ async def async_process_watcher(*args):
                     logger.info("Sleeping for 60 seconds before next run.")
                     complete_time = datetime.datetime.now()
                     await asyncio.sleep(WATCHER_LAPSED_TIME - (complete_time - init_time).total_seconds())
-                    logger.info(f"Unlock process completed. With Sleep {WATCHER_LAPSED_TIME - (complete_time - init_time).total_seconds()}")
+                    logger.info("Unlock process completed.")
             except Timeout:
                 logger.info("Watcher process is already running, skipping this run.")

--- a/keep/api/tasks/process_watcher_task.py
+++ b/keep/api/tasks/process_watcher_task.py
@@ -39,7 +39,7 @@ async def async_process_watcher(*args):
                     resp = await loop.run_in_executor(None, MaintenanceWindowsBl.recover_strategy, logger)
                     logger.info("Sleeping for 60 seconds before next run.")
                     complete_time = datetime.datetime.now()
-                    await asyncio.sleep(WATCHER_LAPSED_TIME - (complete_time - init_time).total_seconds())
+                    await asyncio.sleep(max(0, WATCHER_LAPSED_TIME - (complete_time - init_time).total_seconds()))
                     logger.info("Unlock process completed.")
             except Timeout:
                 logger.info("Watcher process is already running, skipping this run.")

--- a/keep/api/tasks/process_watcher_task.py
+++ b/keep/api/tasks/process_watcher_task.py
@@ -1,0 +1,45 @@
+import asyncio
+import datetime
+import logging
+from filelock import FileLock, Timeout
+import redis
+from keep.api.bl.maintenance_windows_bl import MaintenanceWindowsBl
+from keep.api.consts import REDIS, WATCHER_LAPSED_TIME
+
+logger = logging.getLogger(__name__)
+
+
+async def async_process_watcher(*args):
+    if REDIS:
+        ctx = args[0]
+        redis_instance: redis.Redis = ctx.get("redis")
+        lock_key = "lock:watcher:process"
+        is_exec_stopped = await redis_instance.set(lock_key, "1", ex=WATCHER_LAPSED_TIME+10, nx=True)
+        if not is_exec_stopped:
+            logger.info("Watcher process is already running, skipping this run.")
+            return
+        logger.info("Watcher process started, acquiring lock.")
+        try:
+            loop = asyncio.get_running_loop()
+            resp = await loop.run_in_executor(ctx.get("pool"), MaintenanceWindowsBl.recover_strategy, logger)
+        except Exception as e:
+            logger.error("Error in run_in_executor: %s", e, exc_info=True)
+            raise
+        finally:
+            await redis_instance.delete(lock_key)
+            logger.info("Watcher process completed and lock released.")
+        return resp
+    else:
+        while True:
+            init_time = datetime.datetime.now()
+            try:
+                with FileLock("/tmp/watcher_process.lock", timeout=WATCHER_LAPSED_TIME//2):
+                    logger.info("Watcher process started, acquiring lock.")
+                    loop = asyncio.get_running_loop()
+                    resp = await loop.run_in_executor(None, MaintenanceWindowsBl.recover_strategy, logger)
+                    logger.info("Sleeping for 60 seconds before next run.")
+                    complete_time = datetime.datetime.now()
+                    await asyncio.sleep(WATCHER_LAPSED_TIME - (complete_time - init_time).total_seconds())
+                    logger.info(f"Unlock process completed. With Sleep {WATCHER_LAPSED_TIME - (complete_time - init_time).total_seconds()}")
+            except Timeout:
+                logger.info("Watcher process is already running, skipping this run.")

--- a/tests/test_maintenance_windows_bl.py
+++ b/tests/test_maintenance_windows_bl.py
@@ -1,11 +1,20 @@
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock
+import importlib
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
-
+import keep.api.consts
 from keep.api.bl.maintenance_windows_bl import MaintenanceWindowsBl
+from keep.api.core.dependencies import SINGLE_TENANT_UUID
 from keep.api.models.alert import AlertDto, AlertStatus
+from keep.api.models.db.alert import Alert
 from keep.api.models.db.maintenance_window import MaintenanceWindowRule
+from keep.api.models.db.workflow import Workflow
+from tests.fixtures.workflow_manager import (
+    workflow_manager,
+    wait_for_workflow_execution,
+)
 
 
 @pytest.fixture
@@ -56,6 +65,20 @@ def active_maintenance_window_rule_with_suppression_on():
 
 
 @pytest.fixture
+def expired_maintenance_window_rule_with_suppression_on():
+    return MaintenanceWindowRule(
+        id=1,
+        name="Expired maintenance_window",
+        tenant_id="test-tenant",
+        cel_query='source == "test-source"',
+        start_time=datetime.utcnow() - timedelta(hours=5),
+        end_time=datetime.utcnow() - timedelta(hours=1),
+        enabled=False,
+        suppress=True,
+    )
+
+
+@pytest.fixture
 def expired_maintenance_window_rule():
     return MaintenanceWindowRule(
         id=2,
@@ -77,6 +100,23 @@ def alert_dto():
         status="firing",
         severity="critical",
         lastReceived="2021-08-01T00:00:00Z",
+    )
+
+@pytest.fixture
+def alert_maint():
+    return Alert(
+        id=uuid4(),
+        tenant_id="test-tenant",
+        fingerprint="test-fingerprint",
+        provider_id="test-provider",
+        provider_type="test-provider-type",
+        event={
+            "name": "Test Alert",
+            "status": AlertStatus.MAINTENANCE.value,
+            "previous_status": AlertStatus.FIRING.value,
+            "source": ["test-source"],
+        },
+        alert_hash="test-alert-hash",
     )
 
 
@@ -236,3 +276,181 @@ def test_alert_not_ignored_due_to_custom_status(
     alert_dto.status = AlertStatus.RESOLVED.value
     result = maintenance_window_bl.check_if_alert_in_maintenance_windows(alert_dto)
     assert result is True
+
+
+def test_strategy_restore_update_status(
+    mock_session, active_maintenance_window_rule_with_suppression_on, alert_dto, monkeypatch
+):
+    """
+    Feature: Strategy - recover previous status
+    Scenario: Alert enters in maintenance window with suppression
+    """
+    # GIVEN The strategy is recover_previous_status
+    monkeypatch.setenv("MAINTENANCE_WINDOW_STRATEGY", "recover_previous_status")
+    importlib.reload(keep.api.consts)
+    importlib.reload(keep.api.bl.maintenance_windows_bl)
+    # AND there is a maintenance window rule with suppression on active
+    mock_session.query.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [
+        active_maintenance_window_rule_with_suppression_on
+    ]
+
+    maintenance_window_bl = MaintenanceWindowsBl(
+        tenant_id="test-tenant", session=mock_session
+    )
+
+    # WHEN it checks if the alert is in maintenance windows
+    result = maintenance_window_bl.check_if_alert_in_maintenance_windows(alert_dto)
+
+    # THEN the result should be False
+    assert result is False
+    # AND the previous status should be set old alert status
+    assert alert_dto.previous_status == AlertStatus.FIRING.value
+    # AND the current status should be set to MAINTENANCE
+    assert alert_dto.status == AlertStatus.MAINTENANCE.value
+
+def test_strategy_clean_status(
+    mock_session, alert_maint, monkeypatch, expired_maintenance_window_rule_with_suppression_on
+):
+    """
+    Feature: Strategy - recover previous status
+    Scenario: Alert recovers previous status after maintenance window ends. Whitout any window active.
+    """
+    # GIVEN The strategy is recover_previous_status
+    monkeypatch.setenv("MAINTENANCE_WINDOW_STRATEGY", "recover_previous_status")
+    importlib.reload(keep.api.consts)
+    importlib.reload(keep.api.bl.maintenance_windows_bl)
+    # AND there is a maintenance window expired.
+    retrieve_windows_session = MagicMock()
+    retrieve_windows_session.exec.return_value.all.return_value = [
+        expired_maintenance_window_rule_with_suppression_on
+    ]
+    # AND there is an alert which was received inside a maintenance window
+    retrieve_alerts_session = MagicMock()
+    retrieve_alerts_session.exec.return_value.all.return_value = [alert_maint]
+
+    recover_status_session = MagicMock()
+    recover_status_session.exec = MagicMock()
+    recover_status_session.commit = MagicMock()
+
+    # WHEN recover its previous status
+    mock_session.__enter__.side_effect = [retrieve_windows_session, retrieve_alerts_session, recover_status_session, MagicMock()]
+    with patch("keep.api.core.db.existed_or_new_session", return_value=mock_session):
+        MaintenanceWindowsBl.recover_strategy(logger=MagicMock(), session=mock_session)
+
+    # THEN the new status will be the previous status, and the previous status will be the old status
+    _, new_status, new_previous_status, _ = list(recover_status_session.exec.call_args[0][0]._values.values())[0].value.values()
+    assert new_status == alert_maint.event["previous_status"]
+    assert new_previous_status == alert_maint.event["status"]
+
+
+def test_strategy_alert_block_by_window(
+    mock_session, active_maintenance_window_rule_with_suppression_on, alert_maint, monkeypatch
+):
+    """
+    Feature: Strategy - recover previous status
+    Scenario: Alert is blocked (continue with the same status) by maintenance window
+    """
+    # GIVEN The strategy is block_alert_by_maintenance_window
+    monkeypatch.setenv("MAINTENANCE_WINDOW_STRATEGY", "recover_previous_status")
+    importlib.reload(keep.api.consts)
+    importlib.reload(keep.api.bl.maintenance_windows_bl)
+    # AND there is a maintenance window active
+    retrieve_windows_session = MagicMock()
+    retrieve_windows_session.exec.return_value.all.return_value = [active_maintenance_window_rule_with_suppression_on]
+    # AND there is an alert which was received inside a maintenance window
+    retrieve_alerts_session = MagicMock()
+    retrieve_alerts_session.exec.return_value.all.return_value = [alert_maint]
+
+    recover_status_session = MagicMock()
+    recover_status_session.exec = MagicMock()
+    recover_status_session.commit = MagicMock()
+
+    loggerMag = MagicMock()
+    # WHEN the conditions match to recover the initial alert status
+    mock_session.__enter__.side_effect = [retrieve_windows_session, retrieve_alerts_session, recover_status_session, MagicMock()]
+    with patch("keep.api.core.db.existed_or_new_session", return_value=mock_session):
+        MaintenanceWindowsBl.recover_strategy(logger=loggerMag, session=mock_session)
+
+    # THEN the update status method will not be called
+    assert not recover_status_session.exec.called
+    # AND logger alert will rise an info about the alert blocked by maintenance window
+    loggerMag.info.assert_any_call(
+            "Alert %s is blocked due to the maintenance window: %s.", alert_maint.id,
+            active_maintenance_window_rule_with_suppression_on.id
+        )
+
+def test_strategy_alert_launch_workflow(
+    mock_session, expired_maintenance_window_rule_with_suppression_on, alert_maint, monkeypatch, workflow_manager, db_session
+):
+    """
+    Feature: Strategy - recover previous status
+    Scenario: Having the Maintenance Window expired, the alert in its previous status, workflows should be launched.
+    """
+    # GIVEN The strategy is block_alert_by_maintenance_window
+    monkeypatch.setenv("MAINTENANCE_WINDOW_STRATEGY", "recover_previous_status")
+    importlib.reload(keep.api.consts)
+    importlib.reload(keep.api.bl.maintenance_windows_bl)
+    # AND a workflow matchs the alert attributes
+    workflow_definition = """workflow:
+                                id: 1
+                                name: workflow_strategy_mw_test
+                                description: "Description field"
+                                disabled: false
+                                triggers:
+                                - type: alert
+                                  cel: source == "test-source"
+                                inputs: []
+                                consts: {}
+                                owners: []
+                                services: []
+                                actions:
+                                - name: suppress_alerts
+                                  provider:
+                                    type: mock
+                                    config: "{{ providers.default-mock }}"
+                                    with:
+                                        enrich_alert:
+                                            - key: status
+                                              value: acknowledged
+                            """
+    workflow = Workflow(
+        id="alert-time-check",
+        name="alert-time-check",
+        tenant_id=alert_maint.tenant_id,
+        description="Handle alerts based on startedAt timestamp",
+        created_by="test@keephq.dev",
+        interval=0,
+        workflow_raw=workflow_definition,
+    )
+    monkeypatch.setattr(
+        "keep.workflowmanager.workflowstore.get_all_workflows",
+        lambda tenant_id, exclude_disabled=False: [workflow]
+    )
+    monkeypatch.setattr(
+        "keep.workflowmanager.workflowstore.get_workflow_by_id",
+        lambda self, tenant_id, workflow_id="alert-time-check", exclude_disabled=False: workflow
+    )
+    # AND there is no maintenance window active
+    retrieve_windows_session = MagicMock()
+    retrieve_windows_session.exec.return_value.all.return_value = [expired_maintenance_window_rule_with_suppression_on]
+    # AND there is an alert which was received inside a maintenance window
+    retrieve_alerts_session = MagicMock()
+    retrieve_alerts_session.exec.return_value.all.return_value = [alert_maint]
+
+    recover_status_session = MagicMock()
+    recover_status_session.exec = MagicMock()
+    recover_status_session.commit = MagicMock()
+
+    loggerMag = MagicMock()
+    # WHEN the conditions match to recover the initial alert status
+    mock_session.__enter__.side_effect = [retrieve_windows_session, retrieve_alerts_session, recover_status_session, MagicMock()]
+    with patch("keep.api.core.db.existed_or_new_session", return_value=mock_session):
+        MaintenanceWindowsBl.recover_strategy(logger=loggerMag, session=mock_session)
+
+    workflow_execution = wait_for_workflow_execution(
+        alert_maint.tenant_id, "alert-time-check"
+    )
+
+    # THEN the workflow should be launched
+    assert workflow_execution is not None
+    assert workflow_execution.status == "success"

--- a/tests/test_maintenance_windows_bl.py
+++ b/tests/test_maintenance_windows_bl.py
@@ -350,7 +350,7 @@ def test_strategy_alert_block_by_window(
     Feature: Strategy - recover previous status
     Scenario: Alert is blocked (continue with the same status) by maintenance window
     """
-    # GIVEN The strategy is block_alert_by_maintenance_window
+    # GIVEN The strategy is recover_previous_status
     monkeypatch.setenv("MAINTENANCE_WINDOW_STRATEGY", "recover_previous_status")
     importlib.reload(keep.api.consts)
     importlib.reload(keep.api.bl.maintenance_windows_bl)

--- a/tests/test_maintenance_windows_bl.py
+++ b/tests/test_maintenance_windows_bl.py
@@ -386,7 +386,7 @@ def test_strategy_alert_launch_workflow(
     Feature: Strategy - recover previous status
     Scenario: Having the Maintenance Window expired, the alert in its previous status, workflows should be launched.
     """
-    # GIVEN The strategy is block_alert_by_maintenance_window
+    # GIVEN The strategy is recover_previous_status
     monkeypatch.setenv("MAINTENANCE_WINDOW_STRATEGY", "recover_previous_status")
     importlib.reload(keep.api.consts)
     importlib.reload(keep.api.bl.maintenance_windows_bl)

--- a/tests/test_maintenance_windows_bl.py
+++ b/tests/test_maintenance_windows_bl.py
@@ -124,7 +124,7 @@ def test_alert_in_active_maintenance_window(
     mock_session, active_maintenance_window_rule, alert_dto
 ):
     # Simulate the query to return the active maintenance_window
-    mock_session.query.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [
+    mock_session.query.return_value.filter.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [
         active_maintenance_window_rule
     ]
 
@@ -140,7 +140,7 @@ def test_alert_in_active_maintenance_window_with_suppress(
     mock_session, active_maintenance_window_rule_with_suppression_on, alert_dto
 ):
     # Simulate the query to return the active maintenance_window
-    mock_session.query.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [
+    mock_session.query.return_value.filter.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [
         active_maintenance_window_rule_with_suppression_on
     ]
 
@@ -260,7 +260,7 @@ def test_alert_not_ignored_due_to_custom_status(
 ):
     # Set the alert status to RESOLVED
 
-    mock_session.query.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [
+    mock_session.query.return_value.filter.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [
         active_maintenance_window_rule_custom_ignore
     ]
 
@@ -290,7 +290,7 @@ def test_strategy_restore_update_status(
     importlib.reload(keep.api.consts)
     importlib.reload(keep.api.bl.maintenance_windows_bl)
     # AND there is a maintenance window rule with suppression on active
-    mock_session.query.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [
+    mock_session.query.return_value.filter.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [
         active_maintenance_window_rule_with_suppression_on
     ]
 
@@ -339,8 +339,8 @@ def test_strategy_clean_status(
 
     # THEN the new status will be the previous status, and the previous status will be the old status
     _, new_status, new_previous_status, _ = list(recover_status_session.exec.call_args[0][0]._values.values())[0].value.values()
-    assert new_status == alert_maint.event["previous_status"]
-    assert new_previous_status == alert_maint.event["status"]
+    assert new_status == AlertStatus.FIRING.value
+    assert new_previous_status == AlertStatus.MAINTENANCE.value
 
 
 def test_strategy_alert_block_by_window(

--- a/tests/test_maintenance_windows_bl.py
+++ b/tests/test_maintenance_windows_bl.py
@@ -414,8 +414,8 @@ def test_strategy_alert_launch_workflow(
                                               value: acknowledged
                             """
     workflow = Workflow(
-        id="alert-time-check",
-        name="alert-time-check",
+        id="workflow_strategy_mw",
+        name="workflow_strategy_mw",
         tenant_id=alert_maint.tenant_id,
         description="Handle alerts based on startedAt timestamp",
         created_by="test@keephq.dev",
@@ -428,7 +428,7 @@ def test_strategy_alert_launch_workflow(
     )
     monkeypatch.setattr(
         "keep.workflowmanager.workflowstore.get_workflow_by_id",
-        lambda self, tenant_id, workflow_id="alert-time-check", exclude_disabled=False: workflow
+        lambda self, tenant_id, workflow_id="workflow_strategy_mw", exclude_disabled=False: workflow
     )
     # AND there is no maintenance window active
     retrieve_windows_session = MagicMock()
@@ -448,7 +448,7 @@ def test_strategy_alert_launch_workflow(
         MaintenanceWindowsBl.recover_strategy(logger=loggerMag, session=mock_session)
 
     workflow_execution = wait_for_workflow_execution(
-        alert_maint.tenant_id, "alert-time-check"
+        alert_maint.tenant_id, "workflow_strategy_mw"
     )
 
     # THEN the workflow should be launched


### PR DESCRIPTION
Close #5257

## 📑 Description
 A new strategy to handle alerts which match with the Maintenance Window rules has been implemented. 

The main mechanism consists of running a Watcher to check periodically whether the alerts match with the rules or not.
This watcher has been implemented to Work in a distribute environment (under Redis) as well as in standalone, relying on Create Task of asyncio. 

In general terms, the changes regarding the strategy are:

- Introduce a new status, "Maintenance" to follow the evolve of alerts in Maintenance Windows.
- Introduce a new Event field, "Previous status", to save the status before the Maintenance set.
- Inhibit the Workflow execution and Incident creation if we are facing a Maintenance alert.
- Check periodically if the alerts in Maintenance status continue or not under the Maintenance Rules, if not:
· Recovering the previous status
· Executing the workflows.
· Handling the incidents.
· Launching Pusher and Presets notify.
- Add documentation in both, Configuration (to introduce the Env vars) and in Maintenance doc.

As well as another changes as, use UTC to compare the dates, keep the logic to use the Default strategy, i.e the Suppresed one, or refactor some chunks of code to improve the reusability.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
