### PR TITLE
fix: Update the severity param type for zabbix provider's change_severity method

### DIFF
--- a/docs/snippets/providers/zabbix-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/zabbix-snippet-autogenerated.mdx
@@ -39,13 +39,13 @@ The provider exposes the following [Provider Methods](/providers/provider-method
 - **change_severity** No description. (action, scopes: event.acknowledge)
 
     - `id`: The problem id.
-    - `new_severity`: The new severity. Can be an integer (0-5) or string:
-- 0 or "Not classified"
-- 1 or "Information"
-- 2 or "Warning"
-- 3 or "Average"
-- 4 or "High"
-- 5 or "Disaster"
+    - `new_severity`: The new severity. Can be an integer string (0-5) or severity name:
+- "0" or "Not classified"
+- "1" or "Information"
+- "2" or "Warning"
+- "3" or "Average"
+- "4" or "High"
+- "5" or "Disaster"
 - **surrpress_problem** No description. (action, scopes: event.acknowledge)
 
     - `id`: The problem id.

--- a/keep/providers/zabbix_provider/zabbix_provider.py
+++ b/keep/providers/zabbix_provider/zabbix_provider.py
@@ -352,33 +352,39 @@ class ZabbixProvider(BaseProvider):
     def change_severity(
         self,
         id: str,
-        new_severity: Union[
-            int,
-            Literal[
-                "Not classified", "Information", "Warning", "Average", "High", "Disaster"
-            ],
-        ],
+        new_severity: str,
     ):
         """
         Change the severity of a problem.
         Args:
             id (str): The problem id.
-            new_severity (int | str): The new severity. Can be an integer (0-5) or string:
-                - 0 or "Not classified"
-                - 1 or "Information"
-                - 2 or "Warning"
-                - 3 or "Average"
-                - 4 or "High"
-                - 5 or "Disaster"
+            new_severity (str): The new severity. Can be an integer string (0-5) or severity name:
+                - "0" or "Not classified"
+                - "1" or "Information"
+                - "2" or "Warning"
+                - "3" or "Average"
+                - "4" or "High"
+                - "5" or "Disaster"
         """
-        # Handle integer input
+        # Validate and convert input
         severity = 0
-        if isinstance(new_severity, int):
-            if 0 <= new_severity <= 5:
-                severity = new_severity
+
+        # Handle numeric string input
+        if new_severity.isdigit():
+            severity_int = int(new_severity)
+            if 0 <= severity_int <= 5:
+                severity = severity_int
+            else:
+                raise ValueError(f"Invalid severity number: {new_severity}. Must be between 0-5.")
         else:
             # Handle string input
-            severity = ZabbixProvider.SEVERITY_NAME_TO_ID_MAP.get(new_severity.lower(), 0)
+            severity_lower = new_severity.lower().strip()
+            if severity_lower in ZabbixProvider.SEVERITY_NAME_TO_ID_MAP:
+                severity = ZabbixProvider.SEVERITY_NAME_TO_ID_MAP[severity_lower]
+            else:
+                valid_severities = list(ZabbixProvider.SEVERITY_NAME_TO_ID_MAP.keys()) + ["0", "1", "2", "3", "4", "5"]
+                raise ValueError(f"Invalid severity: {new_severity}. Valid values are: {valid_severities}")
+
         self.__send_request(
             "event.acknowledge", {"eventids": id, "severity": severity, "action": 8}
         )


### PR DESCRIPTION
Closes #5266 

## 📑 Description
The backend logs the following error while processing the request for `/providers` endpoint. 

> keep.providers.providers_factory: Could not get provider zabbix_provider methods. (2 validation errors for ProviderMethodParam
> expected_values -> 0
>   str type expected (type=type_error.str)
> expected_values -> 1
>   str type expected (type=type_error.str))

This occurs because `change_severity` method has a parameter of type Union[int, str] that the provider factory is not designed to handle. Hence, I have updated the parameter type to string and added validations to make sure the provided value is valid.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
