### PR TITLE
fix: prevent deleted API keys from being used for authentication

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -2027,10 +2027,12 @@ def get_alerts_by_status(
         return session.exec(query).all()
 
 
-def get_api_key(api_key: str) -> TenantApiKey:
+def get_api_key(api_key: str, include_deleted: bool = False) -> TenantApiKey:
     with Session(engine) as session:
         api_key_hashed = hashlib.sha256(api_key.encode()).hexdigest()
         statement = select(TenantApiKey).where(TenantApiKey.key_hash == api_key_hashed)
+        if not include_deleted:
+            statement = statement.where(TenantApiKey.is_deleted != True)
         tenant_api_key = session.exec(statement).first()
     return tenant_api_key
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keep"
-version = "0.47.3"
+version = "0.47.4"
 description = "Alerting. for developers, by developers."
 authors = ["Keep Alerting LTD"]
 packages = [{include = "keep"}]


### PR DESCRIPTION
## Summary
Fixed issue where deleted API keys remained valid and could still be used to send alerts.

## Changes
- Modified `get_api_key()` function in `keep/api/core/db.py` to filter out deleted keys by default
- Added optional `include_deleted` parameter for backward compatibility  
- Bumped version to 0.47.4 in pyproject.toml

## Behavior
- **Before**: Deleted API keys could still authenticate and send alerts
- **After**: Deleted API keys are blocked by default

## Backward Compatibility  
- All existing functionality preserved through optional `include_deleted=True` parameter
- All existing tests pass without modification

## Test Coverage
- Verified fix works with custom test script
- Existing authentication tests continue to pass

Closes #5269

🤖 Generated with [Claude Code](https://claude.ai/code)