### PR TITLE
fix: Bootstrap the default single tenant on when we are using onelogin as an IDP

### DIFF
--- a/keep/api/config.py
+++ b/keep/api/config.py
@@ -58,14 +58,19 @@ def on_starting(server=None):
         IdentityManagerTypes.DB.value,
         IdentityManagerTypes.NOAUTH.value,
         IdentityManagerTypes.OAUTH2PROXY.value,
+        IdentityManagerTypes.ONELOGIN.value,
         "no_auth",  # backwards compatibility
         "single_tenant",  # backwards compatibility
     ]:
+        excluded_from_default_user = [
+            IdentityManagerTypes.OAUTH2PROXY.value,
+            IdentityManagerTypes.ONELOGIN.value,
+        ]
         # for oauth2proxy, we don't want to create the default user
         try_create_single_tenant(
             SINGLE_TENANT_UUID,
             create_default_user=(
-                False if AUTH_TYPE == IdentityManagerTypes.OAUTH2PROXY.value else True
+                False if AUTH_TYPE in excluded_from_default_user else True
             ),
         )
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5280
Extension on https://github.com/keephq/keep/pull/5252

## 📑 Description
Bootstrap the default single tenant on when we are using onelogin as an identity provider, but we do not want a default user created

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
