### PR TITLE
docs: Fix GitHub link in overview/workflow-automation (#5308)

### DIFF
--- a/docs/overview/workflow-automation.mdx
+++ b/docs/overview/workflow-automation.mdx
@@ -11,7 +11,7 @@ It allows you to automate responses, integrate seamlessly with your existing too
   <img height="10" src="/images/workflow.png" />
 </Frame>
 
-This section provides an abstract overview of workflows in Keep. To dive deeper into creating and managing workflows, refer to the dedicated [Workflow Documentation](#workflow-documentation) and explore our [GitHub repository](https://github.com/keephq/keep-workflows) for ready-to-use examples.
+This section provides an abstract overview of workflows in Keep. To dive deeper into creating and managing workflows, refer to the dedicated [Workflow Documentation](#workflow-documentation) and explore our [GitHub repository](https://github.com/keephq/keep/tree/main/examples/workflows) for ready-to-use examples.
 
 
 ## Why Workflow Automation is Core


### PR DESCRIPTION
Fix broken GitHub link in the overview/workflow-automation page

Closes #5308
