### PR TITLE
feat(provider): add reconcile functionality to fluxcd provider

### DIFF
--- a/docs/snippets/providers/fluxcd-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/fluxcd-snippet-autogenerated.mdx
@@ -11,7 +11,8 @@ This provider requires authentication.
 - **insecure**: Skip TLS verification (required: False, sensitive: False)
 
 Certain scopes may be required to perform specific actions or queries via the provider. Below is a summary of relevant scopes and their use cases:
-- **authenticated**: User is Authorized (mandatory)
+- **authenticated**: User is Authorized (mandatory) 
+
 
 
 ## In workflows
@@ -29,6 +30,18 @@ steps:
         **_: {value}  # Additional arguments (ignored)
 ```
 
+
+As "action" to make changes or update data, example:
+```yaml
+actions:
+    - name: Query fluxcd
+      provider: fluxcd
+      config: "{{ provider.my_provider_name }}"
+      with:
+        action: {value}  # The action to perform. Supported actions are:
+- reconcile: Trigger a reconciliation for a FluxCD resource.
+        # Additional arguments for the action.
+```
 
 
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5307

## 📑 Description
<!-- Add a brief description of the pr -->
Adds `reconcile` action for FluxCD.

###
Workflow example

```yaml
  actions:
    - name: flux-action
      provider:
        type: fluxcd
        config: "{{ providers.flux }}"
        with:
          action: reconcile
          kind: HelmRelease
          name: my-app
          namespace: my-namespace
```

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
