### PR TITLE
fix: added a new pkce string generator and use that in oauth handshake

### DIFF
--- a/keep-ui/app/(keep)/providers/provider-form.tsx
+++ b/keep-ui/app/(keep)/providers/provider-form.tsx
@@ -53,6 +53,7 @@ import { KeepApiError, KeepApiReadOnlyError } from "@/shared/api";
 import { showErrorToast } from "@/shared/ui";
 import {
   base64urlencode,
+  generatePkceVerifier,
   generateRandomString,
   sha256,
 } from "@/shared/lib/encodings";
@@ -103,7 +104,7 @@ function getInitialFormValues(provider: Provider, isHealthCheck?: boolean) {
   const initialValues: ProviderFormData = {
     provider_id: provider.id,
     install_webhook: !isHealthCheck
-      ? provider.can_setup_webhook ?? false
+      ? (provider.can_setup_webhook ?? false)
       : false,
     pulling_enabled: provider.pulling_enabled,
   };
@@ -205,7 +206,7 @@ const ProviderForm = ({
   const callInstallWebhook = async () => await installWebhook(provider);
 
   async function handleOauth() {
-    const verifier = generateRandomString();
+    const verifier = generatePkceVerifier();
     cookieCutter.set("verifier", verifier);
     cookieCutter.set(
       "oauth2_install_webhook",

--- a/keep-ui/shared/lib/encodings.ts
+++ b/keep-ui/shared/lib/encodings.ts
@@ -1,6 +1,6 @@
 /**
  * Converts a decimal number to a hexadecimal string with proper padding
- * 
+ *
  * @param dec - The decimal number to convert
  * @returns A hexadecimal string representation
  * @internal This is a utility function used by generateRandomString
@@ -11,9 +11,9 @@ function dec2hex(dec: number) {
 
 /**
  * Generates a cryptographically secure random string
- * 
+ *
  * @returns A random hexadecimal string of 56 characters
- * 
+ *
  * @example
  * const randomStr = generateRandomString();
  * // e.g. "7b8d4f2e9a1c6b3d5e8f2a7c9b4d1e6f3a8c5b2d7e9f1a3c8b6d4e7f2a9c5"
@@ -25,11 +25,29 @@ export function generateRandomString() {
 }
 
 /**
+ * Generates a PKCE verifier string with length 128 characters
+ *
+ * @returns a random string of 128 characters
+ *
+ * @example
+ * const verifier = generatePkceVerifier();
+ * // e.g. "7b8d4f2e9a1c6b3d5e8f2a7c9b4d1e6f3a8c5b2d7e9f1a3c8b6d4e7f2a9c5"
+ */
+export function generatePkceVerifier(): string {
+  const arr = new Uint8Array(96);
+  window.crypto.getRandomValues(arr);
+  return btoa(String.fromCharCode(...arr))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
  * Computes the SHA-256 hash of a string
- * 
+ *
  * @param plain - The input string to hash
  * @returns A Promise that resolves to an ArrayBuffer containing the hash
- * 
+ *
  * @example
  * const hashBuffer = await sha256("hello world");
  */
@@ -41,15 +59,15 @@ export function sha256(plain: string) {
 
 /**
  * Encodes an ArrayBuffer to base64url format (URL-safe base64)
- * 
+ *
  * Base64url encoding is a variant of base64 that is URL and filename safe:
  * - Replaces '+' with '-'
  * - Replaces '/' with '_'
  * - Removes padding '=' characters
- * 
+ *
  * @param a - The ArrayBuffer to encode
  * @returns The base64url-encoded string
- * 
+ *
  * @example
  * const hashBuffer = await sha256("hello world");
  * const base64urlStr = base64urlencode(hashBuffer);


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5322

## 📑 Description
Added a helper function to generate a random string of 128 characters compliant with RFC7636: https://datatracker.ietf.org/doc/html/rfc7636

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
