### PR TITLE
Forbid extra parameters in StepProviderParameter class.

### DIFF
--- a/keep/step/step_provider_parameter.py
+++ b/keep/step/step_provider_parameter.py
@@ -1,7 +1,8 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class StepProviderParameter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     key: str  # the key to render
     safe: bool = False  # whether to validate this key or fail silently ("safe")
     default: str | int | bool = None  # default value if this key doesn't exist


### PR DESCRIPTION
Allow the use of the key "key" in parameters in step workflows, for example a POST body in WebHook provider with the key: "key".

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes  #5333 

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

