### PR TITLE
feat: Maintenance windows improvements

### DIFF
--- a/keep/api/bl/maintenance_windows_bl.py
+++ b/keep/api/bl/maintenance_windows_bl.py
@@ -228,7 +228,7 @@ class MaintenanceWindowsBl:
         for (tenant, fp) in fingerprints_to_check:
             last_alert = get_last_alert_by_fingerprint(tenant, fp, session)
             alert = get_alert_by_event_id(tenant, str(last_alert.alert_id), session)
-            if not ("previous_status" in alert.event):
+            if "previous_status" not in alert.event:
                 logger.info(
                     f"Alert {alert.id} does not have previous status, cannot proceed with recover strategy",
                     extra={"tenant_id": tenant, "fingerprint": fp, "alert_id": alert.id, "alert.status": alert.event.get("status")},

--- a/keep/api/bl/maintenance_windows_bl.py
+++ b/keep/api/bl/maintenance_windows_bl.py
@@ -203,6 +203,9 @@ class MaintenanceWindowsBl:
                     is_in_cel = MaintenanceWindowsBl.evaluate_cel(
                         window, alert, env, logger, {"tenant_id": alert.tenant_id, "alert_id": alert.id}
                     )
+                    # Recover source structure
+                    if not isinstance(alert.event.get("source"), list):
+                        alert.event["source"] = [alert.event["source"]]
                     if is_in_cel:
                         active = True
                         set_maintenance_windows_trace(alert, window, session)

--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -44,6 +44,7 @@ from sqlalchemy.orm.exc import StaleDataError
 from sqlalchemy.sql import exists, expression
 from sqlalchemy.sql.functions import count
 from sqlmodel import Session, SQLModel, col, or_, select, text
+from sqlalchemy.orm.attributes import flag_modified
 
 from keep.api.consts import STATIC_PRESETS
 from keep.api.core.config import config
@@ -5776,6 +5777,19 @@ def set_last_alert(
             # break the retry loop
             break
 
+def set_maintenance_windows_trace(alert: Alert, maintenance_w: MaintenanceWindowRule,  session: Optional[Session] = None):
+    mw_id = str(maintenance_w.id)
+    if mw_id in alert.event.get("maintenance_windows_trace", []):
+        return
+    with existed_or_new_session(session) as session:
+        if "maintenance_windows_trace" in alert.event:
+            if mw_id not in alert.event['maintenance_windows_trace']:
+                alert.event['maintenance_windows_trace'].append(mw_id)
+        else:
+            alert.event['maintenance_windows_trace'] = [mw_id]
+        flag_modified(alert, "event")
+        session.add(alert)
+        session.commit()
 
 def get_provider_logs(
     tenant_id: str, provider_id: str, limit: int = 100

--- a/tests/test_maintenance_windows_bl.py
+++ b/tests/test_maintenance_windows_bl.py
@@ -1,16 +1,21 @@
 from datetime import datetime, timedelta
 import importlib
+import time
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
 import keep.api.consts
 from keep.api.bl.maintenance_windows_bl import MaintenanceWindowsBl
+from keep.api.core.db import get_alerts_by_status, get_workflow_executions, get_workflow_executions_count
 from keep.api.core.dependencies import SINGLE_TENANT_UUID
 from keep.api.models.alert import AlertDto, AlertStatus
 from keep.api.models.db.alert import Alert
-from keep.api.models.db.maintenance_window import MaintenanceWindowRule
+from keep.api.models.db.maintenance_window import MaintenanceRuleCreate, MaintenanceWindowRule
 from keep.api.models.db.workflow import Workflow
+from keep.api.routes.maintenance import update_maintenance_rule
+from keep.functions import cyaml
+from keep.workflowmanager.workflowstore import WorkflowStore
 from tests.fixtures.workflow_manager import (
     workflow_manager,
     wait_for_workflow_execution,
@@ -459,3 +464,163 @@ def test_strategy_alert_launch_workflow(
     # THEN the workflow should be launched
     assert workflow_execution is not None
     assert workflow_execution.status == "success"
+
+
+def test_strategy_alert_expired_by_current_time(
+    create_alert, db_session, monkeypatch, create_window_maintenance_active
+):
+    """
+    Feature: Strategy - recover previous status
+    Scenario: Having a Maintenance window active, receiving new alerts in that window,
+             when the window expires by current time, the alerts should recover its previous status.
+    """
+    # GIVEN The strategy is recover_previous_status
+    monkeypatch.setenv("MAINTENANCE_WINDOW_STRATEGY", "recover_previous_status")
+    importlib.reload(keep.api.consts)
+    importlib.reload(keep.api.bl.maintenance_windows_bl)
+    # AND there is a maintenance window active.
+    mw = create_window_maintenance_active(
+        cel='fingerprint == "alert-test-1" || fingerprint == "alert-test-2"',
+        start=datetime.utcnow() - timedelta(hours=10),
+        end=datetime.utcnow() + timedelta(days=1),
+    )
+
+    #AND there are new alerts
+    create_alert(
+        "alert-test-1",
+        AlertStatus("firing"),
+        datetime.utcnow(),
+        {},
+    )
+    create_alert(
+        "alert-test-2",
+        AlertStatus("firing"),
+        datetime.utcnow(),
+        {},
+    )
+    MaintenanceWindowsBl.recover_strategy(logger=MagicMock(), session=db_session)
+    maintenance_status_prev = get_alerts_by_status(AlertStatus.MAINTENANCE, db_session)
+    #WHEN The Maintenance Window is closed, because the end time is < current time
+    update_maintenance_rule(
+        rule_id=mw.id,
+        rule_dto=MaintenanceRuleCreate(
+            name=mw.name,
+            cel_query=mw.cel_query,
+            start_time=mw.start_time,
+            duration_seconds=36000-5,  # 10h - 5 seconds duration, so the end is just before current time
+        ),
+        authenticated_entity=MagicMock(tenant_id=SINGLE_TENANT_UUID, email="test@keephq.dev"),
+        session=db_session
+    )
+    time.sleep(3)
+    MaintenanceWindowsBl.recover_strategy(logger=MagicMock(), session=db_session)
+
+    #THEN There are 2 alert prev to the current hour and 0 after the maintenance window is expired
+    maintenance_status_post = get_alerts_by_status(AlertStatus.MAINTENANCE, db_session)
+    assert len(maintenance_status_prev) == 2
+    assert len(maintenance_status_post) == 0
+
+@pytest.mark.parametrize(
+    ["solved_alert", "executions"],
+    [
+        (True, 0),
+        (False, 1),
+    ],
+)
+def test_strategy_alert_execution_wf(
+    create_alert, db_session, monkeypatch, create_window_maintenance_active, workflow_manager,
+    solved_alert, executions
+):
+    """
+    Feature: Strategy - recover previous status with Workflow execution
+    Scenario: Having a WF created and a Maintenance window active, 
+             receiving in that window 3 alerts (same FP), 2 FIRING and the other 
+             one in RESOLVED status, the WF is not executed at the end of the
+             maintenance window.
+
+             On the other hand, receiving 2 alerts(same FP) inside the maintenance window,
+             once it's expired, the WF is executed 1 time.
+    """
+    # GIVEN The strategy is recover_previous_status
+    monkeypatch.setenv("MAINTENANCE_WINDOW_STRATEGY", "recover_previous_status")
+    importlib.reload(keep.api.consts)
+    importlib.reload(keep.api.bl.maintenance_windows_bl)
+    #AND A Workflow ready to be executed
+    workflow_definition = """
+        workflow:
+            id: 123-333-22-11-22
+            name: WF_alert-test-1
+            description: Description
+            disabled: false
+            triggers:
+            - type: alert
+              cel: fingerprint == "alert-test-1" && status == "firing"
+            inputs: []
+            consts: {}
+            owners: []
+            services: []
+            steps: []
+            actions:
+            - name: action-mock
+              provider:
+                type: mock
+                config: "{{ providers.default-mock }}"
+                with:
+                    enrich_alert:
+                        - key: extra_field
+                          value: workflow_executed
+        """
+    workflow_data = cyaml.safe_load(workflow_definition)
+    workflow = WorkflowStore().create_workflow(
+            tenant_id=SINGLE_TENANT_UUID,
+            created_by="keep",
+            workflow=workflow_data.pop("workflow"),
+        )
+    #AND A Maintenance window active
+    mw = create_window_maintenance_active(
+        cel='fingerprint == "alert-test-1"',
+        start=datetime.utcnow() - timedelta(hours=10),
+        end=datetime.utcnow() + timedelta(days=1),
+    )
+
+    # AND 2 Firing alerts with the same Fingerprint
+    create_alert(
+        "alert-test-1",
+        AlertStatus("firing"),
+        datetime.utcnow(),
+        {},
+    )
+    create_alert(
+        "alert-test-1",
+        AlertStatus("firing"),
+        datetime.utcnow(),
+        {},
+    )
+    if solved_alert:
+        #AND 1 Resolved alert with the same Fingerprint
+        create_alert(
+            "alert-test-1",
+            AlertStatus("resolved"),
+            datetime.utcnow(),
+            {},
+        )
+    time.sleep(1)
+    MaintenanceWindowsBl.recover_strategy(logger=MagicMock(), session=db_session)
+    #WHEN The Maintenance Window is closed, because the end time is < current time
+    update_maintenance_rule(
+        rule_id=mw.id,
+        rule_dto=MaintenanceRuleCreate(
+            name=mw.name,
+            cel_query=mw.cel_query,
+            start_time=mw.start_time,
+            duration_seconds=36000-5,  # 10h - 5 seconds duration, so the end is just before current time
+        ),
+        authenticated_entity=MagicMock(tenant_id=SINGLE_TENANT_UUID, email="test@keephq.dev"),
+        session=db_session
+    )
+    MaintenanceWindowsBl.recover_strategy(logger=MagicMock(), session=db_session)
+    time.sleep(5)
+    #THEN The WF is not executed if there is a resolved alert or executed 1 time if there are only firing alerts
+    n_executions = get_workflow_executions(SINGLE_TENANT_UUID, workflow.id)[0]
+
+    assert n_executions == executions


### PR DESCRIPTION

Closes #5321

## 📑 Description
With this new PR I've introduced some improvements in Maintenance windows:

-  The alerts are free if the finalization hour is bigger than the current one.
-  Once the maintenance window is over, the alerts will only trigger the WF and Incidents by its fingerprint.
-  In order to track, the alerts will have a new field including the ID of the window.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed

