### PR TITLE
fix: Use deepcopy when rendering alert data in keep_provider

### DIFF
--- a/keep/providers/keep_provider/keep_provider.py
+++ b/keep/providers/keep_provider/keep_provider.py
@@ -547,7 +547,7 @@ class KeepProvider(BaseProvider):
         )
         # render alert data
         for alert_result in trigger_alerts:
-            alert_data = copy.copy(alert or {})
+            alert_data = copy.deepcopy(alert or {})
             # render alert data
             if isinstance(alert_result, dict):
                 rendered_alert_data = self.io_handler.render_context(


### PR DESCRIPTION
Closes #5171 

## 📑 Description
When using the Keep provider to create alerts in a foreach loop, all generated alerts may end up sharing the same (often last) data, especially if the alert template contains nested structures (such as dictionaries or lists). Replace the shallow copy with a deep copy to ensure that each alert in the loop gets a fully independent copy of the template, including all nested structures.

Thanks to @akipham15 for the research in #5171

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
n/a