### PR TITLE
docs: Format IAM permissions in eks-provider documentation

### DIFF
--- a/docs/providers/documentation/eks-provider.mdx
+++ b/docs/providers/documentation/eks-provider.mdx
@@ -52,13 +52,13 @@ aws eks list-clusters --region <your-region>
 ## Required Permissions
 The AWS IAM user needs these permissions:
 
-1. eks:DescribeCluster
-2. eks:ListClusters
+1. **eks:DescribeCluster**
+2. **eks:ListClusters**
 
 Additional permissions for specific operations:
 
-3. eks:AccessKubernetesApi for pod/deployment operations
-4. eks:UpdateCluster for scaling operations
+3. **eks:AccessKubernetesApi** for pod/deployment operations
+4. **eks:UpdateCluster** for scaling operations
 
 | Command | AWS IAM Permissions |
 |---------|-------------------|


### PR DESCRIPTION
Bold the required AWS IAM permissions for clarity.
