### PR TITLE
docs: Update ArgoCD documentation links to stable version

### DIFF
--- a/docs/providers/documentation/argocd-provider.mdx
+++ b/docs/providers/documentation/argocd-provider.mdx
@@ -15,7 +15,7 @@ ArgoCD ApplicationSets are mapped to Keep Applcations
 
 ## Connecting with the Provider
 
-1. Obtain the **access token** from your ArgoCD instance by following `Generate auth token` from [ArgoCD's User management docs](https://argo-cd.readthedocs.io/en/latest/operator-manual/user-management/#manage-users).
+1. Obtain the **access token** from your ArgoCD instance by following `Generate auth token` from [ArgoCD's User management docs](https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/#manage-users).
 2. Set the **deployment URL** to your ArgoCD instance's base URL (e.g., `https://localhost:8080`).
 
 ## Features
@@ -28,5 +28,5 @@ The **ArgoCD Provider** supports the following key features:
 
 ## Useful Links
 
-- [ArgoCD API Documentation](https://argo-cd.readthedocs.io/en/latest/developer-guide/api-docs)
-- [ArgoCD User Management](https://argo-cd.readthedocs.io/en/latest/operator-manual/user-management/#local-usersaccounts)
+- [ArgoCD API Documentation](https://argo-cd.readthedocs.io/en/stable/developer-guide/api-docs)
+- [ArgoCD User Management](https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/#local-usersaccounts)


### PR DESCRIPTION
change the links to the latest STABLE version of ArgoCD instead of pointing to the latest (i.e. unstable) release.
