### PR TITLE
fix: DBSecretManager raises an exception

### DIFF
--- a/keep/secretmanager/dbsecretmanager.py
+++ b/keep/secretmanager/dbsecretmanager.py
@@ -26,6 +26,8 @@ class DbSecretManager(BaseSecretManager):
                     if is_json:
                         return json.loads(secret_model.value)
                     return secret_model.value
+                else:
+                    raise KeyError(f"Secret {secret_name} not found")
             except Exception as e:    
                 self.logger.error(
                     "Failed to read secret",


### PR DESCRIPTION
Closes #5417

## 📑 Description
In the same way as other SecretManager(see filesecretmanager), I've implemented a exception in case of the value doesn't exist in the DB, the callers will caught this and return an empty dict. 

Right now, as I commented in the issue, in case of empty value in db, nothing value was returned, causing this an error.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed

## ℹ Additional Information
Call with empty value:

<img width="1487" height="283" alt="imagen" src="https://github.com/user-attachments/assets/bf40ff33-8afe-4d52-a26d-2e6b6cdcf74c" />

