### PR TITLE
fix: `Not set` even internal is set

### DIFF
--- a/keep-ui/entities/workflows/lib/getTriggerDescription.ts
+++ b/keep-ui/entities/workflows/lib/getTriggerDescription.ts
@@ -34,10 +34,18 @@ export function getTriggerDescriptionFromStep(trigger: V2StepTrigger) {
         return "Run now button";
       }
       case "interval": {
-        if (!trigger.properties?.interval) {
+        // Handle both cases: properties as object with interval property, or properties as direct interval value
+        let intervalValue;
+        if (typeof trigger.properties === "string" || typeof trigger.properties === "number") {
+          intervalValue = trigger.properties;
+        } else if (trigger.properties?.interval) {
+          intervalValue = trigger.properties.interval;
+        }
+        
+        if (!intervalValue) {
           return "Not set";
         }
-        return `Every ${getHumanReadableInterval(trigger.properties.interval)} (${trigger.properties.interval} seconds)`;
+        return `Every ${getHumanReadableInterval(intervalValue)} (${intervalValue} seconds)`;
       }
       case "alert": {
         if (trigger.properties?.cel) {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes [#5456](https://github.com/keephq/keep/issues/5456)<!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Fix bug of Interval shows Not set when reopen a interval workflow
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
