### PR TITLE
fix: argocd provider fails on nodes missing uid

### DIFF
--- a/keep/providers/argocd_provider/argocd_provider.py
+++ b/keep/providers/argocd_provider/argocd_provider.py
@@ -230,6 +230,10 @@ class ArgocdProvider(BaseTopologyProvider):
 
             for node in nodes:
                 if node["kind"] == "Application":
+                    uid = node.get("uid")
+                    if not uid:
+                        self.logger.warning("Skipping node with missing 'uid': %s", node)
+                        continue                    
                     service_topology[metadata["uid"]].dependencies[
                         node["uid"]
                     ] = "unknown"


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5504 

## 📑 Description
`argocd` provider now skips nodes with missing `uid` (and logs a warning).

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
