### PR TITLE
fix(providers): fix Sentry auth token key inconsistency

### DIFF
--- a/keep/providers/sentry_provider/sentry_provider.py
+++ b/keep/providers/sentry_provider/sentry_provider.py
@@ -137,7 +137,7 @@ class SentryProvider(BaseProvider):
             list[tuple] | list[dict]: results of the query
         """
         headers = {
-            "Authorization": f"Bearer {self.config.authentication['api_token']}",
+            "Authorization": f"Bearer {self.authentication_config.api_key}",
         }
 
         params = {"limit": 100}


### PR DESCRIPTION
This PR fixes a critical inconsistency where the Sentry provider was using `api_token` instead of `api_key` in the `_query` method, causing authentication failures.

Closes #1582