### PR TITLE
feat: add nagios provider

### DIFF
--- a/keep/providers/nagios_provider/__init__.py
+++ b/keep/providers/nagios_provider/__init__.py
@@ -1,0 +1,1 @@
+from .nagios_provider import NagiosProvider

--- a/keep/providers/nagios_provider/__init__.py
+++ b/keep/providers/nagios_provider/__init__.py
@@ -1,1 +1,1 @@
-from .nagios_provider import NagiosProvider
+from .nagios_provider import NagiosProvider as NagiosProvider

--- a/keep/providers/nagios_provider/nagios_provider.py
+++ b/keep/providers/nagios_provider/nagios_provider.py
@@ -1,0 +1,105 @@
+"""
+Nagios Provider is a class that provides a way to receive alerts from Nagios using webhooks.
+"""
+import dataclasses
+import pydantic
+import requests
+from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.base.base_provider import BaseProvider
+from keep.providers.models.provider_config import ProviderConfig, ProviderScope
+
+
+@pydantic.dataclasses.dataclass
+class NagiosProviderAuthConfig:
+    """
+    Authentication configuration for Nagios.
+    """
+    host_url: pydantic.AnyHttpUrl = dataclasses.field(
+        metadata={
+            "required": True,
+            "description": "Nagios Host URL",
+            "hint": "e.g. https://nagios.example.com",
+            "sensitive": False,
+        }
+    )
+    api_key: str = dataclasses.field(
+        metadata={
+            "required": False,
+            "description": "API Key for Nagios (optional)",
+            "sensitive": True,
+        }
+    )
+
+
+class NagiosProvider(BaseProvider):
+    """
+    Get alerts from Nagios into Keep via webhooks.
+    """
+    webhook_description = ""
+    webhook_template = ""
+    webhook_markdown = """
+To send alerts from Nagios to Keep:
+
+1. Install the notification script from Keep docs
+2. Set webhook URL: {keep_webhook_api_url}
+3. Add header "X-API-KEY" with your Keep API key
+4. Configure Nagios notification commands
+    """
+
+    PROVIDER_DISPLAY_NAME = "Nagios"
+    PROVIDER_TAGS = ["alert"]
+    PROVIDER_CATEGORY = ["Monitoring"]
+    WEBHOOK_INSTALLATION_REQUIRED = True
+    PROVIDER_ICON = "nagios-icon.png"
+
+    PROVIDER_SCOPES = [
+        ProviderScope(name="read_alerts", description="Read alerts from Nagios"),
+    ]
+
+    STATUS_MAP = {
+        "OK": AlertStatus.RESOLVED,
+        "WARNING": AlertStatus.FIRING,
+        "CRITICAL": AlertStatus.FIRING,
+        "UNKNOWN": AlertStatus.FIRING,
+        "UP": AlertStatus.RESOLVED,
+        "DOWN": AlertStatus.FIRING,
+    }
+
+    SEVERITY_MAP = {
+        "OK": AlertSeverity.INFO,
+        "WARNING": AlertSeverity.WARNING,
+        "CRITICAL": AlertSeverity.CRITICAL,
+        "UNKNOWN": AlertSeverity.INFO,
+        "UP": AlertSeverity.INFO,
+        "DOWN": AlertSeverity.CRITICAL,
+    }
+
+    def __init__(self, context_manager: ContextManager, provider_id: str, config: ProviderConfig):
+        super().__init__(context_manager, provider_id, config)
+
+    def validate_config(self):
+        self.authentication_config = NagiosProviderAuthConfig(**self.config.authentication)
+
+    def validate_scopes(self):
+        return {"read_alerts": True}
+
+    @staticmethod
+    def _format_alert(event: dict, provider_instance: "BaseProvider" = None) -> AlertDto:
+        """Format Nagios webhook payload into Keep alert format."""
+        host = event.get("host", "")
+        service = event.get("service", "")
+        state = event.get("state", "UNKNOWN")
+        output = event.get("output", "")
+        
+        return AlertDto(
+            id=f"{host}:{service}" if service else host,
+            name=service or host,
+            status=NagiosProvider.STATUS_MAP.get(state, AlertStatus.FIRING),
+            severity=NagiosProvider.SEVERITY_MAP.get(state, AlertSeverity.INFO),
+            description=output,
+            source=["nagios"],
+            hostname=host,
+            service_name=service,
+            state=state,
+        )

--- a/keep/providers/nagios_provider/nagios_provider.py
+++ b/keep/providers/nagios_provider/nagios_provider.py
@@ -3,7 +3,6 @@ Nagios Provider is a class that provides a way to receive alerts from Nagios usi
 """
 import dataclasses
 import pydantic
-import requests
 from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
 from keep.contextmanager.contextmanager import ContextManager
 from keep.providers.base.base_provider import BaseProvider

--- a/tests/test_nagios_provider.py
+++ b/tests/test_nagios_provider.py
@@ -1,0 +1,156 @@
+"""Tests for Nagios Provider.
+
+This module tests the Nagios provider webhook functionality, state mapping,
+and alert formatting.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.nagios_provider.nagios_provider import NagiosProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+
+class TestNagiosProvider:
+    """Test suite for Nagios Provider."""
+
+    @pytest.fixture
+    def nagios_config(self):
+        return ProviderConfig(
+            description="Test Nagios",
+            authentication={
+                "host_url": "http://nagios.example.com/nagios",
+                "api_user": "admin",
+                "api_password": "password",
+            },
+        )
+
+    @pytest.fixture
+    def nagios_provider(self, nagios_config):
+        cm = ContextManager(tenant_id="test", workflow_id="test")
+        return NagiosProvider(cm, "test-nagios", nagios_config)
+
+    def test_format_alert_ok(self):
+        """Test formatting a Nagios OK alert."""
+        event = {
+            "host": "server1",
+            "service": "CPU Usage",
+            "state_id": 0,
+            "output": "CPU load is normal",
+        }
+        alert = NagiosProvider._format_alert(event)
+        assert alert.status == AlertStatus.RESOLVED
+        assert alert.severity == AlertSeverity.INFO
+        assert alert.name == "CPU Usage"
+
+    def test_format_alert_warning(self):
+        """Test formatting a Nagios WARNING alert."""
+        event = {
+            "host": "server1",
+            "service": "Disk Space",
+            "state_id": 1,
+            "output": "Disk space 85% full",
+        }
+        alert = NagiosProvider._format_alert(event)
+        assert alert.status == AlertStatus.FIRING
+        assert alert.severity == AlertSeverity.WARNING
+
+    def test_format_alert_critical(self):
+        """Test formatting a Nagios CRITICAL alert."""
+        event = {
+            "host": "server1",
+            "service": "Memory",
+            "state_id": 2,
+            "output": "Memory usage critical",
+        }
+        alert = NagiosProvider._format_alert(event)
+        assert alert.status == AlertStatus.FIRING
+        assert alert.severity == AlertSeverity.CRITICAL
+
+    def test_format_alert_unknown(self):
+        """Test formatting a Nagios UNKNOWN alert."""
+        event = {
+            "host": "server1",
+            "service": "Process",
+            "state_id": 3,
+            "output": "Process status unknown",
+        }
+        alert = NagiosProvider._format_alert(event)
+        assert alert.status == AlertStatus.FIRING
+        assert alert.severity == AlertSeverity.INFO
+
+    def test_format_alert_host_check(self):
+        """Test formatting a host check (no service)."""
+        event = {
+            "host": "server1",
+            "state_id": 2,
+            "output": "Host is DOWN",
+        }
+        alert = NagiosProvider._format_alert(event)
+        assert alert.name == "server1"
+        assert alert.status == AlertStatus.FIRING
+        assert "server1" == alert.hostname
+
+    @patch("requests.get")
+    def test_get_alerts_success(self, mock_get, nagios_provider):
+        """Test getting alerts from Nagios."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": {
+                "servicelist": {
+                    "server1": {
+                        "SSH": {"status": 2, "plugin_output": "SSH failed"},
+                        "HTTP": {"status": 1, "plugin_output": "Slow response"},
+                    }
+                }
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        alerts = nagios_provider._get_alerts()
+        assert len(alerts) == 2
+        assert alerts[0].status == AlertStatus.FIRING
+
+    @patch("requests.get")
+    def test_get_alerts_empty(self, mock_get, nagios_provider):
+        """Test getting alerts when all services are OK."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": {
+                "servicelist": {
+                    "server1": {
+                        "SSH": {"status": 0, "plugin_output": "OK"},
+                    }
+                }
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        alerts = nagios_provider._get_alerts()
+        assert len(alerts) == 0  # OK services excluded
+
+    @patch("requests.get")
+    def test_validate_scopes_success(self, mock_get, nagios_provider):
+        """Test validate_scopes with successful connection."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        scopes = nagios_provider.validate_scopes()
+        assert scopes["read_alerts"] is True
+
+    @patch("requests.get")
+    def test_validate_scopes_failure(self, mock_get, nagios_provider):
+        """Test validate_scopes with failed connection."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.raise_for_status.side_effect = Exception("Unauthorized")
+        mock_get.return_value = mock_response
+
+        scopes = nagios_provider.validate_scopes()
+        assert "error" in str(scopes["read_alerts"]).lower()


### PR DESCRIPTION
## Summary
Adds Nagios monitoring provider to Keep for receiving alerts via webhooks.

## Features
- Receives alerts from Nagios via webhooks
- Maps Nagios states (OK, WARNING, CRITICAL, UNKNOWN) to Keep status/severity
- Supports both host and service notifications
- Handles recovery notifications

## Related Issue
Closes #3960

/claim #3960