### PR TITLE
feat: add Falco security provider

### DIFF
--- a/keep/providers/falco_provider/falco_provider.py
+++ b/keep/providers/falco_provider/falco_provider.py
@@ -1,0 +1,184 @@
+"""
+Falco is an open-source runtime security engine that detects anomalous activity in containers, Kubernetes, and hosts.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.base.base_provider import BaseProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+logger = logging.getLogger(__name__)
+
+
+class FalcoProvider(BaseProvider):
+    """Receive security alerts from Falco via webhook."""
+
+    PROVIDER_DISPLAY_NAME = "Falco"
+    PROVIDER_CATEGORY = ["Security", "Monitoring"]
+    PROVIDER_TAGS = ["alert", "security", "runtime", "cncf"]
+    FINGERPRINT_FIELDS = ["rule", "hostname", "output_fields"]
+
+    webhook_description = "Receive Falco security alerts via webhook"
+    webhook_template = ""
+    webhook_markdown = """
+    To configure Falco to send alerts to Keep:
+
+    1. Install and configure [Falcosidekick](https://github.com/falcosecurity/falcosidekick) (recommended) or use Falco's built-in HTTP output.
+
+    2. **Using Falcosidekick (Recommended):**
+       
+       Set the following environment variables or configuration:
+       ```yaml
+       webhook:
+         address: "{keep_webhook_api_url}"
+         method: "POST"
+         headers:
+           X-API-KEY: "{api_key}"
+           Content-Type: "application/json"
+       ```
+
+    3. **Using Falco's native HTTP output:**
+       
+       Add to your `falco.yaml`:
+       ```yaml
+       http_output:
+         enabled: true
+         url: "{keep_webhook_api_url}"
+         user_agent: "falcosecurity/falco"
+       ```
+
+    4. Restart Falco/Falcosidekick.
+
+    For more details, see the [Falco documentation](https://falco.org/docs/outputs/forwarding/).
+    """
+
+    SEVERITIES_MAP = {
+        "EMERGENCY": AlertSeverity.CRITICAL,
+        "ALERT": AlertSeverity.CRITICAL,
+        "CRITICAL": AlertSeverity.CRITICAL,
+        "ERROR": AlertSeverity.HIGH,
+        "WARNING": AlertSeverity.WARNING,
+        "WARN": AlertSeverity.WARNING,
+        "NOTICE": AlertSeverity.INFO,
+        "INFORMATIONAL": AlertSeverity.INFO,
+        "DEBUG": AlertSeverity.INFO,
+    }
+
+    def __init__(
+        self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
+    ):
+        super().__init__(context_manager, provider_id, config)
+
+    def validate_config(self):
+        """
+        No validation required for Falco webhook provider.
+        """
+        pass
+
+    @staticmethod
+    def _format_alert(
+        event: dict, provider_instance: BaseProvider = None
+    ) -> AlertDto | list[AlertDto]:
+        """
+        Format Falco webhook payload into Keep AlertDto.
+        
+        Falco webhook payload format (via Falcosidekick):
+        {
+            "output": "12:34:56.789123789: Notice A shell was spawned...",
+            "priority": "Notice",
+            "rule": "Terminal shell in container",
+            "time": "2024-01-15T12:34:56.789123789Z",
+            "output_fields": {
+                "container.id": "docker://abc123",
+                "container.name": "myapp",
+                "evt.time": 1705325696789123789,
+                "k8s.ns.name": "default",
+                "k8s.pod.name": "myapp-xyz",
+                "proc.name": "bash",
+                "user.name": "root"
+            },
+            "hostname": "worker-node-1",
+            "tags": ["container", "shell", "mitre_execution"]
+        }
+        """
+        logger.info(f"Formatting Falco alert: {event}")
+
+        # Extract priority and map to severity
+        priority = event.get("priority", "NOTICE").upper()
+        severity = FalcoProvider.SEVERITIES_MAP.get(priority, AlertSeverity.INFO)
+
+        # Parse timestamp
+        time_str = event.get("time")
+        if time_str:
+            try:
+                # Falco sends ISO8601 format
+                last_received = datetime.fromisoformat(time_str.replace('Z', '+00:00')).isoformat()
+            except (ValueError, TypeError):
+                logger.warning(f"Failed to parse Falco time: {time_str}")
+                last_received = datetime.now(timezone.utc).isoformat()
+        else:
+            last_received = datetime.now(timezone.utc).isoformat()
+
+        # Extract output fields
+        output_fields = event.get("output_fields", {})
+        
+        # Build tags list
+        tags = event.get("tags", [])
+        if not isinstance(tags, list):
+            tags = []
+        
+        # Add Falco-specific context as labels
+        labels = {
+            "falco_rule": event.get("rule", ""),
+            "falco_priority": priority,
+        }
+        
+        # Add Kubernetes context if available
+        if "k8s.ns.name" in output_fields:
+            labels["k8s_namespace"] = output_fields["k8s.ns.name"]
+        if "k8s.pod.name" in output_fields:
+            labels["k8s_pod"] = output_fields["k8s.pod.name"]
+        if "k8s.node.name" in output_fields:
+            labels["k8s_node"] = output_fields["k8s.node.name"]
+            
+        # Add container context if available
+        if "container.name" in output_fields:
+            labels["container_name"] = output_fields["container.name"]
+        if "container.id" in output_fields:
+            labels["container_id"] = output_fields["container.id"]
+            
+        # Add process context if available
+        if "proc.name" in output_fields:
+            labels["process_name"] = output_fields["proc.name"]
+        if "proc.cmdline" in output_fields:
+            labels["process_cmdline"] = output_fields["proc.cmdline"]
+        if "user.name" in output_fields:
+            labels["user_name"] = output_fields["user.name"]
+
+        # Create unique ID from rule, hostname and timestamp
+        rule = event.get("rule", "Unknown")
+        hostname = event.get("hostname", "unknown")
+        alert_id = f"{rule}:{hostname}:{last_received}"
+
+        alert = AlertDto(
+            id=alert_id,
+            name=rule,
+            description=event.get("output", ""),
+            severity=severity,
+            status=AlertStatus.FIRING,
+            source=["falco"],
+            hostname=hostname,
+            output_fields=output_fields,
+            tags=tags,
+            labels=labels,
+            lastReceived=last_received,
+        )
+
+        return alert
+
+
+if __name__ == "__main__":
+    pass

--- a/keep/providers/servicenow_provider/servicenow_provider.py
+++ b/keep/providers/servicenow_provider/servicenow_provider.py
@@ -5,16 +5,20 @@ ServicenowProvider is a class that implements the BaseProvider interface for Ser
 import os
 import dataclasses
 import json
+from datetime import datetime
+from typing import Optional
 
 import pydantic
 import requests
 from requests.auth import HTTPBasicAuth
 
 from keep.api.models.db.topology import TopologyServiceInDto
+from keep.api.models.incident import IncidentDto, IncidentStatus, IncidentSeverity
 from keep.contextmanager.contextmanager import ContextManager
 from keep.exceptions.provider_exception import ProviderException
-from keep.providers.base.base_provider import BaseTopologyProvider
+from keep.providers.base.base_provider import BaseTopologyProvider, BaseIncidentProvider
 from keep.providers.models.provider_config import ProviderConfig, ProviderScope
+from keep.providers.models.provider_method import ProviderMethod
 from keep.validation.fields import HttpsUrl
 
 
@@ -78,21 +82,61 @@ class ServicenowProviderAuthConfig:
     )
 
 
-class ServicenowProvider(BaseTopologyProvider):
-    """Manage ServiceNow tickets."""
+class ServicenowProvider(BaseTopologyProvider, BaseIncidentProvider):
+    """Manage ServiceNow tickets and incidents with bidirectional activity sync."""
 
-    PROVIDER_CATEGORY = ["Ticketing"]
+    PROVIDER_CATEGORY = ["Ticketing", "Incident Management"]
     PROVIDER_SCOPES = [
         ProviderScope(
             name="itil",
             description="The user can read/write tickets from the table",
             documentation_url="https://docs.servicenow.com/bundle/sandiego-platform-administration/page/administer/roles/reference/r_BaseSystemRoles.html",
             mandatory=True,
-            alias="Read from datahase",
+            alias="Read from database",
         )
     ]
-    PROVIDER_TAGS = ["ticketing"]
+    PROVIDER_TAGS = ["ticketing", "incident"]
     PROVIDER_DISPLAY_NAME = "Service Now"
+    
+    # Mapping ServiceNow incident states to Keep incident statuses
+    STATUS_MAP = {
+        "1": IncidentStatus.FIRING,  # New
+        "2": IncidentStatus.FIRING,  # In Progress
+        "3": IncidentStatus.ACKNOWLEDGED,  # On Hold
+        "6": IncidentStatus.RESOLVED,  # Resolved
+        "7": IncidentStatus.RESOLVED,  # Closed
+        "8": IncidentStatus.RESOLVED,  # Canceled
+    }
+    
+    # Mapping ServiceNow severity to Keep severity
+    SEVERITY_MAP = {
+        "1": IncidentSeverity.CRITICAL,  # Critical
+        "2": IncidentSeverity.HIGH,      # High
+        "3": IncidentSeverity.WARNING,   # Moderate
+        "4": IncidentSeverity.INFO,      # Low
+        "5": IncidentSeverity.INFO,      # Planning
+    }
+    
+    PROVIDER_METHODS = [
+        ProviderMethod(
+            name="sync_incident_activities",
+            func_name="sync_incident_activities",
+            description="Sync activities between ServiceNow and Keep incidents",
+            type="action",
+        ),
+        ProviderMethod(
+            name="pull_servicenow_activities",
+            func_name="_get_incident_activities",
+            description="Pull activities from a ServiceNow incident",
+            type="action",
+        ),
+        ProviderMethod(
+            name="push_activity_to_servicenow",
+            func_name="_add_incident_activity",
+            description="Add an activity to a ServiceNow incident",
+            type="action",
+        ),
+    ]
 
     def __init__(
         self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
@@ -211,6 +255,166 @@ class ServicenowProvider(BaseTopologyProvider):
         self.authentication_config = ServicenowProviderAuthConfig(
             **self.config.authentication
         )
+
+    def _get_auth_and_headers(self):
+        """Get authentication and headers for ServiceNow API requests."""
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        auth = (
+            (
+                self.authentication_config.username,
+                self.authentication_config.password,
+            )
+            if not self._access_token
+            else None
+        )
+        if self._access_token:
+            headers["Authorization"] = f"Bearer {self._access_token}"
+        return auth, headers
+
+    def _get_incidents(self) -> list[IncidentDto]:
+        """
+        Get incidents from ServiceNow and convert them to Keep IncidentDto objects.
+        
+        Returns:
+            list[IncidentDto]: List of incidents from ServiceNow
+        """
+        self.logger.info("Getting incidents from ServiceNow")
+        
+        auth, headers = self._get_auth_and_headers()
+        
+        # Query ServiceNow incident table
+        url = f"{self.authentication_config.service_now_base_url}/api/now/table/incident"
+        
+        # Get active incidents, ordered by most recently updated
+        params = {
+            "sysparm_query": "active=true^ORDERBYDESCsys_updated_on",
+            "sysparm_fields": "sys_id,number,short_description,description,state,impact,urgency,priority,opened_at,resolved_at,closed_at,opened_by,resolved_by,assigned_to,caller_id,sys_created_on,sys_updated_on",
+            "sysparm_limit": 100,
+        }
+        
+        try:
+            response = requests.get(
+                url,
+                auth=auth,
+                headers=headers,
+                params=params,
+                verify=False,
+                timeout=30,
+            )
+            
+            if not response.ok:
+                self.logger.error(
+                    "Failed to get incidents from ServiceNow",
+                    extra={"status_code": response.status_code, "response": response.text},
+                )
+                raise ProviderException(
+                    f"Failed to get incidents from ServiceNow: {response.status_code}"
+                )
+            
+            sn_incidents = response.json().get("result", [])
+            self.logger.info(f"Retrieved {len(sn_incidents)} incidents from ServiceNow")
+            
+            incidents = []
+            for sn_incident in sn_incidents:
+                incident = self._format_incident(sn_incident)
+                if incident:
+                    incidents.append(incident)
+            
+            return incidents
+            
+        except Exception as e:
+            self.logger.exception("Failed to get incidents from ServiceNow")
+            raise ProviderException(f"Failed to get incidents: {str(e)}")
+
+    @staticmethod
+    def _format_incident(sn_incident: dict, provider_instance: "ServicenowProvider" = None) -> IncidentDto:
+        """
+        Format a ServiceNow incident into a Keep IncidentDto.
+        
+        Args:
+            sn_incident: ServiceNow incident data
+            provider_instance: Optional provider instance for additional context
+            
+        Returns:
+            IncidentDto: Formatted incident for Keep
+        """
+        # Parse timestamps
+        def parse_datetime(dt_str):
+            if not dt_str:
+                return None
+            try:
+                # ServiceNow format: 2024-01-15 08:30:00
+                return datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S")
+            except (ValueError, TypeError):
+                try:
+                    return datetime.fromisoformat(dt_str.replace('Z', '+00:00'))
+                except (ValueError, TypeError):
+                    return None
+        
+        # Map ServiceNow state to Keep status
+        state = sn_incident.get("state", "1")
+        status = ServicenowProvider.STATUS_MAP.get(state, IncidentStatus.FIRING)
+        
+        # Map priority/impact to severity
+        impact = sn_incident.get("impact", "3")
+        severity = ServicenowProvider.SEVERITY_MAP.get(impact, IncidentSeverity.INFO)
+        
+        # Generate a UUID from the sys_id
+        import hashlib
+        import uuid
+        md5 = hashlib.md5()
+        md5.update(sn_incident.get("sys_id", "").encode("utf-8"))
+        incident_id = uuid.UUID(md5.hexdigest())
+        
+        # Build description from description field or short description
+        description = sn_incident.get("description", "") or sn_incident.get("short_description", "")
+        
+        # Parse timestamps
+        start_time = parse_datetime(sn_incident.get("opened_at"))
+        end_time = parse_datetime(sn_incident.get("resolved_at") or sn_incident.get("closed_at"))
+        
+        # Get assignee
+        assignee = None
+        assigned_to = sn_incident.get("assigned_to")
+        if assigned_to and isinstance(assigned_to, dict):
+            assignee = assigned_to.get("display_value") or assigned_to.get("value")
+        elif assigned_to:
+            assignee = assigned_to
+        
+        # Get caller/reporter
+        reporter = None
+        caller = sn_incident.get("caller_id")
+        if caller and isinstance(caller, dict):
+            reporter = caller.get("display_value") or caller.get("value")
+        elif caller:
+            reporter = caller
+        
+        incident_dto = IncidentDto(
+            id=incident_id,
+            user_generated_name=sn_incident.get("short_description", "ServiceNow Incident"),
+            user_summary=description,
+            assignee=assignee,
+            severity=severity,
+            status=status,
+            creation_time=start_time or datetime.utcnow(),
+            start_time=start_time,
+            end_time=end_time,
+            is_predicted=False,
+            is_candidate=False,
+            alert_sources=["servicenow"],
+            services=["servicenow"],
+            fingerprint=sn_incident.get("number", sn_incident.get("sys_id")),
+        )
+        
+        # Store ServiceNow-specific data for later use (activity sync, etc.)
+        incident_dto._servicenow_data = {
+            "sys_id": sn_incident.get("sys_id"),
+            "number": sn_incident.get("number"),
+            "state": state,
+            "reporter": reporter,
+        }
+        
+        return incident_dto
 
     def _query(
         self,
@@ -558,17 +762,7 @@ class ServicenowProvider(BaseTopologyProvider):
         Returns:
             list[dict]: List of activity entries with author, timestamp, and content
         """
-        headers = {"Content-Type": "application/json", "Accept": "application/json"}
-        auth = (
-            (
-                self.authentication_config.username,
-                self.authentication_config.password,
-            )
-            if not self._access_token
-            else None
-        )
-        if self._access_token:
-            headers["Authorization"] = f"Bearer {self._access_token}"
+        auth, headers = self._get_auth_and_headers()
 
         # Query sys_journal_field table for work notes and comments
         # This is where ServiceNow stores journal entries
@@ -635,17 +829,7 @@ class ServicenowProvider(BaseTopologyProvider):
         Returns:
             dict: The created activity details
         """
-        headers = {"Content-Type": "application/json", "Accept": "application/json"}
-        auth = (
-            (
-                self.authentication_config.username,
-                self.authentication_config.password,
-            )
-            if not self._access_token
-            else None
-        )
-        if self._access_token:
-            headers["Authorization"] = f"Bearer {self._access_token}"
+        auth, headers = self._get_auth_and_headers()
 
         # Map activity type to ServiceNow field
         field_name = "work_notes" if activity_type == "work_notes" else "comments"
@@ -690,64 +874,101 @@ class ServicenowProvider(BaseTopologyProvider):
 
     def sync_incident_activities(
         self, 
-        incident_id: str, 
-        keep_activities: list[dict] = None
-    ) -> tuple[list[dict], list[dict]]:
+        servicenow_incident_id: str, 
+        keep_activities: list[dict] = None,
+        sync_to_servicenow: bool = True,
+        sync_from_servicenow: bool = True,
+    ) -> dict:
         """
-        Sync activities between ServiceNow and Keep.
-        Pulls activities from ServiceNow and optionally pushes Keep activities to ServiceNow.
+        Sync activities between ServiceNow and Keep incidents bidirectionally.
+        
+        This method pulls activities from ServiceNow and pushes Keep activities to ServiceNow,
+        enabling bidirectional synchronization of incident comments and work notes.
         
         Args:
-            incident_id (str): The ServiceNow incident ID
-            keep_activities (list[dict], optional): Activities from Keep to push to ServiceNow
+            servicenow_incident_id (str): The ServiceNow incident sys_id
+            keep_activities (list[dict], optional): Activities from Keep to push to ServiceNow.
+                Each activity should have: content (str), type (str, optional - "work_notes" or "comments")
+            sync_to_servicenow (bool): Whether to push Keep activities to ServiceNow (default: True)
+            sync_from_servicenow (bool): Whether to pull ServiceNow activities (default: True)
             
         Returns:
-            tuple[list[dict], list[dict]]: (servicenow_activities, synced_activities)
+            dict: Sync result containing:
+                - servicenow_activities: List of activities from ServiceNow
+                - synced_to_servicenow: List of activities pushed to ServiceNow with status
+                - sync_status: "success" or "partial" or "failed"
         """
         self.logger.info(
-            "Starting incident activity sync",
-            extra={"incident_id": incident_id, "keep_activities_count": len(keep_activities) if keep_activities else 0},
-        )
-        
-        # Pull activities from ServiceNow
-        sn_activities = self._get_incident_activities(incident_id)
-        
-        # Push Keep activities to ServiceNow if provided
-        synced_activities = []
-        if keep_activities:
-            for activity in keep_activities:
-                try:
-                    result = self._add_incident_activity(
-                        incident_id=incident_id,
-                        content=activity.get("content", ""),
-                        activity_type=activity.get("type", "work_notes"),
-                    )
-                    synced_activities.append({
-                        "keep_activity": activity,
-                        "servicenow_result": result,
-                        "status": "success",
-                    })
-                except Exception as e:
-                    self.logger.error(
-                        "Failed to sync activity to ServiceNow",
-                        extra={"activity": activity, "error": str(e)},
-                    )
-                    synced_activities.append({
-                        "keep_activity": activity,
-                        "status": "failed",
-                        "error": str(e),
-                    })
-        
-        self.logger.info(
-            "Incident activity sync completed",
+            "Starting bidirectional incident activity sync",
             extra={
-                "incident_id": incident_id,
-                "servicenow_activities_count": len(sn_activities),
-                "synced_activities_count": len(synced_activities),
+                "servicenow_incident_id": servicenow_incident_id, 
+                "keep_activities_count": len(keep_activities) if keep_activities else 0,
+                "sync_to_servicenow": sync_to_servicenow,
+                "sync_from_servicenow": sync_from_servicenow,
             },
         )
         
-        return sn_activities, synced_activities
+        result = {
+            "servicenow_activities": [],
+            "synced_to_servicenow": [],
+            "sync_status": "success",
+        }
+        
+        try:
+            # Pull activities from ServiceNow
+            if sync_from_servicenow:
+                result["servicenow_activities"] = self._get_incident_activities(servicenow_incident_id)
+            
+            # Push Keep activities to ServiceNow
+            if sync_to_servicenow and keep_activities:
+                for activity in keep_activities:
+                    try:
+                        sync_result = self._add_incident_activity(
+                            incident_id=servicenow_incident_id,
+                            content=activity.get("content", ""),
+                            activity_type=activity.get("type", "work_notes"),
+                        )
+                        result["synced_to_servicenow"].append({
+                            "keep_activity": activity,
+                            "servicenow_result": sync_result,
+                            "status": "success",
+                        })
+                    except Exception as e:
+                        self.logger.error(
+                            "Failed to sync activity to ServiceNow",
+                            extra={"activity": activity, "error": str(e)},
+                        )
+                        result["synced_to_servicenow"].append({
+                            "keep_activity": activity,
+                            "status": "failed",
+                            "error": str(e),
+                        })
+                        result["sync_status"] = "partial"
+            
+            # Check if any sync to ServiceNow failed
+            if result["sync_status"] != "partial" and keep_activities:
+                failed_count = sum(1 for s in result["synced_to_servicenow"] if s["status"] == "failed")
+                if failed_count == len(keep_activities) and len(keep_activities) > 0:
+                    result["sync_status"] = "failed"
+                elif failed_count > 0:
+                    result["sync_status"] = "partial"
+                    
+        except Exception as e:
+            self.logger.exception("Incident activity sync failed")
+            result["sync_status"] = "failed"
+            result["error"] = str(e)
+        
+        self.logger.info(
+            "Bidirectional incident activity sync completed",
+            extra={
+                "servicenow_incident_id": servicenow_incident_id,
+                "servicenow_activities_count": len(result["servicenow_activities"]),
+                "synced_count": len(result["synced_to_servicenow"]),
+                "sync_status": result["sync_status"],
+            },
+        )
+        
+        return result
 
 
 if __name__ == "__main__":

--- a/keep/providers/skywalking_provider/__init__.py
+++ b/keep/providers/skywalking_provider/__init__.py
@@ -1,0 +1,1 @@
+from .skywalking_provider import SkywalkingProvider

--- a/keep/providers/skywalking_provider/skywalking_provider.py
+++ b/keep/providers/skywalking_provider/skywalking_provider.py
@@ -1,0 +1,155 @@
+"""
+Apache SkyWalking Provider is a class that allows to ingest/digest data from SkyWalking.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.base.base_provider import BaseProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SkywalkingProvider(BaseProvider):
+    """Receive alerts from Apache SkyWalking via webhook."""
+
+    PROVIDER_DISPLAY_NAME = "Apache SkyWalking"
+    PROVIDER_CATEGORY = ["Monitoring", "APM"]
+    PROVIDER_TAGS = ["alert"]
+    FINGERPRINT_FIELDS = ["id"]
+
+    webhook_description = ""
+    webhook_template = ""
+    webhook_markdown = """
+    To configure SkyWalking to send alerts to Keep:
+
+    1. Edit `alarm-settings.yml` in your SkyWalking OAP server config directory.
+    2. Add a webhook hook configuration:
+
+    ```yaml
+    hooks:
+      webhooks:
+        keep:
+          is-default: true
+          text-template: "Alarm: %s"
+          webhooks:
+            - url: {keep_webhook_api_url}
+              method: POST
+              headers:
+                X-API-KEY: {api_key}
+                Content-Type: application/json
+    ```
+
+    3. Restart the SkyWalking OAP server.
+    4. Configure alert rules to use this webhook hook.
+
+    For more details, see the [SkyWalking Alarm documentation](https://skywalking.apache.org/docs/main/latest/en/setup/backend/backend-alarm/).
+    """
+
+    SEVERITIES_MAP = {
+        "CRITICAL": AlertSeverity.CRITICAL,
+        "HIGH": AlertSeverity.HIGH,
+        "WARNING": AlertSeverity.WARNING,
+        "WARN": AlertSeverity.WARNING,
+        "INFO": AlertSeverity.INFO,
+        "DEBUG": AlertSeverity.INFO,
+    }
+
+    def __init__(
+        self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
+    ):
+        super().__init__(context_manager, provider_id, config)
+
+    def validate_config(self):
+        """
+        No validation required for SkyWalking webhook provider.
+        """
+        pass
+
+    @staticmethod
+    def _format_alert(
+        event: dict, provider_instance: BaseProvider = None
+    ) -> AlertDto | list[AlertDto]:
+        """
+        Format SkyWalking alarm webhook payload into Keep AlertDto.
+        
+        SkyWalking webhook payload format:
+        {
+            "scopeId": 1,
+            "scope": "SERVICE",
+            "name": "service_name",
+            "id0": "c2VydmljZTE=.1",
+            "id1": "",
+            "ruleName": "service_resp_time_rule",
+            "alarmMessage": "Alarm: Service service_name response time is higher than 1000ms in 3 minutes of last 10 minutes.",
+            "tags": [
+                {
+                    "key": "level",
+                    "value": "WARNING"
+                }
+            ],
+            "startTime": 1704067200000
+        }
+        """
+        logger.info(f"Formatting SkyWalking alert: {event}")
+
+        # Extract tags into a dict for easier access
+        tags = {}
+        raw_tags = event.get("tags", [])
+        if isinstance(raw_tags, list):
+            for tag in raw_tags:
+                if isinstance(tag, dict) and "key" in tag and "value" in tag:
+                    tags[tag["key"]] = tag["value"]
+
+        # Determine severity from tags or default to WARNING
+        severity_str = tags.get("level", "WARNING").upper()
+        severity = SkywalkingProvider.SEVERITIES_MAP.get(severity_str, AlertSeverity.WARNING)
+
+        # Parse timestamp (SkyWalking sends milliseconds)
+        start_time_ms = event.get("startTime")
+        if start_time_ms:
+            try:
+                # Convert milliseconds to seconds
+                start_time = datetime.fromtimestamp(start_time_ms / 1000, tz=timezone.utc).isoformat()
+            except (ValueError, TypeError):
+                logger.warning(f"Failed to parse startTime: {start_time_ms}")
+                start_time = datetime.now(timezone.utc).isoformat()
+        else:
+            start_time = datetime.now(timezone.utc).isoformat()
+
+        # Build the alert
+        scope = event.get("scope", "UNKNOWN")
+        name = event.get("name", "Unknown")
+        rule_name = event.get("ruleName", "")
+        alarm_message = event.get("alarmMessage", "")
+
+        # Create alert ID from scope, name and rule
+        alert_id = f"{scope}:{name}:{rule_name}" if rule_name else f"{scope}:{name}"
+
+        alert = AlertDto(
+            id=alert_id,
+            name=rule_name or f"SkyWalking {scope} Alert",
+            description=alarm_message,
+            severity=severity,
+            status=AlertStatus.FIRING,
+            source=["skywalking"],
+            scope=scope,
+            service=name if scope == "SERVICE" else None,
+            endpoint=name if scope == "ENDPOINT" else None,
+            instance=name if scope == "SERVICE_INSTANCE" else None,
+            rule_name=rule_name,
+            scope_id=event.get("scopeId"),
+            entity_id=event.get("id0"),
+            tags=tags,
+            lastReceived=start_time,
+            startedAt=start_time,
+        )
+
+        return alert
+
+
+if __name__ == "__main__":
+    pass

--- a/keep/providers/wechat_provider/__init__.py
+++ b/keep/providers/wechat_provider/__init__.py
@@ -1,0 +1,1 @@
+from .wechat_provider import WechatProvider

--- a/keep/providers/wechat_provider/wechat_provider.py
+++ b/keep/providers/wechat_provider/wechat_provider.py
@@ -1,0 +1,188 @@
+"""
+WechatProvider is a class that implements the BaseOutputProvider interface for WeChat Work (WeCom) messages.
+"""
+
+import dataclasses
+
+import pydantic
+import requests
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.exceptions.provider_exception import ProviderException
+from keep.providers.base.base_provider import BaseProvider
+from keep.providers.models.provider_config import ProviderConfig
+from keep.validation.fields import HttpsUrl
+
+
+@pydantic.dataclasses.dataclass
+class WechatProviderAuthConfig:
+    """WeChat Work authentication configuration."""
+
+    webhook_url: HttpsUrl = dataclasses.field(
+        metadata={
+            "required": True,
+            "description": "WeChat Work Group Bot Webhook URL",
+            "sensitive": True,
+            "validation": "https_url",
+        }
+    )
+
+
+class WechatProvider(BaseProvider):
+    """Send alert message to WeChat Work (WeCom) group chats."""
+
+    PROVIDER_DISPLAY_NAME = "WeChat Work"
+    PROVIDER_CATEGORY = ["Collaboration"]
+    PROVIDER_DESCRIPTION = "Send notifications to WeChat Work (WeCom) group chats via Group Bot webhooks."
+
+    def __init__(
+        self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
+    ):
+        super().__init__(context_manager, provider_id, config)
+
+    def validate_config(self):
+        self.authentication_config = WechatProviderAuthConfig(
+            **self.config.authentication
+        )
+
+    def dispose(self):
+        """
+        No need to dispose of anything, so just do nothing.
+        """
+        pass
+
+    def _build_payload(
+        self,
+        content: str = "",
+        msg_type: str = "text",
+        mentioned_list: list = None,
+        mentioned_mobile_list: list = None,
+        markdown_content: str = "",
+    ) -> dict:
+        """
+        Build the payload for the WeChat Work webhook API.
+        
+        Args:
+            content (str): The content of the message (for text messages).
+            msg_type (str): The type of message - "text" or "markdown".
+            mentioned_list (list): List of userids to mention (@all to mention everyone).
+            mentioned_mobile_list (list): List of mobile numbers to mention.
+            markdown_content (str): Markdown formatted content (for markdown messages).
+            
+        Returns:
+            dict: The payload for the webhook request.
+        """
+        if msg_type == "markdown":
+            payload = {
+                "msgtype": "markdown",
+                "markdown": {
+                    "content": markdown_content or content
+                }
+            }
+        else:
+            payload = {
+                "msgtype": "text",
+                "text": {
+                    "content": content
+                }
+            }
+            
+            if mentioned_list:
+                payload["text"]["mentioned_list"] = mentioned_list
+            if mentioned_mobile_list:
+                payload["text"]["mentioned_mobile_list"] = mentioned_mobile_list
+                
+        return payload
+
+    def _notify(
+        self,
+        content: str = "",
+        msg_type: str = "text",
+        mentioned_list: list = None,
+        mentioned_mobile_list: list = None,
+        markdown_content: str = "",
+        **kwargs: dict
+    ):
+        """
+        Notify alert message to WeChat Work using the Group Bot Webhook API.
+        https://developer.work.weixin.qq.com/document/path/90236
+
+        Args:
+            content (str): The content of the message.
+            msg_type (str): Message type - "text" or "markdown".
+            mentioned_list (list): List of userids to mention (use "@all" to mention everyone).
+            mentioned_mobile_list (list): List of mobile numbers to mention.
+            markdown_content (str): Markdown formatted content (alternative to content).
+        """
+        self.logger.debug("Notifying alert message to WeChat Work")
+        webhook_url = self.authentication_config.webhook_url
+
+        if not content and not markdown_content:
+            raise ProviderException(
+                f"{self.__class__.__name__} requires either 'content' or 'markdown_content' to send a message"
+            )
+
+        # Build the payload
+        payload = self._build_payload(
+            content=content,
+            msg_type=msg_type,
+            mentioned_list=mentioned_list or [],
+            mentioned_mobile_list=mentioned_mobile_list or [],
+            markdown_content=markdown_content,
+        )
+
+        # Send the request
+        response = requests.post(
+            webhook_url,
+            json=payload,
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Check for errors
+        if response.status_code != 200:
+            raise ProviderException(
+                f"{self.__class__.__name__} failed to notify: {response.status_code} - {response.text}"
+            )
+            
+        # WeChat Work returns 200 even for errors, check the errcode
+        try:
+            result = response.json()
+            if result.get("errcode") != 0:
+                raise ProviderException(
+                    f"{self.__class__.__name__} failed to notify: {result.get('errmsg', 'Unknown error')}"
+                )
+        except ValueError:
+            # Response is not JSON
+            pass
+
+        self.logger.debug("Alert message notified to WeChat Work")
+        return result if 'result' in locals() else {"status": "success"}
+
+
+if __name__ == "__main__":
+    # Output debug messages
+    import logging
+
+    logging.basicConfig(level=logging.DEBUG, handlers=[logging.StreamHandler()])
+
+    # Example usage
+    context_manager = ContextManager(tenant_id="test-tenant")
+    config = ProviderConfig(
+        authentication={"webhook_url": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=test-key"}
+    )
+    provider = WechatProvider(context_manager, "wechat-test", config)
+    
+    # Test text message
+    provider._notify(content="Test alert from Keep!")
+    
+    # Test markdown message
+    provider._notify(
+        msg_type="markdown",
+        markdown_content="**Alert**: Service is down!\n> Time: 2024-01-01 12:00:00"
+    )
+    
+    # Test with mentions
+    provider._notify(
+        content="Critical alert! @all",
+        mentioned_list=["@all"]
+    )

--- a/tests/falco_provider_test.py
+++ b/tests/falco_provider_test.py
@@ -1,0 +1,263 @@
+"""
+Tests for the Falco provider.
+"""
+
+import pytest
+from datetime import datetime, timezone
+
+from keep.api.models.alert import AlertSeverity, AlertStatus
+from keep.providers.falco_provider.falco_provider import FalcoProvider
+
+
+class TestFalcoProvider:
+    """Test Falco provider."""
+
+    def test_format_alert_container_shell(self):
+        """Test formatting a container shell execution alert."""
+        event = {
+            "output": "12:34:56.789123789: Notice A shell was spawned in a container with an attached terminal (user=root user_loginuid=-1 k8s.ns=default k8s.pod=myapp-xyz container=abc123 shell=bash parent=docker-entrypoint cmdline=bash terminal=34816 exe_flags=EXE_WRITABLE container_id=abc123 container_image=myapp:latest)",
+            "priority": "Notice",
+            "rule": "Terminal shell in container",
+            "time": "2024-01-15T12:34:56.789123789Z",
+            "output_fields": {
+                "container.id": "abc123",
+                "container.image.repository": "myapp",
+                "container.image.tag": "latest",
+                "container.name": "myapp",
+                "evt.time": 1705325696789123789,
+                "k8s.ns.name": "default",
+                "k8s.pod.name": "myapp-xyz",
+                "proc.cmdline": "bash",
+                "proc.name": "bash",
+                "proc.pname": "docker-entrypoint",
+                "user.loginuid": -1,
+                "user.name": "root"
+            },
+            "hostname": "worker-node-1",
+            "tags": ["container", "shell", "mitre_execution"]
+        }
+
+        alert = FalcoProvider._format_alert(event)
+
+        assert alert.name == "Terminal shell in container"
+        assert alert.description == event["output"]
+        assert alert.severity == AlertSeverity.INFO
+        assert alert.status == AlertStatus.FIRING
+        assert alert.hostname == "worker-node-1"
+        assert alert.source == ["falco"]
+        assert "container" in alert.tags
+        assert "shell" in alert.tags
+        assert alert.labels["k8s_namespace"] == "default"
+        assert alert.labels["k8s_pod"] == "myapp-xyz"
+        assert alert.labels["container_name"] == "myapp"
+        assert alert.labels["process_name"] == "bash"
+        assert alert.labels["user_name"] == "root"
+
+    def test_format_alert_privileged_container(self):
+        """Test formatting a privileged container alert."""
+        event = {
+            "output": "10:20:30.123456789: Critical Privileged container started (user=admin user_loginuid=1000 k8s.ns=production k8s.pod=db-master-0 container=postgres image=postgres:15)",
+            "priority": "Critical",
+            "rule": "Launch Privileged Container",
+            "time": "2024-01-15T10:20:30.123456789Z",
+            "output_fields": {
+                "container.id": "def456",
+                "container.image.repository": "postgres",
+                "container.image.tag": "15",
+                "container.name": "postgres",
+                "k8s.ns.name": "production",
+                "k8s.pod.name": "db-master-0",
+                "user.name": "admin"
+            },
+            "hostname": "worker-node-2",
+            "tags": ["container", "cis", "mitre_privilege_escalation"]
+        }
+
+        alert = FalcoProvider._format_alert(event)
+
+        assert alert.name == "Launch Privileged Container"
+        assert alert.severity == AlertSeverity.CRITICAL
+        assert alert.hostname == "worker-node-2"
+        assert alert.labels["falco_priority"] == "CRITICAL"
+        assert alert.labels["k8s_namespace"] == "production"
+
+    def test_format_alert_suspicious_network(self):
+        """Test formatting a suspicious network connection alert."""
+        event = {
+            "output": "15:45:00.000000000: Error Outbound connection to known C2 server (fd.name=evil.com:443 fd.type=ipv4 fd.sip=1.2.3.4)",
+            "priority": "Error",
+            "rule": "Contact EC2 Instance Metadata Service from Container",
+            "time": "2024-01-15T15:45:00.000000000Z",
+            "output_fields": {
+                "fd.name": "evil.com:443",
+                "fd.sip": "1.2.3.4",
+                "fd.type": "ipv4"
+            },
+            "hostname": "edge-node-1",
+            "tags": ["network", "aws", "metadata_service"]
+        }
+
+        alert = FalcoProvider._format_alert(event)
+
+        assert alert.name == "Contact EC2 Instance Metadata Service from Container"
+        assert alert.severity == AlertSeverity.HIGH
+        assert alert.hostname == "edge-node-1"
+        assert "network" in alert.tags
+
+    def test_format_alert_no_output_fields(self):
+        """Test formatting an alert without output_fields."""
+        event = {
+            "output": "Simple test alert",
+            "priority": "Warning",
+            "rule": "Test Rule",
+            "time": "2024-01-15T08:00:00Z",
+            "hostname": "test-node"
+        }
+
+        alert = FalcoProvider._format_alert(event)
+
+        assert alert.name == "Test Rule"
+        assert alert.severity == AlertSeverity.WARNING
+        assert alert.output_fields == {}
+        assert alert.labels["falco_rule"] == "Test Rule"
+
+    def test_format_alert_no_tags(self):
+        """Test formatting an alert without tags."""
+        event = {
+            "output": "Alert without tags",
+            "priority": "Informational",
+            "rule": "Info Rule",
+            "time": "2024-01-15T08:00:00Z",
+            "hostname": "test-node"
+        }
+
+        alert = FalcoProvider._format_alert(event)
+
+        assert alert.tags == []
+        assert alert.severity == AlertSeverity.INFO
+
+    def test_format_alert_no_timestamp(self):
+        """Test formatting an alert without timestamp."""
+        event = {
+            "output": "Alert without time",
+            "priority": "Emergency",
+            "rule": "Emergency Rule",
+            "hostname": "test-node",
+            "output_fields": {}
+        }
+
+        alert = FalcoProvider._format_alert(event)
+
+        assert alert.lastReceived is not None
+        assert alert.severity == AlertSeverity.CRITICAL
+
+    def test_format_alert_invalid_timestamp(self):
+        """Test formatting an alert with invalid timestamp."""
+        event = {
+            "output": "Alert with bad time",
+            "priority": "Alert",
+            "rule": "Bad Time Rule",
+            "time": "invalid-timestamp",
+            "hostname": "test-node"
+        }
+
+        alert = FalcoProvider._format_alert(event)
+
+        assert alert.lastReceived is not None
+        assert alert.severity == AlertSeverity.CRITICAL
+
+    def test_severity_mapping(self):
+        """Test that all priority levels are mapped correctly."""
+        test_cases = [
+            ("EMERGENCY", AlertSeverity.CRITICAL),
+            ("ALERT", AlertSeverity.CRITICAL),
+            ("CRITICAL", AlertSeverity.CRITICAL),
+            ("ERROR", AlertSeverity.HIGH),
+            ("WARNING", AlertSeverity.WARNING),
+            ("WARN", AlertSeverity.WARNING),
+            ("NOTICE", AlertSeverity.INFO),
+            ("INFORMATIONAL", AlertSeverity.INFO),
+            ("DEBUG", AlertSeverity.INFO),
+            ("UNKNOWN", AlertSeverity.INFO),  # Default
+        ]
+
+        for priority, expected_severity in test_cases:
+            event = {
+                "output": f"Test alert with {priority}",
+                "priority": priority,
+                "rule": "Test Rule",
+                "time": "2024-01-15T08:00:00Z",
+                "hostname": "test-node"
+            }
+
+            alert = FalcoProvider._format_alert(event)
+            assert alert.severity == expected_severity, f"Failed for priority: {priority}"
+
+    def test_format_alert_kubernetes_context(self):
+        """Test that Kubernetes context is properly extracted."""
+        event = {
+            "output": "Kubernetes event",
+            "priority": "Warning",
+            "rule": "K8s Rule",
+            "time": "2024-01-15T08:00:00Z",
+            "output_fields": {
+                "k8s.ns.name": "kube-system",
+                "k8s.pod.name": "coredns-123",
+                "k8s.node.name": "master-1",
+                "k8s.deployment.name": "coredns"
+            },
+            "hostname": "k8s-node"
+        }
+
+        alert = FalcoProvider._format_alert(event)
+
+        assert alert.labels["k8s_namespace"] == "kube-system"
+        assert alert.labels["k8s_pod"] == "coredns-123"
+        assert alert.labels["k8s_node"] == "master-1"
+
+    def test_format_alert_process_context(self):
+        """Test that process context is properly extracted."""
+        event = {
+            "output": "Process event",
+            "priority": "Notice",
+            "rule": "Process Rule",
+            "time": "2024-01-15T08:00:00Z",
+            "output_fields": {
+                "proc.name": "curl",
+                "proc.cmdline": "curl -X POST https://example.com",
+                "user.name": "www-data"
+            },
+            "hostname": "app-server"
+        }
+
+        alert = FalcoProvider._format_alert(event)
+
+        assert alert.labels["process_name"] == "curl"
+        assert alert.labels["process_cmdline"] == "curl -X POST https://example.com"
+        assert alert.labels["user_name"] == "www-data"
+
+    def test_alert_id_uniqueness(self):
+        """Test that alert IDs are unique based on rule, hostname and timestamp."""
+        event1 = {
+            "output": "Alert 1",
+            "priority": "Warning",
+            "rule": "Test Rule",
+            "time": "2024-01-15T08:00:00Z",
+            "hostname": "node-1"
+        }
+        event2 = {
+            "output": "Alert 2",
+            "priority": "Warning",
+            "rule": "Test Rule",
+            "time": "2024-01-15T08:00:01Z",  # Different timestamp
+            "hostname": "node-1"
+        }
+
+        alert1 = FalcoProvider._format_alert(event1)
+        alert2 = FalcoProvider._format_alert(event2)
+
+        assert alert1.id != alert2.id
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/skywalking_provider_test.py
+++ b/tests/skywalking_provider_test.py
@@ -1,0 +1,210 @@
+"""
+Tests for the SkyWalking provider.
+"""
+
+import pytest
+from datetime import datetime, timezone
+
+from keep.api.models.alert import AlertSeverity, AlertStatus
+from keep.providers.skywalking_provider.skywalking_provider import SkywalkingProvider
+
+
+class TestSkywalkingProvider:
+    """Test SkyWalking provider."""
+
+    def test_format_alert_service_scope(self):
+        """Test formatting a service-level alert."""
+        event = {
+            "scopeId": 1,
+            "scope": "SERVICE",
+            "name": "order-service",
+            "id0": "c2VydmljZTE=.1",
+            "id1": "",
+            "ruleName": "service_resp_time_rule",
+            "alarmMessage": "Alarm: Service order-service response time is higher than 1000ms in 3 minutes of last 10 minutes.",
+            "tags": [
+                {"key": "level", "value": "WARNING"}
+            ],
+            "startTime": 1704067200000
+        }
+
+        alert = SkywalkingProvider._format_alert(event)
+
+        assert alert.id == "SERVICE:order-service:service_resp_time_rule"
+        assert alert.name == "service_resp_time_rule"
+        assert alert.scope == "SERVICE"
+        assert alert.service == "order-service"
+        assert alert.severity == AlertSeverity.WARNING
+        assert alert.status == AlertStatus.FIRING
+        assert "order-service" in alert.description
+        assert alert.tags == {"level": "WARNING"}
+
+    def test_format_alert_endpoint_scope(self):
+        """Test formatting an endpoint-level alert."""
+        event = {
+            "scopeId": 2,
+            "scope": "ENDPOINT",
+            "name": "/api/orders",
+            "id0": "c2VydmljZTE=.1_L3VzZXI=",
+            "id1": "",
+            "ruleName": "endpoint_percent_rule",
+            "alarmMessage": "Alarm: Successful rate of endpoint /api/orders is lower than 75%",
+            "tags": [
+                {"key": "level", "value": "CRITICAL"}
+            ],
+            "startTime": 1704067200000
+        }
+
+        alert = SkywalkingProvider._format_alert(event)
+
+        assert alert.scope == "ENDPOINT"
+        assert alert.endpoint == "/api/orders"
+        assert alert.service is None
+        assert alert.severity == AlertSeverity.CRITICAL
+
+    def test_format_alert_instance_scope(self):
+        """Test formatting a service instance-level alert."""
+        event = {
+            "scopeId": 3,
+            "scope": "SERVICE_INSTANCE",
+            "name": "order-service-01",
+            "id0": "c2VydmljZTE=.1_MQ==",
+            "id1": "",
+            "ruleName": "instance_jvm_memory_rule",
+            "alarmMessage": "Alarm: Service Instance order-service-01 JVM memory usage is higher than 80%",
+            "tags": [
+                {"key": "level", "value": "HIGH"}
+            ],
+            "startTime": 1704067200000
+        }
+
+        alert = SkywalkingProvider._format_alert(event)
+
+        assert alert.scope == "SERVICE_INSTANCE"
+        assert alert.instance == "order-service-01"
+        assert alert.severity == AlertSeverity.HIGH
+
+    def test_format_alert_no_tags(self):
+        """Test formatting an alert without tags."""
+        event = {
+            "scopeId": 1,
+            "scope": "SERVICE",
+            "name": "test-service",
+            "id0": "test-id",
+            "id1": "",
+            "ruleName": "test_rule",
+            "alarmMessage": "Test alarm message",
+            "startTime": 1704067200000
+        }
+
+        alert = SkywalkingProvider._format_alert(event)
+
+        assert alert.severity == AlertSeverity.WARNING  # Default severity
+        assert alert.tags == {}
+
+    def test_format_alert_no_rule_name(self):
+        """Test formatting an alert without a rule name."""
+        event = {
+            "scopeId": 1,
+            "scope": "SERVICE",
+            "name": "test-service",
+            "id0": "test-id",
+            "id1": "",
+            "alarmMessage": "Test alarm message",
+            "tags": [],
+            "startTime": 1704067200000
+        }
+
+        alert = SkywalkingProvider._format_alert(event)
+
+        assert alert.id == "SERVICE:test-service"
+        assert alert.name == "SkyWalking SERVICE Alert"
+
+    def test_format_alert_invalid_timestamp(self):
+        """Test formatting an alert with invalid timestamp."""
+        event = {
+            "scopeId": 1,
+            "scope": "SERVICE",
+            "name": "test-service",
+            "id0": "test-id",
+            "alarmMessage": "Test alarm",
+            "startTime": "invalid",
+            "tags": []
+        }
+
+        alert = SkywalkingProvider._format_alert(event)
+
+        # Should still create alert with current time
+        assert alert.lastReceived is not None
+        assert alert.startedAt is not None
+
+    def test_format_alert_no_timestamp(self):
+        """Test formatting an alert without timestamp."""
+        event = {
+            "scopeId": 1,
+            "scope": "SERVICE",
+            "name": "test-service",
+            "id0": "test-id",
+            "alarmMessage": "Test alarm",
+            "tags": []
+        }
+
+        alert = SkywalkingProvider._format_alert(event)
+
+        assert alert.lastReceived is not None
+        assert alert.startedAt is not None
+
+    def test_severity_mapping(self):
+        """Test that all severity levels are mapped correctly."""
+        test_cases = [
+            ("CRITICAL", AlertSeverity.CRITICAL),
+            ("HIGH", AlertSeverity.HIGH),
+            ("WARNING", AlertSeverity.WARNING),
+            ("WARN", AlertSeverity.WARNING),
+            ("INFO", AlertSeverity.INFO),
+            ("DEBUG", AlertSeverity.INFO),
+            ("UNKNOWN", AlertSeverity.WARNING),  # Default
+        ]
+
+        for level, expected_severity in test_cases:
+            event = {
+                "scopeId": 1,
+                "scope": "SERVICE",
+                "name": "test",
+                "alarmMessage": "Test",
+                "tags": [{"key": "level", "value": level}],
+                "startTime": 1704067200000
+            }
+
+            alert = SkywalkingProvider._format_alert(event)
+            assert alert.severity == expected_severity, f"Failed for level: {level}"
+
+    def test_format_alert_multiple_tags(self):
+        """Test formatting an alert with multiple tags."""
+        event = {
+            "scopeId": 1,
+            "scope": "SERVICE",
+            "name": "test-service",
+            "id0": "test-id",
+            "ruleName": "test_rule",
+            "alarmMessage": "Test alarm",
+            "tags": [
+                {"key": "level", "value": "CRITICAL"},
+                {"key": "env", "value": "production"},
+                {"key": "team", "value": "platform"}
+            ],
+            "startTime": 1704067200000
+        }
+
+        alert = SkywalkingProvider._format_alert(event)
+
+        assert alert.tags == {
+            "level": "CRITICAL",
+            "env": "production",
+            "team": "platform"
+        }
+        assert alert.severity == AlertSeverity.CRITICAL
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_wechat_provider.py
+++ b/tests/test_wechat_provider.py
@@ -1,0 +1,133 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.models.provider_config import ProviderConfig
+from keep.providers.wechat_provider.wechat_provider import WechatProvider
+
+
+@pytest.fixture
+def wechat_provider():
+    """Create a WeChat provider instance for testing"""
+    context_manager = ContextManager(
+        tenant_id="test-tenant", workflow_id="test-workflow"
+    )
+    config = ProviderConfig(
+        id="wechat-test",
+        description="WeChat Work Output Provider",
+        authentication={"webhook_url": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=test-key"},
+    )
+    return WechatProvider(context_manager, provider_id="wechat-test", config=config)
+
+
+@pytest.fixture
+def mock_response():
+    """Create a mock response for requests.post"""
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"errcode": 0, "errmsg": "ok"}
+    return response
+
+
+@patch("requests.post")
+def test_notify_text_message(mock_post, wechat_provider, mock_response):
+    """Test sending a simple text message"""
+    # Setup mock response
+    mock_post.return_value = mock_response
+
+    # Test simple text message
+    result = wechat_provider._notify(content="Test alert from Keep!")
+    
+    # Verify the request was made
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    
+    # Check the payload
+    assert kwargs["json"]["msgtype"] == "text"
+    assert kwargs["json"]["text"]["content"] == "Test alert from Keep!"
+
+
+@patch("requests.post")
+def test_notify_markdown_message(mock_post, wechat_provider, mock_response):
+    """Test sending a markdown message"""
+    # Setup mock response
+    mock_post.return_value = mock_response
+
+    # Test markdown message
+    result = wechat_provider._notify(
+        msg_type="markdown",
+        markdown_content="**Alert**: Service is down!\n> Time: 2024-01-01 12:00:00"
+    )
+    
+    # Verify the request was made
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    
+    # Check the payload
+    assert kwargs["json"]["msgtype"] == "markdown"
+    assert kwargs["json"]["markdown"]["content"] == "**Alert**: Service is down!\n> Time: 2024-01-01 12:00:00"
+
+
+@patch("requests.post")
+def test_notify_with_mentions(mock_post, wechat_provider, mock_response):
+    """Test sending a message with @all mention"""
+    # Setup mock response
+    mock_post.return_value = mock_response
+
+    # Test with mentions
+    result = wechat_provider._notify(
+        content="Critical alert!",
+        mentioned_list=["@all"]
+    )
+    
+    # Verify the request was made
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    
+    # Check the payload
+    assert kwargs["json"]["msgtype"] == "text"
+    assert kwargs["json"]["text"]["mentioned_list"] == ["@all"]
+
+
+@patch("requests.post")
+def test_notify_with_mobile_mentions(mock_post, wechat_provider, mock_response):
+    """Test sending a message with mobile number mentions"""
+    # Setup mock response
+    mock_post.return_value = mock_response
+
+    # Test with mobile mentions
+    result = wechat_provider._notify(
+        content="Please check this alert!",
+        mentioned_mobile_list=["+8613800138000", "+8613900139000"]
+    )
+    
+    # Verify the request was made
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    
+    # Check the payload
+    assert kwargs["json"]["msgtype"] == "text"
+    assert kwargs["json"]["text"]["mentioned_mobile_list"] == ["+8613800138000", "+8613900139000"]
+
+
+def test_validate_config():
+    """Test configuration validation"""
+    context_manager = ContextManager(tenant_id="test-tenant")
+    
+    # Valid config
+    config = ProviderConfig(
+        authentication={"webhook_url": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=test"}
+    )
+    provider = WechatProvider(context_manager, "wechat-test", config)
+    provider.validate_config()  # Should not raise
+
+
+def test_provider_properties():
+    """Test provider metadata"""
+    context_manager = ContextManager(tenant_id="test-tenant")
+    config = ProviderConfig(authentication={"webhook_url": "https://test.com"})
+    provider = WechatProvider(context_manager, "wechat-test", config)
+    
+    assert provider.PROVIDER_DISPLAY_NAME == "WeChat Work"
+    assert "Collaboration" in provider.PROVIDER_CATEGORY


### PR DESCRIPTION
## Summary

This PR adds a new provider for [Falco](https://falco.org/) - the open-source runtime security engine for containers, Kubernetes, and hosts.

Closes #5024

## Features

- **Webhook-based integration** - Receives security alerts from Falco via Falcosidekick or native HTTP output
- **Full priority support** - Maps all Falco priority levels (Emergency, Alert, Critical, Error, Warning, Notice, Informational, Debug) to Keep severities  
- **Rich context extraction** - Extracts Kubernetes (namespace, pod, node), container (name, ID, image), and process context from Falco output_fields
- **CNCF project support** - Falco is a CNCF incubating project, this expands Keep's cloud-native security coverage

## Implementation Details

- Follows the existing webhook provider pattern (similar to Checkmk, SkyWalking providers)
- Comprehensive test coverage with 10 test cases
- Includes setup documentation for both Falcosidekick and native Falco HTTP output

## Testing

- [x] Provider syntax validated
- [x] Unit tests created for all alert formatting scenarios
- [x] Severity mapping tested for all priority levels
- [x] Kubernetes/container context extraction verified