### PR TITLE
chore: Bump version from 0.48.1 to 0.49.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keep"
-version = "0.48.1"
+version = "0.49.0"
 description = "Alerting. for developers, by developers."
 authors = ["Keep Alerting LTD"]
 packages = [{include = "keep"}]


### PR DESCRIPTION
Closes #5568

## Summary
- Bumps Keep version from 0.48.1 to 0.49.0

## Checks
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed