### PR TITLE
feat: ServiceNow bidirectional incident activity sync

### DIFF
--- a/keep/api/models/action_type.py
+++ b/keep/api/models/action_type.py
@@ -42,4 +42,5 @@ class ActionType(enum.Enum):
     INCIDENT_ENRICH = "Incident enriched"
     INCIDENT_STATUS_CHANGE = "Incident status changed"
     INCIDENT_ASSIGN = "Incident assigned"
-    INCIDENT_UNENRICH = "Incident enriched"
+    INCIDENT_UNENRICH = "Incident un-enriched"
+    INCIDENT_WORK_NOTE = "A work note was added to the incident"

--- a/keep/providers/base/base_provider.py
+++ b/keep/providers/base/base_provider.py
@@ -873,6 +873,9 @@ class BaseIncidentProvider(BaseProvider):
     def get_incidents(self) -> list[IncidentDto]:
         return self._get_incidents()
 
+    def get_incident_activity(self, incident_id: str) -> list[dict]:
+        raise NotImplementedError("get_incident_activity() not implemented")
+
     @staticmethod
     def _format_incident(
         event: dict, provider_instance: "BaseProvider" = None


### PR DESCRIPTION
Closes #3379

Implemented bidirectional activity sync for ServiceNow incidents:
1. Pulls comments and work notes from ServiceNow sys_journal_field and maps them to Keep Incident Audit logs.
2. Pushes Keep incident comments back to ServiceNow.

Changes:
- Added `get_incident_activity` and `comment_incident` to `ServicenowProvider`.
- Added `INCIDENT_WORK_NOTE` to `ActionType`.
- Updated `IncidentBl` to handle activity pulling and bidirectional syncing.