### PR TITLE
feat: improve service name extraction in Cilium provider

### DIFF
--- a/keep/providers/cilium_provider/cilium_provider.py
+++ b/keep/providers/cilium_provider/cilium_provider.py
@@ -54,6 +54,10 @@ class CiliumProvider(BaseTopologyProvider):
             return label.split("=")[1]
         elif label.startswith("k8s:app.kubernetes.io/name="):
             return label.split("=")[1]
+        elif label.startswith("k8s:io.kubernetes.container.name="):
+            return label.split("=")[1]
+        elif label.startswith("k8s:io.cilium.k8s.policy.service-name="):
+            return label.split("=")[1]
 
         return None
 


### PR DESCRIPTION
Fixes #5411

This PR improves how service names are extracted in the Cilium topology map.

Changes:

Added support for extracting names from k8s:io.kubernetes.container.name and k8s:io.cilium.k8s.policy.service-name labels.
Ensures that the topology map shows human-readable service names instead of just IP addresses when the data is available in labels.