### PR TITLE
fix: SQLAlchemy session leak in watcher tasks

### DIFF
--- a/keep/api/bl/dismissal_expiry_bl.py
+++ b/keep/api/bl/dismissal_expiry_bl.py
@@ -145,179 +145,178 @@ class DismissalExpiryBl:
             
             if not expired_enrichments:
                 logger.info("No enrichments with expired dismissals found")
-                return
+            else:
+                logger.info(f"Processing {len(expired_enrichments)} expired dismissal enrichments")
                 
-            logger.info(f"Processing {len(expired_enrichments)} expired dismissal enrichments")
-            
-            # Process each expired enrichment
-            for enrichment in expired_enrichments:
-                logger.info(
-                    f"Processing expired dismissal for fingerprint {enrichment.alert_fingerprint}",
-                    extra={
-                        "tenant_id": enrichment.tenant_id,
-                        "fingerprint": enrichment.alert_fingerprint,
-                        "dismissed_until": enrichment.enrichments.get("dismissedUntil")
-                    }
-                )
-                
-                # Store original values for audit
-                original_dismissed = enrichment.enrichments.get("dismissed", False)
-                original_dismissed_until = enrichment.enrichments.get("dismissedUntil")
-                
-                # Update enrichment - set back to not dismissed
-                new_enrichments = enrichment.enrichments.copy()
-                new_enrichments["dismissed"] = False
-                new_enrichments["dismissUntil"] = None  # Clear the original field
-                
-                # Reset status if it was set to suppressed during dismissal
-                enrichment_status = enrichment.enrichments.get("status")
-                if enrichment_status == "suppressed":
-                    # Remove the suppressed status entirely - let the system use the original alert status
-                    # The AlertDto will get the status from the original alert event data
-                    new_enrichments.pop("status", None)
+                # Process each expired enrichment
+                for enrichment in expired_enrichments:
                     logger.info(
-                        f"Removed suppressed status for fingerprint {enrichment.alert_fingerprint} - will use original alert status",
+                        f"Processing expired dismissal for fingerprint {enrichment.alert_fingerprint}",
                         extra={
                             "tenant_id": enrichment.tenant_id,
                             "fingerprint": enrichment.alert_fingerprint,
-                            "removed_status": enrichment_status
+                            "dismissed_until": enrichment.enrichments.get("dismissedUntil")
                         }
                     )
-                
-                # Clean up ALL disposable fields (use pattern matching instead of hardcoded list)
-                cleaned_fields = []
-                keys_to_remove = []
-                for field_name in new_enrichments.keys():
-                    if field_name.startswith("disposable_"):
-                        keys_to_remove.append(field_name)
-                        cleaned_fields.append(field_name)
-                
-                # Remove the disposable fields
-                for field_name in keys_to_remove:
-                    new_enrichments.pop(field_name)
-                        
-                if cleaned_fields:
-                    logger.info(
-                        f"Cleaned up disposable fields: {cleaned_fields}",
-                        extra={
-                            "tenant_id": enrichment.tenant_id,
-                            "fingerprint": enrichment.alert_fingerprint
-                        }
-                    )
-                
-                # Update the enrichment record
-                enrichment.enrichments = new_enrichments
-                session.add(enrichment)
-                
-                # Add audit trail
-                try:
-                    audit = AlertAudit(
-                        tenant_id=enrichment.tenant_id,
-                        fingerprint=enrichment.alert_fingerprint,
-                        user_id="system",
-                        action=ActionType.DISMISSAL_EXPIRED.value,  # Use .value to get the string
-                        description=(
-                            f"Dismissal expired at {original_dismissed_until}, "
-                            f"enrichment updated from dismissed={original_dismissed} to dismissed=False"
-                        )
-                    )
-                    session.add(audit)
-                    logger.info(
-                        "Added audit trail for expired dismissal",
-                        extra={
-                            "tenant_id": enrichment.tenant_id,
-                            "fingerprint": enrichment.alert_fingerprint
-                        }
-                    )
-                except Exception as e:
-                    logger.error(
-                        f"Failed to add audit trail for fingerprint {enrichment.alert_fingerprint}: {e}",
-                        extra={
-                            "tenant_id": enrichment.tenant_id,
-                            "fingerprint": enrichment.alert_fingerprint
-                        }
-                    )
-                
-                # Update Elasticsearch index
-                try:
-                    # Get the latest alert for this fingerprint to create AlertDto
-                    latest_alert = session.exec(
-                        select(Alert)
-                        .where(Alert.tenant_id == enrichment.tenant_id)
-                        .where(Alert.fingerprint == enrichment.alert_fingerprint)
-                        .order_by(Alert.timestamp.desc())
-                        .limit(1)
-                    ).first()
                     
-                    if latest_alert:
-                        # Create AlertDto with updated enrichments
-                        alert_data = latest_alert.event.copy()
-                        
-                        # Only update specific enrichment fields, don't override alert event data with None values
-                        enrichment_fields = ['dismissed', 'dismissUntil', 'note', 'assignee', 'status']
-                        for field in enrichment_fields:
-                            if field in new_enrichments and new_enrichments[field] is not None:
-                                alert_data[field] = new_enrichments[field]
-                            elif field in new_enrichments and new_enrichments[field] is None and field in ['dismissed', 'dismissUntil']:
-                                # For dismissal fields, None is a valid value (means not dismissed)
-                                alert_data[field] = new_enrichments[field]
-                        
-                        alert_dto = AlertDto(**alert_data)
-                        
-                        elastic_client = ElasticClient(enrichment.tenant_id)
-                        elastic_client.index_alert(alert_dto)
+                    # Store original values for audit
+                    original_dismissed = enrichment.enrichments.get("dismissed", False)
+                    original_dismissed_until = enrichment.enrichments.get("dismissedUntil")
+                    
+                    # Update enrichment - set back to not dismissed
+                    new_enrichments = enrichment.enrichments.copy()
+                    new_enrichments["dismissed"] = False
+                    new_enrichments["dismissUntil"] = None  # Clear the original field
+                    
+                    # Reset status if it was set to suppressed during dismissal
+                    enrichment_status = enrichment.enrichments.get("status")
+                    if enrichment_status == "suppressed":
+                        # Remove the suppressed status entirely - let the system use the original alert status
+                        # The AlertDto will get the status from the original alert event data
+                        new_enrichments.pop("status", None)
                         logger.info(
-                            f"Updated Elasticsearch index for fingerprint {enrichment.alert_fingerprint}",
+                            f"Removed suppressed status for fingerprint {enrichment.alert_fingerprint} - will use original alert status",
                             extra={
                                 "tenant_id": enrichment.tenant_id,
-                                "fingerprint": enrichment.alert_fingerprint
+                                "fingerprint": enrichment.alert_fingerprint,
+                                "removed_status": enrichment_status
                             }
                         )
-                    else:
-                        logger.warning(
-                            f"No alert found for fingerprint {enrichment.alert_fingerprint}, skipping Elasticsearch update",
-                            extra={
-                                "tenant_id": enrichment.tenant_id,
-                                "fingerprint": enrichment.alert_fingerprint
-                            }
-                        )
-                        
-                except Exception as e:
-                    logger.error(
-                        f"Failed to update Elasticsearch for fingerprint {enrichment.alert_fingerprint}: {e}",
-                        extra={
-                            "tenant_id": enrichment.tenant_id,
-                            "fingerprint": enrichment.alert_fingerprint
-                        }
-                    )
-                
-                # Notify UI of change
-                try:
-                    pusher_client = get_pusher_client()
-                    if pusher_client:
-                        pusher_client.trigger(
-                            f"private-{enrichment.tenant_id}",
-                            "alert-update",
-                            {
-                                "fingerprint": enrichment.alert_fingerprint, 
-                                "action": "dismissal_expired"
-                            }
-                        )
+                    
+                    # Clean up ALL disposable fields (use pattern matching instead of hardcoded list)
+                    cleaned_fields = []
+                    keys_to_remove = []
+                    for field_name in new_enrichments.keys():
+                        if field_name.startswith("disposable_"):
+                            keys_to_remove.append(field_name)
+                            cleaned_fields.append(field_name)
+                    
+                    # Remove the disposable fields
+                    for field_name in keys_to_remove:
+                        new_enrichments.pop(field_name)
+                            
+                    if cleaned_fields:
                         logger.info(
-                            f"Sent UI notification for fingerprint {enrichment.alert_fingerprint}",
+                            f"Cleaned up disposable fields: {cleaned_fields}",
                             extra={
                                 "tenant_id": enrichment.tenant_id,
                                 "fingerprint": enrichment.alert_fingerprint
                             }
                         )
-                except Exception as e:
-                    logger.error(
-                        f"Failed to send UI notification for fingerprint {enrichment.alert_fingerprint}: {e}",
-                        extra={
-                            "tenant_id": enrichment.tenant_id,
-                            "fingerprint": enrichment.alert_fingerprint
-                        }
-                    )
+                    
+                    # Update the enrichment record
+                    enrichment.enrichments = new_enrichments
+                    session.add(enrichment)
+                    
+                    # Add audit trail
+                    try:
+                        audit = AlertAudit(
+                            tenant_id=enrichment.tenant_id,
+                            fingerprint=enrichment.alert_fingerprint,
+                            user_id="system",
+                            action=ActionType.DISMISSAL_EXPIRED.value,  # Use .value to get the string
+                            description=(
+                                f"Dismissal expired at {original_dismissed_until}, "
+                                f"enrichment updated from dismissed={original_dismissed} to dismissed=False"
+                            )
+                        )
+                        session.add(audit)
+                        logger.info(
+                            "Added audit trail for expired dismissal",
+                            extra={
+                                "tenant_id": enrichment.tenant_id,
+                                "fingerprint": enrichment.alert_fingerprint
+                            }
+                        )
+                    except Exception as e:
+                        logger.error(
+                            f"Failed to add audit trail for fingerprint {enrichment.alert_fingerprint}: {e}",
+                            extra={
+                                "tenant_id": enrichment.tenant_id,
+                                "fingerprint": enrichment.alert_fingerprint
+                            }
+                        )
+                    
+                    # Update Elasticsearch index
+                    try:
+                        # Get the latest alert for this fingerprint to create AlertDto
+                        latest_alert = session.exec(
+                            select(Alert)
+                            .where(Alert.tenant_id == enrichment.tenant_id)
+                            .where(Alert.fingerprint == enrichment.alert_fingerprint)
+                            .order_by(Alert.timestamp.desc())
+                            .limit(1)
+                        ).first()
+                        
+                        if latest_alert:
+                            # Create AlertDto with updated enrichments
+                            alert_data = latest_alert.event.copy()
+                            
+                            # Only update specific enrichment fields, don't override alert event data with None values
+                            enrichment_fields = ['dismissed', 'dismissUntil', 'note', 'assignee', 'status']
+                            for field in enrichment_fields:
+                                if field in new_enrichments and new_enrichments[field] is not None:
+                                    alert_data[field] = new_enrichments[field]
+                                elif field in new_enrichments and new_enrichments[field] is None and field in ['dismissed', 'dismissUntil']:
+                                    # For dismissal fields, None is a valid value (means not dismissed)
+                                    alert_data[field] = new_enrichments[field]
+                            
+                            alert_dto = AlertDto(**alert_data)
+                            
+                            elastic_client = ElasticClient(enrichment.tenant_id)
+                            elastic_client.index_alert(alert_dto)
+                            logger.info(
+                                f"Updated Elasticsearch index for fingerprint {enrichment.alert_fingerprint}",
+                                extra={
+                                    "tenant_id": enrichment.tenant_id,
+                                    "fingerprint": enrichment.alert_fingerprint
+                                }
+                            )
+                        else:
+                            logger.warning(
+                                f"No alert found for fingerprint {enrichment.alert_fingerprint}, skipping Elasticsearch update",
+                                extra={
+                                    "tenant_id": enrichment.tenant_id,
+                                    "fingerprint": enrichment.alert_fingerprint
+                                }
+                            )
+                            
+                    except Exception as e:
+                        logger.error(
+                            f"Failed to update Elasticsearch for fingerprint {enrichment.alert_fingerprint}: {e}",
+                            extra={
+                                "tenant_id": enrichment.tenant_id,
+                                "fingerprint": enrichment.alert_fingerprint
+                            }
+                        )
+                    
+                    # Notify UI of change
+                    try:
+                        pusher_client = get_pusher_client()
+                        if pusher_client:
+                            pusher_client.trigger(
+                                f"private-{enrichment.tenant_id}",
+                                "alert-update",
+                                {
+                                    "fingerprint": enrichment.alert_fingerprint, 
+                                    "action": "dismissal_expired"
+                                }
+                            )
+                            logger.info(
+                                f"Sent UI notification for fingerprint {enrichment.alert_fingerprint}",
+                                extra={
+                                    "tenant_id": enrichment.tenant_id,
+                                    "fingerprint": enrichment.alert_fingerprint
+                                }
+                            )
+                    except Exception as e:
+                        logger.error(
+                            f"Failed to send UI notification for fingerprint {enrichment.alert_fingerprint}: {e}",
+                            extra={
+                                "tenant_id": enrichment.tenant_id,
+                                "fingerprint": enrichment.alert_fingerprint
+                            }
+                        )
             
             # Commit all changes
             session.commit()


### PR DESCRIPTION
This PR fixes a critical SQLAlchemy session leak in the process_watcher_task arqworker. 

The leak occurred because the recover_strategy (in MaintenanceWindowsBl) and check_dismissal_expiry (in DismissalExpiryBl) tasks performed database queries (which start a transaction) but did not explicitly commit or rollback. This left connections in an "idle in transaction" state, eventually exhausting the connection pool and breaking all workflow scheduling.

Changes:
- Added session.commit() and session.rollback() handling to MaintenanceWindowsBl.recover_strategy.
- Updated DismissalExpiryBl.check_dismissal_expiry to ensure session.commit() is called even when no enrichments are found.

Fixes #5610