### PR TITLE
fix(api): rename /alerts/event/error to /alerts/event-errors

### DIFF
--- a/keep-ui/entities/alerts/model/useAlerts.ts
+++ b/keep-ui/entities/alerts/model/useAlerts.ts
@@ -112,7 +112,7 @@ export const useAlerts = () => {
     options: SWRConfiguration = { revalidateOnFocus: false }
   ) => {
     const { data, error, isLoading, mutate } = useSWR<any>(
-      () => (api.isReady() ? `/alerts/event/error` : null),
+      () => (api.isReady() ? `/alerts/event-errors` : null),
       (url) => api.get(url),
       options
     );
@@ -125,7 +125,7 @@ export const useAlerts = () => {
 
       try {
         const payload = alertId ? { alert_id: alertId } : {};
-        await api.post(`/alerts/event/error/dismiss`, payload);
+        await api.post(`/alerts/event-errors/dismiss`, payload);
         await mutate(); // Refresh the data
         return true;
       } catch (error) {

--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -1359,7 +1359,7 @@ def get_alert_quality(
 
 
 @router.get(
-    "/event/error",
+    "/event-errors",
     description="Get alerts that Keep failed to process",
 )
 def get_error_alerts(
@@ -1397,7 +1397,7 @@ def get_error_alerts(
 
 
 @router.post(
-    "/event/error/dismiss",
+    "/event-errors/dismiss",
     description="Dismiss error alerts. If alert_id is provided, dismisses that specific alert. If no alert_id is provided, dismisses all alerts.",
 )
 def dismiss_error_alerts(


### PR DESCRIPTION
Fixes #5521.

This PR renames the GET endpoint `/alerts/event/error` to `/alerts/event-errors` (and its corresponding dismiss endpoint).

**Problem:**
When using OAuth2-proxy (or similar auth proxies), users often bypass auth for webhook endpoints using a regex like `/alerts/event.*`. Because `/alerts/event/error` starts with the same prefix but is a frontend GET request requiring user authentication, it gets caught in the bypass. This leads to the backend receiving requests without user headers, returning 401/403, and triggering a redirect loop in the UI.

**Solution:**
Renaming the endpoint to `/alerts/event-errors` removes the collision with the webhook ingestion path prefix, allowing auth proxies to correctly distinguish between public webhooks and private API calls.