### PR TITLE
feat: enable LOG_FORMAT configuration for backend access logs

### DIFF
--- a/keep/api/logging.py
+++ b/keep/api/logging.py
@@ -353,9 +353,6 @@ CONFIG = {
             "()": DevTerminalFormatter,
             "format": "%(asctime)s - %(thread)s %(otelTraceID)s %(threadName)s %(levelname)s - %(message)s",
         },
-        "uvicorn_access": {  # Add new formatter for uvicorn.access
-            "format": "%(asctime)s - %(otelTraceID)s - %(threadName)s - %(message)s"
-        },
     },
     "handlers": {
         "default": {
@@ -376,7 +373,9 @@ CONFIG = {
         },
         "uvicorn_access": {  # Add new handler for uvicorn.access
             "class": "logging.StreamHandler",
-            "formatter": "uvicorn_access",
+            "formatter": (
+                "json" if LOG_FORMAT == LOG_FORMAT_OPEN_TELEMETRY else "dev_terminal"
+            ),
         },
     },
     "filters": {  # Add filters section


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5644 <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

Other than the api/backend's `default` and `workflowhandler` logs the access log format could not be configured via the `LOG_FORMAT` environment variable. The result was a mix of log formats when `LOG_FORMAT=open_telemetry` (the default) was used.

With this change the access log output is consistent with the other log output.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
