### PR TITLE
feat(cli): add workflow validate command for CI checks

### DIFF
--- a/docs/cli/commands/cli-workflow.mdx
+++ b/docs/cli/commands/cli-workflow.mdx
@@ -30,8 +30,9 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  apply  Apply a workflow.
-  list   List workflows.
-  run    Run a workflow with a specified ID and fingerprint.
-  runs   Manage workflows executions.
+  apply     Apply a workflow.
+  list      List workflows.
+  run       Run a workflow with a specified ID and fingerprint.
+  runs      Manage workflows executions.
+  validate  Validate workflow YAML files for syntax and Keep workflow...
 ```

--- a/docs/cli/commands/workflow-validate.mdx
+++ b/docs/cli/commands/workflow-validate.mdx
@@ -1,0 +1,49 @@
+---
+sidebarTitle: "keep workflow validate"
+---
+
+Validate one or more workflow files without requiring API credentials.
+
+## Usage
+
+```
+Usage: keep workflow validate [OPTIONS]
+```
+
+## Options
+* `file`:
+  * Type: Path
+  * Default: `none`
+  * Usage: `--file
+-f`
+
+  The workflow YAML file to validate
+
+* `dir`:
+  * Type: Path
+  * Default: `none`
+  * Usage: `--dir
+-d`
+
+  A directory containing workflow YAML files
+
+* `help`:
+  * Type: BOOL
+  * Default: `false`
+  * Usage: `--help`
+
+  Show this message and exit.
+
+
+## CLI Help
+
+```
+Usage: keep workflow validate [OPTIONS]
+
+  Validate workflow YAML files for syntax and Keep workflow schema compatibility.
+
+Options:
+  -f, --file PATH  The workflow YAML file to validate
+  -d, --dir PATH   A directory containing workflow YAML files
+  --help           Show this message and exit.
+```

--- a/tests/test_cli_workflow_validate.py
+++ b/tests/test_cli_workflow_validate.py
@@ -1,0 +1,55 @@
+from click.testing import CliRunner
+
+from keep.cli.cli import cli
+
+
+def _write_valid_workflow(path):
+    path.write_text(
+        """workflow:
+  id: cli-validate-test
+  name: CLI Validate Test
+  triggers:
+    - type: manual
+  steps:
+    - name: console-step
+      provider:
+        type: console
+        with:
+          message: hello
+""",
+        encoding="utf-8",
+    )
+
+
+def test_workflow_validate_single_file_success(tmp_path):
+    workflow_file = tmp_path / "workflow.yml"
+    _write_valid_workflow(workflow_file)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["workflow", "validate", "-f", str(workflow_file)])
+
+    assert result.exit_code == 0
+    assert "Validation summary: 1 passed, 0 failed" in result.output
+
+
+def test_workflow_validate_single_file_failure(tmp_path):
+    workflow_file = tmp_path / "invalid.yml"
+    workflow_file.write_text("workflow: [", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["workflow", "validate", "-f", str(workflow_file)])
+
+    assert result.exit_code == 1
+    assert "Validation summary: 0 passed, 1 failed" in result.output
+
+
+def test_workflow_validate_directory_mixed_results(tmp_path):
+    _write_valid_workflow(tmp_path / "good.yml")
+    (tmp_path / "bad.yaml").write_text("workflow: [", encoding="utf-8")
+    (tmp_path / "ignore.txt").write_text("not a workflow", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["workflow", "validate", "-d", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "Validation summary: 1 passed, 1 failed" in result.output


### PR DESCRIPTION
## Summary
Add a new CLI command keep workflow validate to validate Keep workflow YAML files locally and in CI.

## What's included
- New command: keep workflow validate
- Supports --file/-f for single workflow file validation
- Supports --dir/-d for directory batch validation
- Prints validation summary with passed/failed counts
- Exits with code 1 when any file fails (CI-friendly)
- Works without API key

## Tests
- Added unit tests for:
  - single-file success
  - single-file failure
  - directory mixed results

## Docs
- Added docs page for workflow validate
- Updated workflow CLI docs index

Fixes keephq/keep#3376
Related issue: https://github.com/keephq/keep/issues/3376