### PR TITLE
chore: Bump version from 0.49.0 to 0.49.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keep"
-version = "0.49.0"
+version = "0.49.1"
 description = "Alerting. for developers, by developers."
 authors = ["Keep Alerting LTD"]
 packages = [{include = "keep"}]


### PR DESCRIPTION
Closes #5679

## Summary
- Bumps Keep version from 0.49.0 to 0.49.1

## Checks
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the package version in `pyproject.toml` with no functional code changes.
> 
> **Overview**
> Bumps the Poetry project version in `pyproject.toml` from `0.49.0` to `0.49.1` for the next release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 250e75e957b0c5993b88a2d17b06530c2bb8b75f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->