### PR TITLE
fix: map PagerDuty incidents to urgency instead of priority (#2154)

### DIFF
--- a/keep/providers/pagerduty_provider/pagerduty_provider.py
+++ b/keep/providers/pagerduty_provider/pagerduty_provider.py
@@ -110,11 +110,25 @@ class PagerdutyProvider(
         "warning": AlertSeverity.WARNING,
         "info": AlertSeverity.INFO,
     }
+    URGENCY_TO_ALERT_SEVERITY = {
+        "high": AlertSeverity.HIGH,
+        "low": AlertSeverity.INFO,
+    }
+    URGENCY_TO_INCIDENT_SEVERITY = {
+        "high": IncidentSeverity.HIGH,
+        "low": IncidentSeverity.INFO,
+    }
     INCIDENT_SEVERITIES_MAP = {
         "P1": IncidentSeverity.CRITICAL,
         "P2": IncidentSeverity.HIGH,
         "P3": IncidentSeverity.WARNING,
         "P4": IncidentSeverity.INFO,
+    }
+    PRIORITY_TO_ALERT_SEVERITY = {
+        "P1": AlertSeverity.CRITICAL,
+        "P2": AlertSeverity.HIGH,
+        "P3": AlertSeverity.WARNING,
+        "P4": AlertSeverity.INFO,
     }
     ALERT_STATUS_MAP = {
         "triggered": AlertStatus.FIRING,
@@ -801,8 +815,18 @@ class PagerdutyProvider(
         url = data.pop("self", data.pop("html_url", None))
         # format status and severity to Keep format
         status = PagerdutyProvider.ALERT_STATUS_MAP.get(data.pop("status", "firing"))
+        urgency = data.get("urgency")
         priority_summary = (data.get("priority", {}) or {}).get("summary")
-        priority = PagerdutyProvider.ALERT_SEVERITIES_MAP.get(priority_summary, "P4")
+        if urgency is not None:
+            priority = PagerdutyProvider.URGENCY_TO_ALERT_SEVERITY.get(
+                urgency, AlertSeverity.INFO
+            )
+        elif priority_summary:
+            priority = PagerdutyProvider.PRIORITY_TO_ALERT_SEVERITY.get(
+                priority_summary, AlertSeverity.INFO
+            )
+        else:
+            priority = AlertSeverity.INFO
         last_received = data.pop(
             "created_at", datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
         )
@@ -1139,10 +1163,18 @@ class PagerdutyProvider(
         status = PagerdutyProvider.INCIDENT_STATUS_MAP.get(
             event.get("status", "firing"), IncidentStatus.FIRING
         )
-        priority_summary = (event.get("priority", {}) or {}).get("summary", "P4")
-        severity = PagerdutyProvider.INCIDENT_SEVERITIES_MAP.get(
-            priority_summary, IncidentSeverity.INFO
-        )
+        urgency = event.get("urgency")
+        priority_summary = (event.get("priority", {}) or {}).get("summary")
+        if urgency is not None:
+            severity = PagerdutyProvider.URGENCY_TO_INCIDENT_SEVERITY.get(
+                urgency, IncidentSeverity.INFO
+            )
+        elif priority_summary:
+            severity = PagerdutyProvider.INCIDENT_SEVERITIES_MAP.get(
+                priority_summary, IncidentSeverity.INFO
+            )
+        else:
+            severity = IncidentSeverity.INFO
         service = event.pop("service", {}).get("summary", "unknown")
 
         created_at = event.get("created_at")

--- a/tests/test_pagerduty_provider.py
+++ b/tests/test_pagerduty_provider.py
@@ -14,7 +14,7 @@ class TestPagerdutyProvider(unittest.TestCase):
         formatted_alert = PagerdutyProvider._format_incident({"event": {"data": data}})
 
         self.assertEqual(formatted_alert.name, "PD-Fifth Alert-Q11LATZGWTP02U")
-        self.assertEqual(formatted_alert.severity, IncidentSeverity.WARNING)
+        self.assertEqual(formatted_alert.severity, IncidentSeverity.HIGH)
         self.assertEqual(formatted_alert.status, IncidentStatus.FIRING)
         self.assertEqual(formatted_alert.alert_sources, ["pagerduty"])
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2154

## 📑 Description
Map PagerDuty incident/alert severity in Keep from **urgency** (high/low) instead of **priority** (P1–P4). Urgency is set by PagerDuty from alert severity at ingestion time; priority often cannot be set from monitoring tools (e.g. Alertmanager), so using urgency aligns Keep with how PagerDuty actually derives severity.

- [x] Prefer `urgency` over `priority` in `_format_incident` and `_format_alert_old`
- [x] Add `URGENCY_TO_INCIDENT_SEVERITY` and `URGENCY_TO_ALERT_SEVERITY` (high→HIGH, low→INFO)
- [x] Add `PRIORITY_TO_ALERT_SEVERITY` as fallback when urgency is missing
- [x] Update test to expect severity from urgency (HIGH for `urgency: "high"`) instead of priority (P3→WARNING)

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
- **Behavior change:** For incidents/alerts that have both `urgency` and `priority`, Keep now uses `urgency` to set severity. When `urgency` is absent (e.g. some webhooks or manual incidents), we fall back to `priority` (P1–P4) as before.
- **References:** [PagerDuty Dynamic Notifications – severity & urgency](https://support.pagerduty.com/main/docs/dynamic-notifications#eventalert-severity-levels)
