### PR TITLE
fix: batch_enrich merges enrichments instead of overwriting

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -1366,6 +1366,7 @@ def batch_enrich(
     action_description: str,
     session=None,
     audit_enabled=True,
+    force=False,
 ):
     """
     Batch enrich multiple alerts with the same enrichments in a single transaction.
@@ -1378,8 +1379,8 @@ def batch_enrich(
         action_callee (str): The ID of the user performing the action.
         action_description (str): Description of the action.
         session (Session, optional): Database session to use.
-        force (bool, optional): Whether to override existing enrichments. Defaults to False.
         audit_enabled (bool, optional): Whether to create audit entries. Defaults to True.
+        force (bool, optional): Whether to override existing enrichments. Defaults to False.
 
     Returns:
         List[AlertEnrichment]: List of enriched alert objects.
@@ -1396,7 +1397,6 @@ def batch_enrich(
         }
 
         # Prepare bulk update for existing enrichments
-        to_update = []
         to_create = []
         audit_entries = []
 
@@ -1404,7 +1404,14 @@ def batch_enrich(
             existing = existing_enrichments.get(fingerprint)
 
             if existing:
-                to_update.append(existing.id)
+                # Merge new enrichments with existing ones (unless force=True)
+                if force:
+                    new_enrichment_data = enrichments
+                else:
+                    new_enrichment_data = {**existing.enrichments, **enrichments}
+                # Update the existing enrichment
+                existing.enrichments = new_enrichment_data
+                session.add(existing)
             else:
                 # For new entries
                 to_create.append(
@@ -1425,15 +1432,6 @@ def batch_enrich(
                         description=action_description,
                     )
                 )
-
-        # Bulk update in a single query
-        if to_update:
-            stmt = (
-                update(AlertEnrichment)
-                .where(AlertEnrichment.id.in_(to_update))
-                .values(enrichments=enrichments)
-            )
-            session.execute(stmt)
 
         # Bulk insert new enrichments
         if to_create:


### PR DESCRIPTION
## Summary
Fixes #5692 - batch_enrich was overwriting existing enrichments instead of merging

## Problem
When using the bulk status change feature in the UI, batch_enrich() replaced all existing alert enrichments instead of merging new fields with existing ones. This caused downstream workflows that depend on previously enriched fields (e.g., ticket_id, ticket_url) to fail.

## Solution
- Added force parameter to batch_enrich() (defaults to False)
- When force=False (default): New enrichments are merged with existing ones
- When force=True: Existing enrichments are overwritten (for special cases)
- Changed from bulk SQL update to individual updates to properly merge JSON fields

## Changes
- Modified keep/api/core/db.py: Updated batch_enrich() function
- Added tests/test_batch_enrich_merge.py: New test cases for merge behavior

## Testing
- [x] Logic verified with unit test
- [ ] Integration tests pass (need to run in CI)

Fixes #5692