### PR TITLE
fix(uptimekuma): fix heartbeat loop, datetime TypeError, webhook KeyError

### DIFF
--- a/keep/providers/uptimekuma_provider/uptimekuma_provider.py
+++ b/keep/providers/uptimekuma_provider/uptimekuma_provider.py
@@ -132,18 +132,19 @@ class UptimekumaProvider(BaseProvider):
                     # Single retry
                     api = self._get_api()
                     name = api.get_monitor(monitor_id)["name"]
-            heartbeats.append(
-                AlertDto(
-                    id=heartbeat["id"],
-                    name=name,
-                    monitor_id=heartbeat["monitor_id"],
-                    description=heartbeat["msg"],
-                    status=self.STATUS_MAP.get(heartbeat["status"], "firing"),
-                    lastReceived=self._format_datetime(heartbeat["localDateTime"], heartbeat["timezoneOffset"]),
-                    ping=heartbeat["ping"],
-                    source=["uptimekuma"],
+                # Bug fix: append was outside the loop — only the last monitor was reported
+                heartbeats.append(
+                    AlertDto(
+                        id=heartbeat["id"],
+                        name=name,
+                        monitor_id=heartbeat.get("monitor_id", heartbeat.get("monitorID")),
+                        description=heartbeat["msg"],
+                        status=self.STATUS_MAP.get(heartbeat["status"], AlertStatus.FIRING.value),
+                        lastReceived=self._format_datetime(heartbeat["localDateTime"], heartbeat["timezoneOffset"]),
+                        ping=heartbeat.get("ping"),
+                        source=["uptimekuma"],
+                    )
                 )
-            )
             api.disconnect()
             return heartbeats
         except Exception as e:
@@ -164,22 +165,45 @@ class UptimekumaProvider(BaseProvider):
     def _format_alert(
         cls, event: dict, provider_instance: "BaseProvider" = None
     ) -> AlertDto:
+        monitor = event.get("monitor", {})
+        heartbeat = event.get("heartbeat", {})
+        # Bug fix: original code used hard-coded key access which caused KeyError
+        # crashes when optional fields were absent in some notification types.
         alert = AlertDto(
-            id=event["monitor"]["id"],
-            name=event["monitor"]["name"],
-            monitor_url=event["monitor"]["url"],
-            status=cls.STATUS_MAP.get(event["heartbeat"]["status"], "firing"),
-            description=event["msg"],
-            lastReceived=cls._format_datetime(event["heartbeat"]["localDateTime"], event["heartbeat"]["timezoneOffset"]),
-            msg=event["heartbeat"]["msg"],
+            id=str(monitor.get("id", "")),
+            name=monitor.get("name", "unknown"),
+            monitor_url=monitor.get("url", ""),
+            status=cls.STATUS_MAP.get(
+                heartbeat.get("status"), AlertStatus.FIRING.value
+            ),
+            description=event.get("msg", heartbeat.get("msg", "")),
+            lastReceived=cls._format_datetime(
+                heartbeat.get("localDateTime", ""),
+                heartbeat.get("timezoneOffset", 0),
+            ),
+            msg=heartbeat.get("msg", ""),
             source=["uptimekuma"],
         )
-
         return alert
 
     @staticmethod
-    def _format_datetime(dt, offset):
-        return dt + offset
+    def _format_datetime(dt: str, offset) -> str:
+        """
+        Combine a naive datetime string with a UTC offset.
+
+        UptimeKuma returns ``localDateTime`` as a string like
+        ``"2024-01-15 10:30:00"`` and ``timezoneOffset`` as an integer
+        representing minutes east of UTC (e.g. 60 for UTC+1).
+        The original code did ``dt + offset`` which raises a
+        ``TypeError`` (str + int).
+        """
+        from datetime import datetime, timezone, timedelta
+        try:
+            naive = datetime.strptime(dt, "%Y-%m-%d %H:%M:%S")
+            tz = timezone(timedelta(minutes=int(offset)))
+            return naive.replace(tzinfo=tz).isoformat()
+        except Exception:
+            return str(dt)
 
 if __name__ == "__main__":
     import logging


### PR DESCRIPTION
## Summary

Fixes three critical bugs in the UptimeKuma provider reported in #5655.

## Bugs Fixed

### Bug 1: `heartbeats.append()` outside the `for` loop (only last monitor reported)

The `_get_heartbeats` method looped over all monitors but the `heartbeats.append()` call was **outside** the loop body due to incorrect indentation. This meant only the last monitor in the response was ever added to the list.

```python
# Before (broken)
for key in response:
    heartbeat = response[key][-1]
    name = api.get_monitor(monitor_id)["name"]
heartbeats.append(AlertDto(...))  # ← outside loop!

# After (fixed)
for key in response:
    heartbeat = response[key][-1]
    name = api.get_monitor(monitor_id)["name"]
    heartbeats.append(AlertDto(...))  # ← inside loop ✓
```

### Bug 2: `_format_datetime` raises `TypeError` (string + int)

`localDateTime` is a string (`"2024-01-15 10:30:00"`) and `timezoneOffset` is an integer (minutes). The original `return dt + offset` raised `TypeError: can only concatenate str (not "int") to str`.

Fixed by parsing the datetime string with `strptime`, applying the offset as a `timedelta`, and returning an ISO-8601 string. Falls back to `str(dt)` on unexpected formats.

### Bug 3: `_format_alert` raises `KeyError` on missing webhook fields

`_format_alert` used hard-coded bracket access (`event["monitor"]["id"]` etc.) which crashed with `KeyError` when optional fields were absent in some UptimeKuma notification types.

Replaced all accesses with `.get()` and safe defaults.

## Testing

These fixes address all three bugs described in #5655. The changes are minimal and surgical — no new dependencies, no behaviour changes for well-formed payloads.

Closes #5655