### PR TITLE
fix: properly handle signout for OAUTH2PROXY auth type

### DIFF
--- a/keep-ui/shared/lib/hooks/useSignOut.ts
+++ b/keep-ui/shared/lib/hooks/useSignOut.ts
@@ -5,6 +5,7 @@ import { signOut } from "next-auth/react";
 import * as Sentry from "@sentry/nextjs";
 import posthog from "posthog-js";
 import { useConfig } from "@/utils/hooks/useConfig";
+import { AuthType } from "@/utils/authenticationType";
 
 export function useSignOut() {
   const { data: configData } = useConfig();
@@ -20,6 +21,14 @@ export function useSignOut() {
 
     if (configData?.POSTHOG_DISABLED !== "true") {
       posthog.reset();
+    }
+
+    // For OAUTH2PROXY auth, redirect to oauth2-proxy's sign_out endpoint
+    // This properly clears the oauth2-proxy session cookie and can trigger
+    // OIDC provider logout via the rd parameter or --backend-logout-url
+    if (configData?.AUTH_TYPE === AuthType.OAUTH2PROXY) {
+      window.location.href = "/oauth2/sign_out";
+      return;
     }
 
     signOut();


### PR DESCRIPTION
## Summary

When using `AUTH_TYPE=OAUTH2PROXY`, the signout was not working correctly because it always called NextAuth's `signOut()` function. This only cleared the NextAuth session but left the OAuth2-proxy cookie and OIDC provider SSO session intact, causing users to be immediately auto-logged back in.

Fixes #5713

## Changes

- Added check for `AUTH_TYPE === OAUTH2PROXY` in `useSignOut` hook
- For OAUTH2PROXY, redirect to `/oauth2/sign_out` instead of calling NextAuth `signOut()`
- This allows oauth2-proxy to properly clear its session cookie and trigger OIDC provider logout

## Why this is needed

The oauth2-proxy `/oauth2/sign_out` endpoint:
- Clears the oauth2-proxy session cookie
- Can redirect to OIDC provider logout via `rd` parameter or `--backend-logout-url`
- Ensures complete logout from the SSO session

Without this fix, enterprise deployments using OAuth2-proxy with SSO providers (Zitadel, Keycloak, Okta, etc.) cannot properly log out users - which is a security concern for shared workstations and account switching.

## Test plan

- [ ] Deploy with `AUTH_TYPE=OAUTH2PROXY`
- [ ] Click Sign out
- [ ] Verify redirect to `/oauth2/sign_out`
- [ ] Verify oauth2-proxy cookie is cleared
- [ ] Verify user is not auto-logged back in