### PR TITLE
feat: add custom severity color mapping for alert table

### DIFF
--- a/keep-ui/entities/alerts/model/index.ts
+++ b/keep-ui/entities/alerts/model/index.ts
@@ -4,4 +4,6 @@ export { DEFAULT_ROW_STYLE } from "./constants";
 export { getTabsFromPreset } from "@/entities/alerts/lib/getTabsFromPreset";
 export { useAlertTableTheme } from "@/entities/alerts/model/useAlertTableTheme";
 export { useAlertRowStyle } from "@/entities/alerts/model/useAlertRowStyle";
+export { useSeverityMapping, getMappedColor } from "@/entities/alerts/model/useSeverityMapping";
+export type { SeverityMappingConfig } from "@/entities/alerts/model/useSeverityMapping";
 export { useAlerts } from "./useAlerts";

--- a/keep-ui/entities/alerts/model/useSeverityMapping.ts
+++ b/keep-ui/entities/alerts/model/useSeverityMapping.ts
@@ -1,0 +1,46 @@
+import { useLocalStorage } from "@/utils/hooks/useLocalStorage";
+import { AlertDto } from "./types";
+import { getNestedValue } from "@/shared/lib/object-utils";
+
+export interface SeverityMappingConfig {
+  enabled: boolean;
+  sourceField: string;
+  mappings: Record<string, string>; // value → hex color
+}
+
+const defaultConfig: SeverityMappingConfig = {
+  enabled: false,
+  sourceField: "",
+  mappings: {},
+};
+
+export function useSeverityMapping() {
+  const [severityMapping, setSeverityMapping] =
+    useLocalStorage<SeverityMappingConfig>("severity-mapping", defaultConfig);
+
+  return { severityMapping, setSeverityMapping };
+}
+
+/**
+ * Returns the custom color for an alert based on the mapping config,
+ * or null if no mapping applies.
+ */
+export function getMappedColor(
+  alert: AlertDto,
+  config: SeverityMappingConfig
+): string | null {
+  if (!config.enabled || !config.sourceField) {
+    return null;
+  }
+
+  const value = getNestedValue(alert, config.sourceField);
+  if (value != null) {
+    const stringValue = String(value);
+    const color = config.mappings[stringValue];
+    if (color && color.startsWith("#")) {
+      return color;
+    }
+  }
+
+  return null;
+}

--- a/keep-ui/features/alerts/severity-mapping/index.ts
+++ b/keep-ui/features/alerts/severity-mapping/index.ts
@@ -1,0 +1,2 @@
+export { SeverityMappingSelection } from "./ui/SeverityMappingSelection";
+export { SeverityMappingFacet } from "./ui/SeverityMappingFacet";

--- a/keep-ui/features/alerts/severity-mapping/ui/SeverityMappingFacet.tsx
+++ b/keep-ui/features/alerts/severity-mapping/ui/SeverityMappingFacet.tsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
+import { Button, Text, Title } from "@tremor/react";
+import { SeverityMappingConfig } from "@/entities/alerts/model/useSeverityMapping";
+
+interface SeverityMappingFacetProps {
+  config: SeverityMappingConfig;
+  onCelChange: (cel: string) => void;
+}
+
+export function SeverityMappingFacet({
+  config,
+  onCelChange,
+}: SeverityMappingFacetProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const mappingEntries = Object.entries(config.mappings);
+  const [selected, setSelected] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(mappingEntries.map(([value]) => [value, true]))
+  );
+
+  const exclusivelySelected = (value: string) => {
+    const selectedValues = mappingEntries.filter(([v]) => selected[v]);
+    return selectedValues.length === 1 && selected[value];
+  };
+
+  const buildCel = (newSelected: Record<string, boolean>) => {
+    const unchecked = mappingEntries.filter(([value]) => !newSelected[value]);
+    if (unchecked.length === 0) {
+      return "";
+    }
+    // Filter OUT unchecked values
+    const conditions = unchecked.map(
+      ([value]) => `${config.sourceField} != "${value}"`
+    );
+    return conditions.join(" && ");
+  };
+
+  const toggle = (value: string) => {
+    const newSelected = { ...selected, [value]: !selected[value] };
+    setSelected(newSelected);
+    onCelChange(buildCel(newSelected));
+  };
+
+  const selectOnly = (value: string) => {
+    const newSelected = Object.fromEntries(
+      mappingEntries.map(([v]) => [v, v === value])
+    );
+    setSelected(newSelected);
+    onCelChange(buildCel(newSelected));
+  };
+
+  const selectAll = () => {
+    const newSelected = Object.fromEntries(
+      mappingEntries.map(([v]) => [v, true])
+    );
+    setSelected(newSelected);
+    onCelChange("");
+  };
+
+  if (!config.enabled || mappingEntries.length === 0) {
+    return null;
+  }
+
+  const Icon = isOpen ? ChevronDownIcon : ChevronRightIcon;
+
+  return (
+    <div className="pb-2 border-b border-gray-200">
+      <div
+        className="flex items-center px-2 py-2 cursor-pointer hover:bg-gray-50"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <div className="flex items-center space-x-2">
+          <Icon className="size-5 -m-0.5 text-gray-600" />
+          <Title className="text-sm capitalize">{config.sourceField}</Title>
+        </div>
+      </div>
+
+      {isOpen && (
+        <div>
+          {mappingEntries.map(([value, color]) => {
+            const isChecked = selected[value];
+            const isExclusive = exclusivelySelected(value);
+
+            return (
+              <div
+                key={value}
+                className="flex items-center px-2 py-1 h-7 hover:bg-gray-100 rounded-sm cursor-pointer group"
+                onClick={() => toggle(value)}
+              >
+                <div className="flex items-center min-w-[24px]">
+                  <input
+                    type="checkbox"
+                    readOnly
+                    checked={isChecked}
+                    style={{ accentColor: "#eb6221" }}
+                    className="h-4 w-4 rounded border-gray-300 cursor-pointer"
+                  />
+                </div>
+
+                <div
+                  className="flex-1 flex items-center min-w-0 gap-1"
+                  title={value}
+                >
+                  <div className="flex items-center">
+                    <div
+                      className="w-1 h-4 rounded-lg"
+                      style={{ backgroundColor: color }}
+                    />
+                  </div>
+                  <Text className="truncate flex-1" title={value}>
+                    {value}
+                  </Text>
+                </div>
+
+                <div className="flex-shrink-0 w-8 text-right flex justify-end">
+                  <Button
+                    size="xs"
+                    variant="light"
+                    color="orange"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (isExclusive) {
+                        selectAll();
+                      } else {
+                        selectOnly(value);
+                      }
+                    }}
+                    className="hidden group-hover:block !p-0 !text-xs"
+                  >
+                    {isExclusive ? "All" : "Only"}
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/keep-ui/features/alerts/severity-mapping/ui/SeverityMappingSelection.tsx
+++ b/keep-ui/features/alerts/severity-mapping/ui/SeverityMappingSelection.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { Button, TextInput } from "@tremor/react";
+import {
+  SeverityMappingConfig,
+  useSeverityMapping,
+} from "@/entities/alerts/model/useSeverityMapping";
+import { TrashIcon } from "@heroicons/react/24/outline";
+
+interface MappingEntry {
+  value: string;
+  color: string;
+}
+
+const DEFAULT_COLOR = "#3b82f6";
+
+export function SeverityMappingSelection({
+  onClose,
+}: {
+  onClose?: () => void;
+}) {
+  const { severityMapping, setSeverityMapping } = useSeverityMapping();
+
+  const [enabled, setEnabled] = useState(severityMapping.enabled);
+  const [sourceField, setSourceField] = useState(severityMapping.sourceField);
+  const [entries, setEntries] = useState<MappingEntry[]>(() => {
+    const existing = Object.entries(severityMapping.mappings);
+    return existing.length > 0
+      ? existing.map(([value, color]) => ({ value, color }))
+      : [{ value: "", color: DEFAULT_COLOR }];
+  });
+
+  const addEntry = () => {
+    setEntries([...entries, { value: "", color: DEFAULT_COLOR }]);
+  };
+
+  const removeEntry = (index: number) => {
+    setEntries(entries.filter((_, i) => i !== index));
+  };
+
+  const updateEntryValue = (index: number, value: string) => {
+    const updated = [...entries];
+    updated[index] = { ...updated[index], value };
+    setEntries(updated);
+  };
+
+  const updateEntryColor = (index: number, color: string) => {
+    const updated = [...entries];
+    updated[index] = { ...updated[index], color };
+    setEntries(updated);
+  };
+
+  const handleApply = () => {
+    const mappings: Record<string, string> = {};
+    for (const entry of entries) {
+      if (entry.value.trim()) {
+        mappings[entry.value.trim()] = entry.color;
+      }
+    }
+
+    const config: SeverityMappingConfig = {
+      enabled,
+      sourceField: sourceField.trim(),
+      mappings,
+    };
+
+    setSeverityMapping(config);
+    onClose?.();
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-hidden flex flex-col">
+        <span className="text-gray-400 text-sm mb-2">
+          Map alert field values to custom bar colors
+        </span>
+
+        <label className="flex items-center gap-2 mb-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            className="rounded border-gray-300"
+          />
+          <span className="text-sm">Enable custom severity mapping</span>
+        </label>
+
+        {enabled && (
+          <>
+            <div className="mb-3">
+              <label className="text-sm text-gray-500 mb-1 block">
+                Source field
+              </label>
+              <TextInput
+                placeholder="e.g. priority"
+                value={sourceField}
+                onValueChange={setSourceField}
+              />
+            </div>
+
+            <div className="flex-1 overflow-y-auto">
+              <label className="text-sm text-gray-500 mb-1 block">
+                Value → Color
+              </label>
+              <div className="space-y-2">
+                {entries.map((entry, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <TextInput
+                      className="flex-1"
+                      placeholder="e.g. P1"
+                      value={entry.value}
+                      onValueChange={(v) => updateEntryValue(index, v)}
+                    />
+                    <input
+                      type="color"
+                      value={entry.color}
+                      onChange={(e) => updateEntryColor(index, e.target.value)}
+                      className="w-8 h-8 rounded cursor-pointer border border-gray-300 p-0.5"
+                    />
+                    <button
+                      onClick={() => removeEntry(index)}
+                      className="p-1 text-gray-400 hover:text-red-500"
+                      aria-label="Remove mapping"
+                    >
+                      <TrashIcon className="h-4 w-4" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+
+              <Button
+                variant="light"
+                color="orange"
+                size="xs"
+                className="mt-2"
+                onClick={addEntry}
+              >
+                + Add mapping
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+
+      <Button className="mt-4" color="orange" onClick={handleApply}>
+        Apply
+      </Button>
+    </div>
+  );
+}

--- a/keep-ui/widgets/alerts-table/lib/alert-table-utils.tsx
+++ b/keep-ui/widgets/alerts-table/lib/alert-table-utils.tsx
@@ -41,6 +41,10 @@ import {
   useAlertRowStyle,
 } from "@/entities/alerts/model/useAlertRowStyle";
 import {
+  getMappedColor,
+  useSeverityMapping,
+} from "@/entities/alerts/model/useSeverityMapping";
+import {
   formatDateTime,
   TimeFormatOption,
   isDateTimeColumn,
@@ -233,6 +237,7 @@ export const useAlertTableCols = (
     `column-rename-mapping-${presetName}`,
     {}
   );
+  const { severityMapping: severityMappingConfig } = useSeverityMapping();
 
   const filteredAndGeneratedCols = additionalColsToGenerate.map((colName) =>
     columnHelper.accessor(
@@ -364,11 +369,30 @@ export const useAlertTableCols = (
       id: "severity",
       maxSize: 2,
       header: () => <></>,
-      cell: (context) => (
-        <TableSeverityCell
-          severity={context.row.original.severity as unknown as UISeverity}
-        />
-      ),
+      cell: (context) => {
+        const customColor = getMappedColor(
+          context.row.original,
+          severityMappingConfig
+        );
+        if (customColor) {
+          return (
+            <>
+              <div
+                className="absolute w-1 h-full top-0 left-0"
+                style={{ backgroundColor: customColor }}
+              />
+              <div className="pl-1" />
+            </>
+          );
+        }
+        return (
+          <TableSeverityCell
+            severity={
+              context.row.original.severity as unknown as UISeverity
+            }
+          />
+        );
+      },
       meta: {
         tdClassName: "w-1 !p-0",
         thClassName: "w-1 !p-0",

--- a/keep-ui/widgets/alerts-table/ui/SettingsSelection.tsx
+++ b/keep-ui/widgets/alerts-table/ui/SettingsSelection.tsx
@@ -14,6 +14,7 @@ import { Table } from "@tanstack/table-core";
 import { AlertDto } from "@/entities/alerts/model";
 import ColumnSelection from "./ColumnSelection";
 import { AlertTableThemeSelection } from "@/features/alerts/change-alert-table-theme";
+import { SeverityMappingSelection } from "@/features/alerts/severity-mapping";
 import { RowStyleSelection } from "@/widgets/alerts-table/ui/RowStyleSelection";
 import { ActionTraySelection } from "@/widgets/alerts-table/ui/ActionTraySelection";
 
@@ -77,6 +78,7 @@ export default function SettingsSelection({
                 <TabList className="mb-4">
                   <Tab data-testid="tab-columns">Columns</Tab>
                   <Tab data-testid="tab-theme">Theme</Tab>
+                  <Tab data-testid="tab-severity">Severity</Tab>
                   <Tab data-testid="tab-row-style">Row Style</Tab>
                   <Tab data-testid="tab-action-tray">Action Tray</Tab>
                 </TabList>
@@ -91,6 +93,9 @@ export default function SettingsSelection({
                   </TabPanel>
                   <TabPanel className="h-full" data-testid="panel-theme">
                     <AlertTableThemeSelection onClose={close} />
+                  </TabPanel>
+                  <TabPanel className="h-full" data-testid="panel-severity">
+                    <SeverityMappingSelection onClose={close} />
                   </TabPanel>
                   <TabPanel className="h-full" data-testid="panel-row-style">
                     <RowStyleSelection onClose={close} />

--- a/keep-ui/widgets/alerts-table/ui/alert-table-server-side.tsx
+++ b/keep-ui/widgets/alerts-table/ui/alert-table-server-side.tsx
@@ -64,8 +64,9 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { GrTest } from "react-icons/gr";
 import { PlusIcon } from "@heroicons/react/20/solid";
 import { DynamicImageProviderIcon } from "@/components/ui";
-import { useAlertRowStyle, useAlertTableTheme } from "@/entities/alerts/model";
+import { useAlertRowStyle, useAlertTableTheme, useSeverityMapping } from "@/entities/alerts/model";
 import { useIsShiftKeyHeld } from "@/features/keyboard-shortcuts";
+import { SeverityMappingFacet } from "@/features/alerts/severity-mapping";
 import SettingsSelection from "./SettingsSelection";
 import EnhancedDateRangePickerV2, {
   AllTimeFrame,
@@ -140,6 +141,7 @@ export function AlertTableServerSide({
   );
   const [grouping, setGrouping] = useState<GroupingState>([]);
   const [filterCel, setFilterCel] = useState<string | null>(null);
+  const [mappingCel, setMappingCel] = useState<string>("");
   const [searchCel, setSearchCel] = useState<string | null>(null);
 
   const alertsQueryRef = useRef<AlertsQuery | null>(null);
@@ -177,6 +179,7 @@ export function AlertTableServerSide({
   const { data: configData } = useConfig();
   const noisyAlertsEnabled = configData?.NOISY_ALERTS_ENABLED;
   const { theme } = useAlertTableTheme();
+  const { severityMapping: severityMappingConfig } = useSeverityMapping();
   const [timeFrame, setTimeFrame] = useTimeframeState({
     enableQueryParams: true,
     defaultTimeframe: {
@@ -215,8 +218,11 @@ export function AlertTableServerSide({
       }
 
       if (onQueryChange) {
+        const combinedFilterCel = [filterCel, mappingCel]
+          .filter(Boolean)
+          .join(" && ");
         const query: AlertsTableDataQuery = {
-          filterCel: filterCel,
+          filterCel: combinedFilterCel,
           searchCel: searchCel,
           timeFrame: timeFrame,
           limit: paginationState.limit,
@@ -229,7 +235,7 @@ export function AlertTableServerSide({
         onQueryChange(query);
       }
     },
-    [filterCel, searchCel, paginationState, sorting, timeFrame, onQueryChange]
+    [filterCel, mappingCel, searchCel, paginationState, sorting, timeFrame, onQueryChange]
   );
 
   const [selectedAlert, setSelectedAlert] = useState<AlertDto | null>(null);
@@ -291,7 +297,7 @@ export function AlertTableServerSide({
         ...paginationStateRef.current,
         offset: 0,
       }),
-    [filterCel, searchCel, setPaginationState]
+    [filterCel, mappingCel, searchCel, setPaginationState]
   );
 
   const selectedAlertsFingerprints = Object.keys(table.getState().rowSelection);
@@ -712,6 +718,10 @@ export function AlertTableServerSide({
         <div className="flex gap-4">
           {/* Facets sidebar */}
           <div className="w-33 min-w-[12rem] overflow-y-auto">
+            <SeverityMappingFacet
+              config={severityMappingConfig}
+              onCelChange={setMappingCel}
+            />
             <FacetsPanelServerSide
               usePropertyPathsSuggestions={true}
               entityName={"alerts"}


### PR DESCRIPTION
## Summary
Closes #5719 (reopened from #5720 after fork recreation)

- Add a "Severity" tab in alert table settings to configure custom color mappings
- Users specify a source field (e.g., `priority`) and map its values to colors via color picker
- Mapped colors replace the default severity bar on matching alert rows
- Interactive facet in the sidebar allows filtering by mapped values
- Configuration stored in localStorage, no backend changes

## Test plan
- [x] Open alert table → Settings → "Severity" tab
- [x] Enable mapping, set source field and value-to-color entries, click Apply
- [x] Verify colored bars appear on matching alert rows
- [x] Verify facet in sidebar shows mapped values with colors
- [x] Verify facet checkboxes filter the table
- [x] Verify disabling the mapping restores default severity colors
- [x] Verify no TypeScript or lint errors