### PR TITLE
fix: prevent webpack from inlining AUTH_TYPE at build time

### DIFF
--- a/keep-ui/auth.config.ts
+++ b/keep-ui/auth.config.ts
@@ -23,11 +23,19 @@ export class BackendRefusedError extends AuthError {
   static type = "BackendRefusedError";
 }
 
-const authSessionTimeout = process.env.AUTH_SESSION_TIMEOUT
-  ? Number.parseInt(process.env.AUTH_SESSION_TIMEOUT)
+// Read env vars via bracket notation to prevent webpack DefinePlugin from
+// inlining them as `undefined` at build time.  This file is imported by
+// middleware.ts (Edge Runtime) where DefinePlugin replaces direct
+// `process.env.X` references with their build-time values.
+function runtimeEnv(key: string): string | undefined {
+  return process.env[key];
+}
+
+const authSessionTimeout = runtimeEnv("AUTH_SESSION_TIMEOUT")
+  ? Number.parseInt(runtimeEnv("AUTH_SESSION_TIMEOUT")!)
   : 30 * 24 * 60 * 60; // Default to 30 days if not set
 // Determine auth type with backward compatibility
-const authTypeEnv = process.env.AUTH_TYPE;
+const authTypeEnv = runtimeEnv("AUTH_TYPE");
 export const authType =
   authTypeEnv === MULTI_TENANT
     ? AuthType.AUTH0


### PR DESCRIPTION
## Summary
Closes #5725

`auth.config.ts` is imported by `middleware.ts` (Edge Runtime), causing webpack's DefinePlugin to replace `process.env.AUTH_TYPE` with its build-time value. Since `AUTH_TYPE` is not set during `docker build`, it gets inlined as `undefined`, silently falling back to NOAUTH regardless of the runtime environment variable.

- Add `runtimeEnv()` helper that uses `process.env[key]` (bracket notation), which webpack cannot statically analyze
- Replace direct `process.env.AUTH_TYPE` and `process.env.AUTH_SESSION_TIMEOUT` references with `runtimeEnv()` calls

## Test plan
- [x] Build frontend Docker image without `AUTH_TYPE` set (default)
- [x] Run container with `AUTH_TYPE=OAUTH2PROXY` as runtime env var
- [x] Visit `/api/auth/providers` → should show `"name": "OAuth2Proxy"` (not `"NoAuth"`)
- [x] Verify other auth types (`KEYCLOAK`, `AUTH0`, etc.) also work as runtime env vars