### PR TITLE
fix(icinga2_provider): add missing dispose() abstract method implementation

### DIFF
--- a/keep/providers/icinga2_provider/icinga2_provider.py
+++ b/keep/providers/icinga2_provider/icinga2_provider.py
@@ -115,6 +115,12 @@ To send alerts from Icinga2 to Keep, configure a new notification command:
     ):
         super().__init__(context_manager, provider_id, config)
 
+    def dispose(self):
+        """
+        Dispose of the provider.
+        """
+        pass
+
     def validate_config(self):
         """
         Validates required configuration for Icinga2 provider.


### PR DESCRIPTION
## Summary

Fixes #5730 by implementing the missing `dispose()` abstract method in Icinga2Provider.

## Changes

- Added `dispose()` method to `Icinga2Provider` class
- Follows the same pattern as other providers (e.g., grafana_provider)
- Empty implementation as no cleanup is required for this provider

## Test Plan

- [x] Code follows existing provider patterns
- [x] Provider can be instantiated without abstract method errors

/claim #5730