### PR TITLE
fix(pusher): handle non-numeric PUSHER_APP_ID gracefully

### DIFF
--- a/keep/api/core/dependencies.py
+++ b/keep/api/core/dependencies.py
@@ -66,18 +66,27 @@ def get_pusher_client() -> Pusher | None:
         return None
 
     # TODO: defaults on open source no docker
-    pusher = Pusher(
-        host=pusher_host,
-        port=(
-            int(os.environ.get("PUSHER_PORT"))
-            if os.environ.get("PUSHER_PORT")
-            else None
-        ),
-        app_id=pusher_app_id,
-        key=pusher_app_key,
-        secret=pusher_app_secret,
-        ssl=False if os.environ.get("PUSHER_USE_SSL", False) is False else True,
-        cluster=os.environ.get("PUSHER_CLUSTER"),
-    )
+    try:
+        pusher = Pusher(
+            host=pusher_host,
+            port=(
+                int(os.environ.get("PUSHER_PORT"))
+                if os.environ.get("PUSHER_PORT")
+                else None
+            ),
+            app_id=pusher_app_id,
+            key=pusher_app_key,
+            secret=pusher_app_secret,
+            ssl=False if os.environ.get("PUSHER_USE_SSL", False) is False else True,
+            cluster=os.environ.get("PUSHER_CLUSTER"),
+        )
+    except ValueError:
+        logger.warning(
+            "Pusher client could not be initialized due to invalid configuration "
+            "(PUSHER_APP_ID must be a numeric string). "
+            "Real-time push notifications are disabled.",
+            extra={"pusher_app_id": pusher_app_id},
+        )
+        return None
     logging.debug("Pusher client initialized")
     return pusher


### PR DESCRIPTION
## Summary

Closes #6023.

`get_pusher_client()` did not catch the `ValueError` raised by the Pusher Python SDK when `PUSHER_APP_ID` is a non-numeric string. This caused every alert to fail after being saved to the DB, with a generic "Error processing event" message — giving no indication that Pusher config was the cause.

- Wrap `Pusher()` initialisation in a `try/except ValueError`
- Return `None` with a clear `WARNING` log on invalid config
- Behaviour is now consistent with how missing env vars are handled (also returns `None`)

## Reproduction

Set `PUSHER_APP_ID` to any non-numeric string (e.g. `keep-app`) in a self-hosted Soketi deployment. Soketi accepts the string fine; the Python SDK raises `ValueError: Invalid app id`. Every incoming alert lands in `/alerts/event/error` with the generic message.

## Test plan

- [x] Deployed fix to staging with `PUSHER_APP_ID=keep-app` — alert now processes cleanly, warning log emitted: _"Pusher client could not be initialized due to invalid configuration (PUSHER_APP_ID must be a numeric string). Real-time push notifications are disabled."_
- [x] No new entry in `/alerts/event/error` after alert delivery
- [x] Existing behaviour unchanged when `PUSHER_APP_ID` is unset (returns `None` as before)
- [x] Existing behaviour unchanged when `PUSHER_APP_ID` is a valid numeric string

🤖 Generated with [Claude Code](https://claude.com/claude-code)