### PR TITLE
fix: write KEEP_AZUREAD_TENANT_ID into the tenant table

### DIFF
--- a/ee/identitymanager/identity_managers/azuread/azuread_identitymanager.py
+++ b/ee/identitymanager/identity_managers/azuread/azuread_identitymanager.py
@@ -1,6 +1,9 @@
+import os
+
 from ee.identitymanager.identity_managers.azuread.azuread_authverifier import (
     AzureadAuthVerifier,
 )
+from keep.api.core.db_on_start import try_create_single_tenant
 from keep.api.models.user import User
 from keep.contextmanager.contextmanager import ContextManager
 from keep.identitymanager.identity_managers.db.db_identitymanager import (
@@ -15,6 +18,15 @@ class AzureadIdentityManager(BaseIdentityManager):
         self.db_identity_manager = DbIdentityManager(
             tenant_id, context_manager, **kwargs
         )
+
+    def on_start(self, app) -> None:
+        azuread_tenant_id = os.environ.get("KEEP_AZUREAD_TENANT_ID")
+        if azuread_tenant_id:
+            try_create_single_tenant(azuread_tenant_id, create_default_user=False)
+        else:
+            self.logger.warning(
+                "AUTH_TYPE=azuread but KEEP_AZUREAD_TENANT_ID is not set"
+            )
 
     def get_users(self) -> list[User]:
         # we keep the azuread users in the db


### PR DESCRIPTION
## 📑 Description
When using AUTH_TYPE=azuread, Keep has no row in the tenants table for the Azure AD tenant GUID on a fresh deployment. This causes a redirect loop on the frontend and a 401 in the backend on every request until the row is inserted manually.

This PR fixes that by adding an on_start() hook to AzureadIdentityManager that calls the existing try_create_single_tenant() function with KEEP_AZUREAD_TENANT_ID at startup — the same mechanism already used by other auth types



## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
