### PR TITLE
fix: fall back to RBAC when API key auth lacks Keycloak token

### DIFF
--- a/ee/identitymanager/identity_managers/keycloak/keycloak_authverifier.py
+++ b/ee/identitymanager/identity_managers/keycloak/keycloak_authverifier.py
@@ -346,6 +346,10 @@ class KeycloakAuthVerifier(AuthVerifierBase):
         if self.keycloak_multi_org:
             return super()._authorize(authenticated_entity)
 
+        # API key auth does not carry a Keycloak token; fall back to RBAC
+        if not getattr(authenticated_entity, "token", None):
+            return super()._authorize(authenticated_entity)
+
         # for single tenant Keycloaks, use Keycloak's UMA to authorize
         try:
             permission = UMAPermission(
@@ -369,6 +373,10 @@ class KeycloakAuthVerifier(AuthVerifierBase):
     def authorize_resource(
         self, resource_type, resource_id, authenticated_entity: AuthenticatedEntity
     ) -> None:
+        # API key auth does not carry a Keycloak token; skip per-resource UMA check
+        if not getattr(authenticated_entity, "token", None):
+            return
+
         # use Keycloak's UMA to authorize
         try:
             permission = UMAPermission(


### PR DESCRIPTION
Closes #6089

## 🔖 Description

When `AUTH_TYPE=KEYCLOAK` (single-tenant mode), `KeycloakAuthVerifier._authorize()` unconditionally accesses `authenticated_entity.token` for UMA permission checks. However, API key authentication (`_verify_api_key` in the base class) creates an `AuthenticatedEntity` **without** a `token` field, causing:
`HTTP 403: {"detail": "Permission check failed - 'AuthenticatedEntity' object has no attribute 'token'"}`

This blocks all webhook/API-key integrations (e.g. alert ingestion from Prometheus, Grafana, SLS, etc.) in Keycloak single-tenant deployments.

**Fix:** Add a guard clause in `_authorize()` and `authorize_resource()` to detect API-key-authenticated entities and fall back to base-class RBAC — consistent with the existing `keycloak_multi_org` guard pattern.

- [x] Completed

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ️ Additional Information

- Tested on Keep v0.50.0 with `AUTH_TYPE=KEYCLOAK` (single-tenant)
- API key webhook ingestion (`POST /alerts/event` with `X-API-KEY` header) returns 202 after fix
- Bearer token authentication continues to use UMA as before
- Multi-org mode unaffected (its guard takes priority)
