### PR TITLE
fix: avoid version validation error in grafana provider

### DIFF
--- a/keep/providers/grafana_provider/grafana_provider.py
+++ b/keep/providers/grafana_provider/grafana_provider.py
@@ -7,6 +7,7 @@ import datetime
 import hashlib
 import json
 import logging
+import re
 import time
 
 import pydantic
@@ -397,7 +398,12 @@ class GrafanaProvider(BaseTopologyProvider, ProviderHealthMixin):
         return [alert_dto]
 
     def _get_grafana_version(self) -> str:
-        """Get the Grafana version."""
+        """Get the Grafana version (PEP 440-compatible for comparison).
+
+        Grafana Cloud/Enterprise returns versions like '13.0.0-22843068776.patch2'
+        which packaging.version.Version cannot parse. We extract the base
+        semantic version (e.g. '13.0.0') before returning.
+        """
         try:
             headers = {"Authorization": f"Bearer {self.authentication_config.token}"}
             health_url = f"{self.authentication_config.host}/api/health"
@@ -406,7 +412,11 @@ class GrafanaProvider(BaseTopologyProvider, ProviderHealthMixin):
 
             if resp.ok:
                 health_data = resp.json()
-                return health_data.get("version", "unknown")
+                raw_version = health_data.get("version", "unknown")
+                if not raw_version or raw_version == "unknown":
+                    return "0.0.0"
+                match = re.match(r"^(\d+\.\d+(?:\.\d+)?)", raw_version)
+                return match.group(1) if match else "0.0.0"
             else:
                 self.logger.warning(
                     f"Failed to get Grafana version: {resp.status_code}"


### PR DESCRIPTION
Closes #6103 

### 📑 Description

This pull requests avoids version validation issues in grafana enterprise by parsing the version before using it in a comparison latter. The goal is to avoid the following problem when installing the grafana provider with grafana version `13.0.0-22843068776.patch2`:

<img width="495" height="153" alt="image" src="https://github.com/user-attachments/assets/7c506ee3-1d73-4c91-9a37-38a4253da75f" />


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

### ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
