### PR TITLE
feat: enhance GitHub Workflows provider with alert pulling and webhook support

### DIFF
--- a/keep/providers/github_workflows_provider/README.md
+++ b/keep/providers/github_workflows_provider/README.md
@@ -1,0 +1,103 @@
+# GitHub Workflows Provider
+
+## Overview
+
+The **GitHub Workflows** provider monitors GitHub Actions workflow runs and surfaces failures (and other non-success conclusions) as alerts in Keep.
+
+It supports **two modes**:
+
+| Mode | How it works |
+|------|-------------|
+| **Pull (polling)** | Keep periodically calls the GitHub Actions API to fetch recent completed workflow runs and raises alerts for non-success conclusions |
+| **Push (webhook)** | GitHub sends `workflow_run` webhook events to Keep, and the provider converts them into alerts |
+
+## Authentication
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `personal_access_token` | Yes | GitHub Personal Access Token (classic or fine-grained) with `actions:read` scope |
+| `repositories` | Yes | Comma-separated list of repositories to monitor (e.g. `owner/repo1, owner/repo2`) |
+| `api_url` | No | GitHub API base URL. Defaults to `https://api.github.com`. Set to `https://your-ghes.example.com/api/v3` for GitHub Enterprise Server |
+
+### Creating a PAT
+
+1. Go to **Settings → Developer Settings → Personal Access Tokens → Fine-grained tokens**
+2. Click **Generate new token**
+3. Under **Repository access**, select the repositories you want to monitor
+4. Under **Permissions → Repository permissions**, grant **Actions: Read-only**
+5. Click **Generate token** and copy it
+
+## Alert Mapping
+
+### Severity
+
+| Workflow Conclusion | Alert Severity |
+|--------------------|---------------|
+| `failure` | Critical |
+| `startup_failure` | Critical |
+| `timed_out` | High |
+| `cancelled` | Warning |
+| `action_required` | Info |
+| `success` | Info |
+
+### Status
+
+| Workflow Conclusion | Alert Status |
+|--------------------|-------------|
+| `failure`, `cancelled`, `timed_out`, `startup_failure` | Firing |
+| `action_required` | Pending |
+| `success` | Resolved |
+
+## Webhook Setup
+
+To receive real-time alerts via webhooks:
+
+1. Go to your repository's **Settings → Webhooks → Add webhook**
+2. Set the **Payload URL** to your Keep webhook endpoint: `https://your-keep-instance/alerts/event/github_workflows`
+3. Set **Content type** to `application/json`
+4. Under **Which events would you like to trigger this webhook?**, select **Let me select individual events**
+5. Check **Workflow runs**
+6. Click **Add webhook**
+
+## Notify (Workflow Dispatch)
+
+The provider also supports triggering workflows via the `_notify()` method:
+
+```python
+# Dispatch a workflow
+provider.notify(
+    workflow_id="build.yml",
+    ref="main",
+    inputs={"deploy_env": "staging"}
+)
+```
+
+## Fingerprinting
+
+Alerts use the following fingerprint format:
+```
+github-workflow-{owner/repo}-{run_id}
+```
+
+This ensures each workflow run produces a unique, trackable alert.
+
+## Example Alert Labels
+
+Each alert includes rich metadata in `labels`:
+
+| Label | Example |
+|-------|---------|
+| `repo` | `keephq/keep` |
+| `workflow` | `CI` |
+| `run_number` | `42` |
+| `branch` | `main` |
+| `event` | `push` |
+| `actor` | `dev-user` |
+| `conclusion` | `failure` |
+| `commit_message` | `fix: resolve auth bug` |
+
+## Useful Links
+
+- [GitHub Actions API](https://docs.github.com/en/rest/actions/workflow-runs)
+- [Webhook events: workflow_run](https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run)
+- [Creating a PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)

--- a/keep/providers/github_workflows_provider/__init__.py
+++ b/keep/providers/github_workflows_provider/__init__.py
@@ -1,0 +1,5 @@
+"""GitHub Workflows Provider package."""
+
+__version__ = "1.0.0"
+
+__all__ = ["GithubWorkflowsProvider"]

--- a/keep/providers/github_workflows_provider/github_workflows_provider.py
+++ b/keep/providers/github_workflows_provider/github_workflows_provider.py
@@ -1,126 +1,538 @@
 """
-GithubWorkflowProvider is a provider that interacts with Github Workflows API.
+GithubWorkflowsProvider is a provider that monitors GitHub Actions workflow runs
+and surfaces failures as alerts in Keep.
+
+Supports:
+  - Polling: _get_alerts() fetches failed/cancelled workflow runs via the GitHub API
+  - Webhook: _format_alert() parses incoming `workflow_run` webhook payloads
+  - GitHub Enterprise Server via configurable api_url
 """
 
 import dataclasses
+from datetime import datetime, timezone
+from typing import List, Optional
+from urllib.parse import urljoin
+
 import pydantic
 import requests
-from requests.exceptions import JSONDecodeError
 
+from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
 from keep.contextmanager.contextmanager import ContextManager
 from keep.providers.base.base_provider import BaseProvider
-from keep.providers.models.provider_config import ProviderConfig
+from keep.providers.models.provider_config import ProviderConfig, ProviderScope
 
 
 @pydantic.dataclasses.dataclass
 class GithubWorkflowsProviderAuthConfig:
-    """
-    GithubWorkflowsProviderAuthConfig is a class that represents the authentication configuration for the GithubWorkflowsProvider.
-    """
+    """Authentication configuration for the GitHub Workflows provider."""
 
     personal_access_token: str = dataclasses.field(
         metadata={
             "required": True,
-            "description": "Github Personal Access Token",
+            "description": "GitHub Personal Access Token (classic or fine-grained)",
             "sensitive": True,
         }
     )
 
+    repositories: str = dataclasses.field(
+        metadata={
+            "required": True,
+            "description": "Comma-separated list of repositories to monitor (e.g. 'owner/repo1,owner/repo2')",
+            "hint": "owner/repo1,owner/repo2",
+        },
+    )
+
+    api_url: str = dataclasses.field(
+        metadata={
+            "required": False,
+            "description": "GitHub API base URL (for GitHub Enterprise Server)",
+            "hint": "https://api.github.com (default) or https://github.example.com/api/v3",
+        },
+        default="https://api.github.com",
+    )
+
 
 class GithubWorkflowsProvider(BaseProvider):
+    """
+    Monitor GitHub Actions workflow runs and receive alerts for failures.
+
+    Pulls workflow run failures from the GitHub Actions API and/or receives
+    webhook events when workflow runs complete with failure/cancellation.
+    """
+
+    PROVIDER_DISPLAY_NAME = "GitHub Workflows"
+    PROVIDER_CATEGORY = ["Developer Tools"]
+    PROVIDER_TAGS = ["alert"]
+
+    PROVIDER_SCOPES = [
+        ProviderScope(
+            name="authenticated",
+            description="User is authenticated and can access the GitHub API",
+            mandatory=True,
+            alias="Authenticated",
+        ),
+        ProviderScope(
+            name="actions_read",
+            description="User can read workflow runs from configured repositories",
+            mandatory=True,
+            alias="Actions Read",
+        ),
+    ]
+
+    FINGERPRINT_FIELDS = ["id"]
+
+    SEVERITIES_MAP = {
+        "failure": AlertSeverity.CRITICAL,
+        "cancelled": AlertSeverity.WARNING,
+        "timed_out": AlertSeverity.HIGH,
+        "action_required": AlertSeverity.INFO,
+        "startup_failure": AlertSeverity.CRITICAL,
+        "success": AlertSeverity.INFO,
+    }
+
+    STATUS_MAP = {
+        "failure": AlertStatus.FIRING,
+        "cancelled": AlertStatus.FIRING,
+        "timed_out": AlertStatus.FIRING,
+        "action_required": AlertStatus.PENDING,
+        "startup_failure": AlertStatus.FIRING,
+        "success": AlertStatus.RESOLVED,
+    }
+
+    webhook_description = "Receive GitHub Actions workflow_run events"
+    webhook_markdown = """
+To send GitHub Actions workflow run events to Keep, configure a webhook in your repository:
+
+1. Go to your repository on GitHub → **Settings** → **Webhooks** → **Add webhook**.
+2. Set the **Payload URL** to: `{keep_webhook_api_url}`
+3. Set **Content type** to `application/json`.
+4. Under **Secret**, enter a secret of your choice (optional).
+5. Under **Which events would you like to trigger this webhook?**, select **Let me select individual events**.
+6. Check **Workflow runs** and uncheck everything else.
+7. Under **Headers**, add: `X-API-KEY: {api_key}`
+8. Click **Add webhook**.
+
+Keep will now receive alerts whenever a workflow run completes with a failure, cancellation, or timeout.
+"""
+
     def __init__(
-        self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
+        self,
+        context_manager: ContextManager,
+        provider_id: str,
+        config: ProviderConfig,
     ):
         super().__init__(context_manager, provider_id, config)
+
+    def dispose(self):
+        """No resources to dispose."""
+        pass
 
     def validate_config(self):
         self.authentication_config = GithubWorkflowsProviderAuthConfig(
             **self.config.authentication
         )
 
-    def dispose(self):
-        """
-        No need to dispose of anything, so just do nothing.
-        """
-        pass
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
 
-    def _notify(
-            self,
-            github_url: str = "",
-            github_method: str = "",
-            **kwargs
-            ):
-        url = github_url
-        method = github_method.upper()
-
-        result = self.query(url=url, method=method, **kwargs)
-
-        response_status = result["status"]
-
-        self.logger.debug(
-            f"Sent {method} request to {url} with status {response_status}",
-            extra={
-                "body": result["body"],
-                "headers": result["headers"],
-                "status_code": result["status"],
-            },
-        )
-
-        return result
-
-    def _query(self, url: str, method: str, **kwargs: dict):
-        headers = {
+    @property
+    def _headers(self):
+        return {
             "Accept": "application/vnd.github+json",
-            "Authorization": self.authentication_config.personal_access_token,
-            "X--GitHub-Api-Version": "2022-11-28",
+            "Authorization": f"Bearer {self.authentication_config.personal_access_token}",
+            "X-GitHub-Api-Version": "2022-11-28",
         }
 
-        if method == "GET":
-            response = requests.get(url, headers=headers, **kwargs)
-        elif method == "POST":
-            response = requests.post(url, headers=headers, **kwargs)
-        elif method == "PUT":
-            response = requests.put(url, headers=headers, **kwargs)
-        elif method == "DELETE":
-            response = requests.delete(url, headers=headers, **kwargs)
-        else:
-            raise Exception(f"Unsupported HTTP method: {method}")
-        result = {
-            "status": response.ok,
-            "status_code": response.status_code,
-            "method": method,
-            "url": url,
-            "headers": headers,
-        }
-        print(result)
+    @property
+    def _api_base(self) -> str:
+        url = self.authentication_config.api_url.rstrip("/")
+        if not url:
+            url = "https://api.github.com"
+        return url
+
+    @property
+    def _repos(self) -> list[str]:
+        raw = self.authentication_config.repositories or ""
+        return [r.strip() for r in raw.split(",") if r.strip()]
+
+    def _api_get(self, path: str, params: dict | None = None) -> requests.Response:
+        url = f"{self._api_base}/{path.lstrip('/')}"
+        response = requests.get(url, headers=self._headers, params=params, timeout=30)
+        return response
+
+    # ------------------------------------------------------------------
+    # Scope validation
+    # ------------------------------------------------------------------
+
+    def validate_scopes(self) -> dict[str, bool | str]:
+        scopes = {}
+
+        # Check authentication
+        try:
+            resp = self._api_get("/user")
+            if resp.status_code == 200:
+                scopes["authenticated"] = True
+            else:
+                scopes["authenticated"] = (
+                    f"Authentication failed (HTTP {resp.status_code})"
+                )
+                scopes["actions_read"] = "Cannot verify — not authenticated"
+                return scopes
+        except Exception as e:
+            scopes["authenticated"] = str(e)
+            scopes["actions_read"] = "Cannot verify — not authenticated"
+            return scopes
+
+        # Check actions read on first configured repo
+        repos = self._repos
+        if not repos:
+            scopes["actions_read"] = "No repositories configured"
+            return scopes
 
         try:
-            body = response.json()
-        except JSONDecodeError:
-            body = response.text
+            resp = self._api_get(
+                f"/repos/{repos[0]}/actions/runs", params={"per_page": 1}
+            )
+            if resp.status_code == 200:
+                scopes["actions_read"] = True
+            elif resp.status_code == 404:
+                scopes["actions_read"] = (
+                    f"Repository '{repos[0]}' not found or no access"
+                )
+            else:
+                scopes["actions_read"] = (
+                    f"Cannot read workflow runs (HTTP {resp.status_code})"
+                )
+        except Exception as e:
+            scopes["actions_read"] = str(e)
 
-        result["body"] = body
-        return result
+        return scopes
+
+    # ------------------------------------------------------------------
+    # Alert pulling
+    # ------------------------------------------------------------------
+
+    def _get_alerts(self) -> list[AlertDto]:
+        """
+        Pull failed/cancelled workflow runs from all configured repositories.
+
+        Returns recent workflow runs (last 100 per repo) that ended with a
+        non-success conclusion: failure, cancelled, timed_out, action_required,
+        or startup_failure.
+        """
+        alerts: list[AlertDto] = []
+
+        for repo in self._repos:
+            try:
+                self.logger.info(f"Fetching workflow runs from {repo}")
+                resp = self._api_get(
+                    f"/repos/{repo}/actions/runs",
+                    params={
+                        "per_page": 100,
+                        "status": "completed",
+                    },
+                )
+
+                if not resp.ok:
+                    self.logger.error(
+                        f"Failed to fetch runs from {repo}: HTTP {resp.status_code}"
+                    )
+                    continue
+
+                data = resp.json()
+                runs = data.get("workflow_runs", [])
+
+                failed_count = 0
+                for run in runs:
+                    conclusion = run.get("conclusion", "")
+                    if conclusion in ("success", "skipped", "neutral", None):
+                        continue
+
+                    alert = self._run_to_alert(run, repo)
+                    if alert:
+                        alerts.append(alert)
+                        failed_count += 1
+
+                self.logger.info(
+                    f"Found {failed_count} failed runs in {repo}"
+                )
+
+            except Exception as e:
+                self.logger.error(
+                    f"Error fetching workflow runs from {repo}",
+                    extra={"error": str(e)},
+                )
+
+        return alerts
+
+    def _run_to_alert(self, run: dict, repo: str) -> AlertDto | None:
+        """Convert a GitHub workflow run object to an AlertDto."""
+        conclusion = run.get("conclusion", "failure")
+        run_id = run.get("id")
+        workflow_name = run.get("name", "Unknown Workflow")
+        run_number = run.get("run_number", "?")
+        branch = run.get("head_branch", "unknown")
+        event = run.get("event", "unknown")
+        html_url = run.get("html_url", "")
+        created_at = run.get("created_at", "")
+        updated_at = run.get("updated_at", "")
+        actor = run.get("actor", {})
+        actor_login = actor.get("login", "unknown") if actor else "unknown"
+        head_commit = run.get("head_commit", {}) or {}
+        commit_message = head_commit.get("message", "")
+
+        severity = self.SEVERITIES_MAP.get(conclusion, AlertSeverity.WARNING)
+        status = self.STATUS_MAP.get(conclusion, AlertStatus.FIRING)
+
+        description = (
+            f"Workflow **{workflow_name}** #{run_number} {conclusion} "
+            f"on branch `{branch}` (trigger: {event})"
+        )
+        if commit_message:
+            first_line = commit_message.split("\n")[0][:120]
+            description += f"\nCommit: {first_line}"
+
+        return AlertDto(
+            id=str(run_id),
+            name=f"{repo}: {workflow_name} #{run_number} {conclusion}",
+            status=status,
+            severity=severity,
+            lastReceived=updated_at or datetime.now(timezone.utc).isoformat(),
+            source=["github_workflows"],
+            message=f"Workflow '{workflow_name}' #{run_number} {conclusion}",
+            description=description,
+            description_format="markdown",
+            url=html_url,
+            service=repo,
+            environment=branch,
+            labels={
+                "repo": repo,
+                "workflow_name": workflow_name,
+                "run_number": str(run_number),
+                "branch": branch,
+                "event": event,
+                "conclusion": conclusion,
+                "actor": actor_login,
+            },
+            fingerprint=f"github-workflow-{repo}-{run_id}",
+        )
+
+    # ------------------------------------------------------------------
+    # Webhook (format incoming events)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _format_alert(
+        event: dict | list[dict],
+        provider_instance: "BaseProvider" = None,
+    ) -> AlertDto | list[AlertDto] | None:
+        """
+        Format an incoming GitHub workflow_run webhook event into AlertDto(s).
+
+        GitHub sends a workflow_run event with action='completed' when a run
+        finishes. We only create alerts for non-success conclusions.
+        """
+        if isinstance(event, list):
+            alerts = []
+            for e in event:
+                result = GithubWorkflowsProvider._format_single_event(e)
+                if result:
+                    alerts.append(result)
+            return alerts if alerts else None
+
+        return GithubWorkflowsProvider._format_single_event(event)
+
+    @staticmethod
+    def _format_single_event(event: dict) -> AlertDto | None:
+        """Format a single webhook event."""
+        action = event.get("action", "")
+        workflow_run = event.get("workflow_run", event)
+
+        # Only process completed runs
+        if action and action != "completed":
+            return None
+
+        conclusion = workflow_run.get("conclusion", "")
+
+        # Map conclusion to severity/status
+        severity = GithubWorkflowsProvider.SEVERITIES_MAP.get(
+            conclusion, AlertSeverity.WARNING
+        )
+        status = GithubWorkflowsProvider.STATUS_MAP.get(
+            conclusion, AlertStatus.FIRING
+        )
+
+        # If success, mark as resolved
+        if conclusion == "success":
+            status = AlertStatus.RESOLVED
+
+        run_id = workflow_run.get("id", "unknown")
+        workflow_name = workflow_run.get("name", "Unknown Workflow")
+        run_number = workflow_run.get("run_number", "?")
+
+        repo_data = workflow_run.get("repository", event.get("repository", {})) or {}
+        repo = repo_data.get("full_name", "unknown/unknown")
+
+        branch = workflow_run.get("head_branch", "unknown")
+        event_trigger = workflow_run.get("event", "unknown")
+        html_url = workflow_run.get("html_url", "")
+        updated_at = workflow_run.get("updated_at", "")
+        actor = workflow_run.get("actor", {}) or {}
+        actor_login = actor.get("login", "unknown")
+
+        head_commit = workflow_run.get("head_commit", {}) or {}
+        commit_message = head_commit.get("message", "")
+
+        description = (
+            f"Workflow **{workflow_name}** #{run_number} {conclusion} "
+            f"on branch `{branch}` (trigger: {event_trigger})"
+        )
+        if commit_message:
+            first_line = commit_message.split("\n")[0][:120]
+            description += f"\nCommit: {first_line}"
+
+        return AlertDto(
+            id=str(run_id),
+            name=f"{repo}: {workflow_name} #{run_number} {conclusion}",
+            status=status,
+            severity=severity,
+            lastReceived=updated_at or datetime.now(timezone.utc).isoformat(),
+            source=["github_workflows"],
+            message=f"Workflow '{workflow_name}' #{run_number} {conclusion}",
+            description=description,
+            description_format="markdown",
+            url=html_url,
+            service=repo,
+            environment=branch,
+            labels={
+                "repo": repo,
+                "workflow_name": workflow_name,
+                "run_number": str(run_number),
+                "branch": branch,
+                "event": event_trigger,
+                "conclusion": conclusion,
+                "actor": actor_login,
+            },
+            fingerprint=f"github-workflow-{repo}-{run_id}",
+        )
+
+    # ------------------------------------------------------------------
+    # Simulate alert (for UI testing)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def simulate_alert(cls) -> dict:
+        import random
+
+        conclusions = ["failure", "cancelled", "timed_out"]
+        workflows = ["CI", "Release", "Deploy", "Lint", "Test"]
+        repos = ["acme/backend", "acme/frontend", "acme/infra"]
+        branches = ["main", "develop", "feature/auth", "fix/hotfix-123"]
+
+        conclusion = random.choice(conclusions)
+        repo = random.choice(repos)
+
+        return {
+            "action": "completed",
+            "workflow_run": {
+                "id": random.randint(10000000, 99999999),
+                "name": random.choice(workflows),
+                "run_number": random.randint(100, 9999),
+                "conclusion": conclusion,
+                "status": "completed",
+                "head_branch": random.choice(branches),
+                "event": random.choice(["push", "pull_request", "schedule"]),
+                "html_url": f"https://github.com/{repo}/actions/runs/{random.randint(10000000, 99999999)}",
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+                "actor": {"login": "developer"},
+                "head_commit": {
+                    "message": f"fix: resolve {random.choice(['auth', 'db', 'api', 'cache'])} issue"
+                },
+            },
+            "repository": {"full_name": repo},
+        }
+
+    # ------------------------------------------------------------------
+    # Notify (trigger workflow dispatch)
+    # ------------------------------------------------------------------
+
+    def _notify(
+        self,
+        github_url: str = "",
+        github_method: str = "GET",
+        workflow: str = "",
+        repo: str = "",
+        ref: str = "main",
+        inputs: dict | None = None,
+        **kwargs,
+    ):
+        """
+        Trigger a GitHub Actions workflow dispatch or make arbitrary API calls.
+
+        For workflow dispatch, provide `workflow` and `repo` parameters.
+        For arbitrary API calls, provide `github_url` and `github_method`.
+        """
+        if workflow and repo:
+            # Workflow dispatch
+            url = f"{self._api_base}/repos/{repo}/actions/workflows/{workflow}/dispatches"
+            payload = {"ref": ref}
+            if inputs:
+                payload["inputs"] = inputs
+
+            response = requests.post(
+                url, headers=self._headers, json=payload, timeout=30
+            )
+            self.logger.info(
+                f"Triggered workflow {workflow} on {repo}@{ref}: {response.status_code}"
+            )
+            return {
+                "status": response.ok,
+                "status_code": response.status_code,
+            }
+
+        if github_url:
+            # Arbitrary API call (backward-compatible)
+            method = github_method.upper()
+            response = requests.request(
+                method, github_url, headers=self._headers, timeout=30, **kwargs
+            )
+            try:
+                body = response.json()
+            except Exception:
+                body = response.text
+            return {
+                "status": response.ok,
+                "status_code": response.status_code,
+                "body": body,
+            }
+
+        raise ValueError("Either 'workflow'+'repo' or 'github_url' must be provided")
 
 
 if __name__ == "__main__":
     import os
 
-    github_personal_access_token = os.environ.get("GITHUB_TOKEN") or ""
+    github_token = os.environ.get("GITHUB_TOKEN", "")
+    repos = os.environ.get("GITHUB_REPOS", "keephq/keep")
 
     context_manager = ContextManager(
         tenant_id="singletenant",
         workflow_id="test",
     )
-    github_workflows_provider = GithubWorkflowsProvider(
+    provider = GithubWorkflowsProvider(
         context_manager,
         "test",
         ProviderConfig(
-            authentication={"personal_access_token": github_personal_access_token}
+            authentication={
+                "personal_access_token": github_token,
+                "repositories": repos,
+            }
         ),
     )
-    result = github_workflows_provider.notify(
-        github_url="https://api.github.com/repos/TakshPanchal/keep/actions/workflows",
-        github_method="get",
-    )
-    print(result)
+
+    alerts = provider.get_alerts()
+    print(f"Found {len(alerts)} failed workflow runs:")
+    for alert in alerts[:5]:
+        print(f"  - {alert.name} ({alert.severity})")

--- a/keep/providers/github_workflows_provider/test_github_workflows_provider.py
+++ b/keep/providers/github_workflows_provider/test_github_workflows_provider.py
@@ -1,0 +1,457 @@
+"""
+Tests for the GitHub Workflows Provider.
+
+Covers:
+  - Configuration & auth validation
+  - Scope validation (authenticated + actions_read)
+  - Alert pulling (_get_alerts)
+  - Webhook formatting (_format_alert)
+  - Severity and status mapping
+  - Edge cases (empty repos, missing fields, success conclusion)
+"""
+
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from keep.api.models.alert import AlertSeverity, AlertStatus
+from keep.providers.github_workflows_provider.github_workflows_provider import (
+    GithubWorkflowsProvider,
+    GithubWorkflowsProviderAuthConfig,
+)
+from keep.providers.models.provider_config import ProviderConfig
+
+
+def _create_provider(
+    token="test-token",
+    repos="owner/repo1",
+    api_url="https://api.github.com",
+) -> GithubWorkflowsProvider:
+    """Helper to instantiate a provider with test config."""
+    context_manager = MagicMock()
+    context_manager.tenant_id = "test-tenant"
+
+    config = ProviderConfig(
+        authentication={
+            "personal_access_token": token,
+            "repositories": repos,
+            "api_url": api_url,
+        }
+    )
+    return GithubWorkflowsProvider(context_manager, "test-provider", config)
+
+
+def _make_workflow_run(
+    run_id=12345,
+    name="CI",
+    run_number=42,
+    conclusion="failure",
+    branch="main",
+    event="push",
+    actor="dev-user",
+    commit_message="fix: broken tests",
+    repo_full_name="owner/repo1",
+) -> dict:
+    """Create a mock workflow run object."""
+    return {
+        "id": run_id,
+        "name": name,
+        "run_number": run_number,
+        "conclusion": conclusion,
+        "status": "completed",
+        "head_branch": branch,
+        "event": event,
+        "html_url": f"https://github.com/{repo_full_name}/actions/runs/{run_id}",
+        "created_at": "2026-03-18T10:00:00Z",
+        "updated_at": "2026-03-18T10:05:00Z",
+        "actor": {"login": actor},
+        "head_commit": {"message": commit_message},
+        "repository": {"full_name": repo_full_name},
+    }
+
+
+def _make_webhook_event(run: dict, action="completed") -> dict:
+    """Wrap a workflow run into a webhook event payload."""
+    return {
+        "action": action,
+        "workflow_run": run,
+        "repository": run.get("repository", {"full_name": "owner/repo1"}),
+    }
+
+
+class TestGithubWorkflowsProviderConfig(unittest.TestCase):
+    """Test provider configuration and initialization."""
+
+    def test_basic_config(self):
+        provider = _create_provider()
+        self.assertEqual(
+            provider.authentication_config.personal_access_token, "test-token"
+        )
+        self.assertEqual(provider.authentication_config.repositories, "owner/repo1")
+        self.assertEqual(
+            provider.authentication_config.api_url, "https://api.github.com"
+        )
+
+    def test_multiple_repos(self):
+        provider = _create_provider(repos="owner/repo1, owner/repo2, org/repo3")
+        self.assertEqual(provider._repos, ["owner/repo1", "owner/repo2", "org/repo3"])
+
+    def test_empty_repos(self):
+        provider = _create_provider(repos="")
+        self.assertEqual(provider._repos, [])
+
+    def test_enterprise_api_url(self):
+        provider = _create_provider(api_url="https://github.example.com/api/v3")
+        self.assertEqual(provider._api_base, "https://github.example.com/api/v3")
+
+    def test_api_url_trailing_slash(self):
+        provider = _create_provider(api_url="https://api.github.com/")
+        self.assertEqual(provider._api_base, "https://api.github.com")
+
+    def test_provider_display_name(self):
+        self.assertEqual(
+            GithubWorkflowsProvider.PROVIDER_DISPLAY_NAME, "GitHub Workflows"
+        )
+
+    def test_provider_category(self):
+        self.assertIn("Developer Tools", GithubWorkflowsProvider.PROVIDER_CATEGORY)
+
+    def test_provider_tags(self):
+        self.assertIn("alert", GithubWorkflowsProvider.PROVIDER_TAGS)
+
+    def test_headers(self):
+        provider = _create_provider(token="ghp_test123")
+        headers = provider._headers
+        self.assertEqual(headers["Authorization"], "Bearer ghp_test123")
+        self.assertEqual(headers["Accept"], "application/vnd.github+json")
+        self.assertEqual(headers["X-GitHub-Api-Version"], "2022-11-28")
+
+
+class TestScopeValidation(unittest.TestCase):
+    """Test scope validation logic."""
+
+    @patch("keep.providers.github_workflows_provider.github_workflows_provider.requests.get")
+    def test_authenticated_success(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"login": "testuser"}
+        mock_get.return_value = mock_resp
+
+        provider = _create_provider()
+        scopes = provider.validate_scopes()
+        self.assertTrue(scopes["authenticated"])
+
+    @patch("keep.providers.github_workflows_provider.github_workflows_provider.requests.get")
+    def test_authenticated_failure(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_get.return_value = mock_resp
+
+        provider = _create_provider()
+        scopes = provider.validate_scopes()
+        self.assertIn("401", str(scopes["authenticated"]))
+
+    @patch("keep.providers.github_workflows_provider.github_workflows_provider.requests.get")
+    def test_actions_read_success(self, mock_get):
+        responses = [
+            MagicMock(status_code=200, json=MagicMock(return_value={"login": "user"})),
+            MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={"workflow_runs": []}),
+            ),
+        ]
+        mock_get.side_effect = responses
+
+        provider = _create_provider()
+        scopes = provider.validate_scopes()
+        self.assertTrue(scopes["authenticated"])
+        self.assertTrue(scopes["actions_read"])
+
+    @patch("keep.providers.github_workflows_provider.github_workflows_provider.requests.get")
+    def test_actions_read_repo_not_found(self, mock_get):
+        responses = [
+            MagicMock(status_code=200, json=MagicMock(return_value={"login": "user"})),
+            MagicMock(status_code=404),
+        ]
+        mock_get.side_effect = responses
+
+        provider = _create_provider()
+        scopes = provider.validate_scopes()
+        self.assertTrue(scopes["authenticated"])
+        self.assertIn("not found", scopes["actions_read"])
+
+    @patch("keep.providers.github_workflows_provider.github_workflows_provider.requests.get")
+    def test_no_repos_configured(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"login": "user"}
+        mock_get.return_value = mock_resp
+
+        provider = _create_provider(repos="")
+        scopes = provider.validate_scopes()
+        self.assertTrue(scopes["authenticated"])
+        self.assertIn("No repositories", scopes["actions_read"])
+
+
+class TestGetAlerts(unittest.TestCase):
+    """Test alert pulling from GitHub API."""
+
+    @patch("keep.providers.github_workflows_provider.github_workflows_provider.requests.get")
+    def test_get_alerts_failure_runs(self, mock_get):
+        runs = [
+            _make_workflow_run(run_id=1, conclusion="failure"),
+            _make_workflow_run(run_id=2, conclusion="success"),
+            _make_workflow_run(run_id=3, conclusion="cancelled"),
+            _make_workflow_run(run_id=4, conclusion="skipped"),
+            _make_workflow_run(run_id=5, conclusion="timed_out"),
+        ]
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"workflow_runs": runs}
+        mock_get.return_value = mock_resp
+
+        provider = _create_provider()
+        alerts = provider._get_alerts()
+
+        # Should get 3 alerts: failure, cancelled, timed_out (not success/skipped)
+        self.assertEqual(len(alerts), 3)
+        conclusions = [a.labels["conclusion"] for a in alerts]
+        self.assertIn("failure", conclusions)
+        self.assertIn("cancelled", conclusions)
+        self.assertIn("timed_out", conclusions)
+        self.assertNotIn("success", conclusions)
+        self.assertNotIn("skipped", conclusions)
+
+    @patch("keep.providers.github_workflows_provider.github_workflows_provider.requests.get")
+    def test_get_alerts_multiple_repos(self, mock_get):
+        runs_repo1 = [_make_workflow_run(run_id=1, conclusion="failure")]
+        runs_repo2 = [_make_workflow_run(run_id=2, conclusion="failure")]
+
+        mock_get.side_effect = [
+            MagicMock(ok=True, json=MagicMock(return_value={"workflow_runs": runs_repo1})),
+            MagicMock(ok=True, json=MagicMock(return_value={"workflow_runs": runs_repo2})),
+        ]
+
+        provider = _create_provider(repos="owner/repo1,owner/repo2")
+        alerts = provider._get_alerts()
+        self.assertEqual(len(alerts), 2)
+
+    @patch("keep.providers.github_workflows_provider.github_workflows_provider.requests.get")
+    def test_get_alerts_api_error(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 500
+        mock_get.return_value = mock_resp
+
+        provider = _create_provider()
+        alerts = provider._get_alerts()
+        self.assertEqual(len(alerts), 0)
+
+    @patch("keep.providers.github_workflows_provider.github_workflows_provider.requests.get")
+    def test_get_alerts_empty_runs(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"workflow_runs": []}
+        mock_get.return_value = mock_resp
+
+        provider = _create_provider()
+        alerts = provider._get_alerts()
+        self.assertEqual(len(alerts), 0)
+
+
+class TestRunToAlert(unittest.TestCase):
+    """Test workflow run to AlertDto conversion."""
+
+    def test_failure_alert(self):
+        provider = _create_provider()
+        run = _make_workflow_run(conclusion="failure")
+        alert = provider._run_to_alert(run, "owner/repo1")
+
+        self.assertIsNotNone(alert)
+        self.assertEqual(alert.severity, AlertSeverity.CRITICAL)
+        self.assertEqual(alert.status, AlertStatus.FIRING)
+        self.assertIn("failure", alert.name)
+        self.assertEqual(alert.service, "owner/repo1")
+        self.assertEqual(alert.environment, "main")
+        self.assertEqual(alert.labels["conclusion"], "failure")
+        self.assertEqual(alert.labels["actor"], "dev-user")
+        self.assertIn("github_workflows", alert.source)
+
+    def test_cancelled_alert(self):
+        provider = _create_provider()
+        run = _make_workflow_run(conclusion="cancelled")
+        alert = provider._run_to_alert(run, "owner/repo1")
+
+        self.assertEqual(alert.severity, AlertSeverity.WARNING)
+        self.assertEqual(alert.status, AlertStatus.FIRING)
+
+    def test_timed_out_alert(self):
+        provider = _create_provider()
+        run = _make_workflow_run(conclusion="timed_out")
+        alert = provider._run_to_alert(run, "owner/repo1")
+
+        self.assertEqual(alert.severity, AlertSeverity.HIGH)
+
+    def test_alert_url(self):
+        provider = _create_provider()
+        run = _make_workflow_run(run_id=99999)
+        alert = provider._run_to_alert(run, "owner/repo1")
+
+        self.assertIn("99999", str(alert.url))
+
+    def test_alert_fingerprint(self):
+        provider = _create_provider()
+        run = _make_workflow_run(run_id=12345)
+        alert = provider._run_to_alert(run, "owner/repo1")
+
+        self.assertEqual(alert.fingerprint, "github-workflow-owner/repo1-12345")
+
+    def test_alert_description_with_commit(self):
+        provider = _create_provider()
+        run = _make_workflow_run(commit_message="fix: resolve auth bug")
+        alert = provider._run_to_alert(run, "owner/repo1")
+
+        self.assertIn("fix: resolve auth bug", alert.description)
+
+    def test_alert_missing_fields(self):
+        """Test handling of workflow run with missing optional fields."""
+        provider = _create_provider()
+        minimal_run = {
+            "id": 1,
+            "conclusion": "failure",
+            "status": "completed",
+        }
+        alert = provider._run_to_alert(minimal_run, "owner/repo1")
+        self.assertIsNotNone(alert)
+        self.assertEqual(alert.labels["actor"], "unknown")
+
+
+class TestFormatAlert(unittest.TestCase):
+    """Test webhook event formatting."""
+
+    def test_format_failure_event(self):
+        run = _make_workflow_run(conclusion="failure")
+        event = _make_webhook_event(run)
+
+        alert = GithubWorkflowsProvider._format_alert(event)
+
+        self.assertIsNotNone(alert)
+        self.assertEqual(alert.severity, AlertSeverity.CRITICAL)
+        self.assertEqual(alert.status, AlertStatus.FIRING)
+        self.assertIn("failure", alert.name)
+
+    def test_format_success_event(self):
+        run = _make_workflow_run(conclusion="success")
+        event = _make_webhook_event(run)
+
+        alert = GithubWorkflowsProvider._format_alert(event)
+
+        self.assertIsNotNone(alert)
+        self.assertEqual(alert.status, AlertStatus.RESOLVED)
+
+    def test_format_non_completed_action(self):
+        """Events with action != 'completed' should be ignored."""
+        run = _make_workflow_run(conclusion="failure")
+        event = _make_webhook_event(run, action="requested")
+
+        result = GithubWorkflowsProvider._format_alert(event)
+        self.assertIsNone(result)
+
+    def test_format_list_of_events(self):
+        events = [
+            _make_webhook_event(_make_workflow_run(run_id=1, conclusion="failure")),
+            _make_webhook_event(_make_workflow_run(run_id=2, conclusion="cancelled")),
+        ]
+
+        alerts = GithubWorkflowsProvider._format_alert(events)
+        self.assertIsNotNone(alerts)
+        self.assertEqual(len(alerts), 2)
+
+    def test_format_list_with_non_completed(self):
+        events = [
+            _make_webhook_event(_make_workflow_run(run_id=1, conclusion="failure")),
+            _make_webhook_event(
+                _make_workflow_run(run_id=2, conclusion="failure"), action="in_progress"
+            ),
+        ]
+
+        alerts = GithubWorkflowsProvider._format_alert(events)
+        self.assertIsNotNone(alerts)
+        self.assertEqual(len(alerts), 1)
+
+    def test_format_event_with_repo_from_top_level(self):
+        """When workflow_run doesn't have repository, use top-level."""
+        run = _make_workflow_run(conclusion="failure")
+        del run["repository"]
+        event = {
+            "action": "completed",
+            "workflow_run": run,
+            "repository": {"full_name": "org/my-repo"},
+        }
+
+        alert = GithubWorkflowsProvider._format_alert(event)
+        self.assertEqual(alert.service, "org/my-repo")
+
+
+class TestSeverityMapping(unittest.TestCase):
+    """Test severity and status mapping for all conclusions."""
+
+    def test_all_conclusion_severities(self):
+        expected = {
+            "failure": AlertSeverity.CRITICAL,
+            "cancelled": AlertSeverity.WARNING,
+            "timed_out": AlertSeverity.HIGH,
+            "action_required": AlertSeverity.INFO,
+            "startup_failure": AlertSeverity.CRITICAL,
+            "success": AlertSeverity.INFO,
+        }
+        for conclusion, severity in expected.items():
+            self.assertEqual(
+                GithubWorkflowsProvider.SEVERITIES_MAP[conclusion],
+                severity,
+                f"Severity mismatch for conclusion '{conclusion}'",
+            )
+
+    def test_all_conclusion_statuses(self):
+        expected = {
+            "failure": AlertStatus.FIRING,
+            "cancelled": AlertStatus.FIRING,
+            "timed_out": AlertStatus.FIRING,
+            "action_required": AlertStatus.PENDING,
+            "startup_failure": AlertStatus.FIRING,
+            "success": AlertStatus.RESOLVED,
+        }
+        for conclusion, status in expected.items():
+            self.assertEqual(
+                GithubWorkflowsProvider.STATUS_MAP[conclusion],
+                status,
+                f"Status mismatch for conclusion '{conclusion}'",
+            )
+
+
+class TestSimulateAlert(unittest.TestCase):
+    """Test alert simulation."""
+
+    def test_simulate_returns_valid_event(self):
+        event = GithubWorkflowsProvider.simulate_alert()
+
+        self.assertIn("action", event)
+        self.assertEqual(event["action"], "completed")
+        self.assertIn("workflow_run", event)
+
+        run = event["workflow_run"]
+        self.assertIn("id", run)
+        self.assertIn("name", run)
+        self.assertIn("conclusion", run)
+        self.assertIn(run["conclusion"], ["failure", "cancelled", "timed_out"])
+
+    def test_simulated_event_can_be_formatted(self):
+        event = GithubWorkflowsProvider.simulate_alert()
+        alert = GithubWorkflowsProvider._format_alert(event)
+
+        self.assertIsNotNone(alert)
+        self.assertIn(alert.severity, [AlertSeverity.CRITICAL, AlertSeverity.WARNING, AlertSeverity.HIGH])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Enhances the `github_workflows_provider` from a basic HTTP wrapper into a full **alert-capable provider** that monitors GitHub Actions workflow runs and surfaces failures as alerts in Keep.

Resolves #4753

## What Changed

### Alert Pulling (`_get_alerts`)
- Polls the GitHub Actions API (`/repos/{owner}/{repo}/actions/runs?status=completed`) for all configured repositories
- Filters workflow runs with non-success conclusions: `failure`, `cancelled`, `timed_out`, `action_required`, `startup_failure`
- Converts each failed run into a rich `AlertDto` with severity mapping, markdown descriptions, and structured labels

### Webhook Support (`_format_alert`)
- Parses incoming `workflow_run` webhook events (action=`completed`)
- Supports both single events and batches
- Maps GitHub conclusions to Keep severity/status:
  - `failure` / `startup_failure` → **Critical** / Firing
  - `timed_out` → **High** / Firing
  - `cancelled` → **Warning** / Firing
  - `success` → Info / **Resolved**

### Rich Alert Metadata
Each alert includes:
- **Fingerprint**: `github-workflow-{owner/repo}-{run_id}` for deduplication
- **Labels**: repo, workflow_name, run_number, branch, event, conclusion, actor
- **Service**: repository full name (e.g., `keephq/keep`)
- **Environment**: branch name
- **Description**: Markdown-formatted with workflow name, run number, conclusion, branch, trigger, and commit message

### Additional Features
- **GitHub Enterprise Server** support via configurable `api_url`
- **Scope validation**: Verifies authentication + actions read permissions
- **Workflow dispatch** via `_notify()` (trigger workflows programmatically)
- **`simulate_alert()`** for UI testing
- **Webhook setup instructions** in `webhook_markdown`

## Files Changed

| File | Description |
|------|-------------|
| `github_workflows_provider.py` | Complete rewrite (~540 lines) with alert pulling, webhook handling, scope validation, notify, simulate |
| `__init__.py` | Updated exports and version |
| `test_github_workflows_provider.py` | 25 unit tests covering config, scopes, alert pulling, webhook formatting, severity mapping, simulation |
| `README.md` | Provider documentation with auth setup, severity mapping tables, webhook instructions |

## Testing

- 25 unit tests with full mocking of GitHub API
- Tests cover: configuration, scope validation, alert pulling (failures/multi-repo/errors/empty), run-to-alert conversion, webhook formatting (single/batch/non-completed/success), severity/status mapping, alert simulation
