### PR TITLE
fix: add request parameter to webhook_challenge for Netdata

### DIFF
--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -618,9 +618,9 @@ async def receive_generic_event(
     "/event/netdata",
     description="Helper function to complete Netdata webhook challenge",
 )
-async def webhook_challenge():
+async def webhook_challenge(request: Request):
     try:
-        token = Request.query_params.get("token").encode("ascii")
+        token = request.query_params.get("token").encode("ascii")
     except Exception as e:
         logger.exception("Failed to get token", extra={"error": str(e)})
         raise HTTPException(status_code=400, detail="Bad request: failed to get token")


### PR DESCRIPTION
## Summary

Fixes #6116

The `webhook_challenge` endpoint for Netdata was calling `Request.query_params.get()` on the Starlette `Request` **class** instead of a request **instance**. Since `query_params` is an instance property, this raises `AttributeError` on every request — making the Netdata webhook challenge completely broken.

## Root Cause

```python
# Before (broken): calls .get() on the class, not an instance
async def webhook_challenge():
    token = Request.query_params.get("token").encode("ascii")
```

## Fix

```python
# After (fixed): inject request instance via FastAPI dependency
async def webhook_challenge(request: Request):
    token = request.query_params.get("token").encode("ascii")
```

## Changes
- Added `request: Request` parameter to `webhook_challenge`
- Changed `Request.query_params` → `request.query_params`

2-line fix. No tests needed — the bug is a straightforward Python instance vs class error.