### PR TITLE
fix: distinguish RBAC 403 from 'not installed' in FluxCD provider

### DIFF
--- a/keep/providers/fluxcd_provider/fluxcd_provider.py
+++ b/keep/providers/fluxcd_provider/fluxcd_provider.py
@@ -405,6 +405,14 @@ class FluxcdProvider(BaseTopologyProvider):
             api_instance.read_custom_resource_definition(name=crd_name)
             self.logger.debug(f"Flux CD CRD {crd_name} found")
             return True
+        except ApiException as e:
+            if e.status == 403:
+                # 403 means the ServiceAccount lacks CRD read permissions,
+                # NOT that FluxCD is absent. Re-raise so validate_scopes can
+                # surface an actionable RBAC error instead of misleading the user.
+                raise
+            self.logger.warning(f"Flux CD does not appear to be installed: {str(e)}")
+            return False
         except Exception as e:
             self.logger.warning(f"Flux CD does not appear to be installed: {str(e)}")
             return False
@@ -434,6 +442,31 @@ class FluxcdProvider(BaseTopologyProvider):
                 else:
                     # Try to list GitRepositories to validate authentication
                     self.__list_git_repositories()
+        except ApiException as e:
+            if e.status == 403:
+                authenticated = (
+                    "Insufficient RBAC permissions: the ServiceAccount cannot read "
+                    "FluxCD CustomResourceDefinitions. "
+                    "Add ClusterRole permissions for "
+                    "apiextensions.k8s.io/customresourcedefinitions (get, list). "
+                    f"Kubernetes error: {e.reason}"
+                )
+                self.logger.warning(
+                    "FluxCD validation failed due to RBAC permissions (403 Forbidden). "
+                    "The ServiceAccount likely lacks 'get' on customresourcedefinitions.",
+                    extra={
+                        "namespace": self.authentication_config.namespace
+                        if hasattr(self, "authentication_config")
+                        else "unknown",
+                    },
+                )
+            else:
+                error_message = str(e)
+                self.logger.error(
+                    f"Kubernetes API error ({e.status}) while validating FluxCD scope",
+                    extra={"exception": error_message},
+                )
+                authenticated = f"Kubernetes API error ({e.status}): {e.reason}"
         except Exception as e:
             error_type = type(e).__name__
             error_message = str(e)


### PR DESCRIPTION
## Summary

Fixes #5393

When a Kubernetes ServiceAccount lacks permission to read **CustomResourceDefinitions** (HTTP 403 Forbidden), the FluxCD provider was catching this exception generically and reporting:

> "Flux CD does not appear to be installed"

This message is **misleading** — FluxCD *is* installed, but the ServiceAccount simply doesn't have the required RBAC permissions. Users end up troubleshooting a non-existent installation problem.

## Root Cause

`__check_flux_installed` caught all exceptions with a bare `except Exception`, treating a 403 Forbidden the same as a 404 Not Found.

## Changes

- **`__check_flux_installed`**: Catch `ApiException` separately. For status 403, re-raise so the caller can distinguish permission errors from genuine absences. Other errors still return `False` (FluxCD not installed).
- **`validate_scopes`**: Add an explicit `except ApiException` block that returns an actionable error message on 403, directing operators to add `ClusterRole` permissions for `apiextensions.k8s.io/customresourcedefinitions`.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| FluxCD installed, 403 Forbidden | "Flux CD does not appear to be installed" ❌ | "Insufficient RBAC permissions: ... Add ClusterRole permissions for apiextensions.k8s.io/customresourcedefinitions (get, list)" ✅ |
| FluxCD genuinely not installed | "Flux CD does not appear to be installed" ✅ | unchanged ✅ |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>