### PR TITLE
fix: prevent sidebar overflow and avatar distortion in user info section

### DIFF
--- a/keep-ui/components/navbar/UserInfo.tsx
+++ b/keep-ui/components/navbar/UserInfo.tsx
@@ -37,11 +37,13 @@ const UserDropdown = ({ session }: UserDropdownProps) => {
 
   const isNoAuth = configData?.AUTH_TYPE === AuthType.NOAUTH;
   return (
-    <Menu as="li" ref={refs.setReference} className="w-full">
+    <Menu as="li" ref={refs.setReference} className="min-w-0 flex-1">
       <Menu.Button className="flex items-center justify-between w-full text-sm pl-2.5 pr-2 py-1 text-gray-700 hover:bg-stone-200/50 font-medium rounded-lg hover:text-orange-400 focus:ring focus:ring-orange-300 group capitalize">
-        <span className="space-x-3 flex items-center w-full">
-          <UserAvatar image={image} name={name ?? email} />{" "}
-          <Subtitle className="truncate">{name ?? email}</Subtitle>
+        <span className="space-x-3 flex items-center min-w-0 flex-1">
+          <span className="flex-shrink-0">
+            <UserAvatar image={image} name={name ?? email} />
+          </span>
+          <Subtitle className="truncate block">{name ?? email}</Subtitle>
         </span>
       </Menu.Button>
 
@@ -116,9 +118,9 @@ export const UserInfo = ({ session }: UserInfoProps) => {
             Docs
           </LinkWithIcon>
         </li>
-        <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
           {session && <UserDropdown session={session} />}
-          <ThemeControl className="text-sm size-10 flex items-center justify-center font-medium rounded-lg focus:ring focus:ring-orange-300 hover:!bg-stone-200/50" />
+          <ThemeControl className="text-sm size-10 flex-shrink-0 flex items-center justify-center font-medium rounded-lg focus:ring focus:ring-orange-300 hover:!bg-stone-200/50" />
         </div>
       </ul>
     </>


### PR DESCRIPTION
## Summary
- Fix sidebar user info layout issues when username is too long
- Prevent theme toggle button from being pushed outside the sidebar panel
- Ensure user avatar maintains circular shape instead of appearing oval/distorted

## Before

<img width="257" height="132" alt="image" src="https://github.com/user-attachments/assets/077bb8dc-4dd0-4dba-b2da-7dcb9dd64141" />

## After

<img width="239" height="126" alt="image" src="https://github.com/user-attachments/assets/cfb2e83c-c561-47b7-a002-16b720183c33" />


Fixes #6128

🤖 Generated with [Claude Code](https://claude.com/claude-code)