### PR TITLE
fix: default AlertDto.environment to None instead of "undefined"

### DIFF
--- a/keep/api/models/alert.py
+++ b/keep/api/models/alert.py
@@ -78,7 +78,7 @@ class AlertDto(BaseModel):
     firingStartTimeSinceLastResolved: str | None = None
     firingCounter: int = 0
     unresolvedCounter: int = 0
-    environment: str = "undefined"
+    environment: str | None = None
     isFullDuplicate: bool | None = False
     isPartialDuplicate: bool | None = False
     duplicateReason: str | None = None

--- a/tests/test_alert_dto.py
+++ b/tests/test_alert_dto.py
@@ -262,3 +262,22 @@ def test_alert_dismiss_forever():
     with freezegun.freeze_time(now + timedelta(days=365)):
         revalidated_alert = AlertDto(**alert.dict())
         assert revalidated_alert.dismissed is True
+
+
+def test_alert_dto_environment_default_is_none():
+    """environment should default to None, not a literal string like 'undefined'."""
+    alert = create_basic_alert(
+        name="Env Default Test",
+        last_received="2024-01-01T00:00:00.000Z",
+    )
+    assert alert.environment is None
+
+
+def test_alert_dto_environment_explicit_value():
+    """Explicitly set environment should be preserved."""
+    alert = create_basic_alert(
+        name="Env Explicit Test",
+        last_received="2024-01-01T00:00:00.000Z",
+        environment="production",
+    )
+    assert alert.environment == "production"

--- a/tests/test_iohandler.py
+++ b/tests/test_iohandler.py
@@ -1038,6 +1038,16 @@ def test_fn_na_on_missing_key(mocked_context_manager):
     assert result == "ts=N/A", f"Expected 'ts=N/A', got '{result}'"
 
 
+def test_fn_na_on_none_environment(mocked_context_manager):
+    """fn.na renders 'N/A' when environment is absent (defaults to None, not 'undefined')."""
+    mocked_context_manager.get_full_context.return_value = {
+        "alert": {"name": "test-alert"},  # no 'environment' field
+    }
+    iohandler = IOHandler(mocked_context_manager)
+    result = iohandler.render("env={{#fn.na}}{{ alert.environment }}{{/fn.na}}")
+    assert result == "env=N/A", f"Expected 'env=N/A', got '{result}'"
+
+
 def test_fn_default_on_missing_key(mocked_context_manager):
     """fn.default renders an empty string when the wrapped field is absent."""
     mocked_context_manager.get_full_context.return_value = {


### PR DESCRIPTION
## Summary

Change `AlertDto.environment` default from the literal string `"undefined"` to `None`, matching every other optional string field on the model (`service`, `providerType`, `description`, etc.).

This fixes the `fn.na` workflow template helper, which checks for falsy values but can't catch the truthy string `"undefined"`. Alerts with no `environment` field now correctly render as "N/A" in workflow templates.

Fixes #6148

## Changes

- `keep/api/models/alert.py`: `environment: str = "undefined"` → `environment: str | None = None`
- `tests/test_alert_dto.py`: Add tests for environment default (None) and explicit value
- `tests/test_iohandler.py`: Add integration test for `fn.na` with default environment

## Root Cause

The `fn.na` Mustache lambda does `render(text) or "N/A"`. When `environment` defaults to `"undefined"` (a truthy string), `fn.na` passes it through instead of substituting "N/A". Changing the default to `None` makes the field falsy when absent, so `fn.na` catches it naturally.