### PR TITLE
fix: delete TopologyServiceApplication links before TopologyService rows (fixes #5439)

### DIFF
--- a/keep/api/models/db/migrations/versions/2026-05-12-04-50_topologyserviceapplication_cascade.py
+++ b/keep/api/models/db/migrations/versions/2026-05-12-04-50_topologyserviceapplication_cascade.py
@@ -1,0 +1,76 @@
+"""Add ondelete CASCADE to TopologyServiceApplication foreign keys
+
+Revision ID: a1b2c3d4e5f6
+Revises: 9dd1be4539e0
+Create Date: 2026-05-12 04:50:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "9dd1be4539e0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop existing FK constraints and recreate with ondelete=CASCADE
+    # FK on service_id -> topologyservice.id
+    op.drop_constraint(
+        "topologyserviceapplication_service_id_fkey",
+        "topologyserviceapplication",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "topologyserviceapplication_service_id_fkey",
+        "topologyserviceapplication",
+        "topologyservice",
+        ["service_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    # FK on application_id -> topologyapplication.id
+    op.drop_constraint(
+        "topologyserviceapplication_application_id_fkey",
+        "topologyserviceapplication",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "topologyserviceapplication_application_id_fkey",
+        "topologyserviceapplication",
+        "topologyapplication",
+        ["application_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    # Revert to no ondelete
+    op.drop_constraint(
+        "topologyserviceapplication_service_id_fkey",
+        "topologyserviceapplication",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "topologyserviceapplication_service_id_fkey",
+        "topologyserviceapplication",
+        "topologyservice",
+        ["service_id"],
+        ["id"],
+    )
+    op.drop_constraint(
+        "topologyserviceapplication_application_id_fkey",
+        "topologyserviceapplication",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "topologyserviceapplication_application_id_fkey",
+        "topologyserviceapplication",
+        "topologyapplication",
+        ["application_id"],
+        ["id"],
+    )

--- a/keep/api/models/db/topology.py
+++ b/keep/api/models/db/topology.py
@@ -8,8 +8,8 @@ from sqlmodel import JSON, Column, Field, Relationship, SQLModel, func
 
 
 class TopologyServiceApplication(SQLModel, table=True):
-    service_id: int = Field(foreign_key="topologyservice.id", primary_key=True)
-    application_id: UUID = Field(foreign_key="topologyapplication.id", primary_key=True)
+    service_id: int = Field(foreign_key="topologyservice.id", primary_key=True, ondelete="CASCADE")
+    application_id: UUID = Field(foreign_key="topologyapplication.id", primary_key=True, ondelete="CASCADE")
 
     service: "TopologyService" = Relationship(
         sa_relationship_kwargs={

--- a/keep/api/tasks/process_topology_task.py
+++ b/keep/api/tasks/process_topology_task.py
@@ -8,6 +8,7 @@ from keep.api.core.dependencies import get_pusher_client
 from keep.api.models.db.topology import (
     TopologyApplicationDtoIn,
     TopologyService,
+    TopologyServiceApplication,
     TopologyServiceDependency,
     TopologyServiceDtoIn,
     TopologyServiceInDto,
@@ -45,6 +46,17 @@ def process_topology(
         # delete dependencies
         session.query(TopologyServiceDependency).filter(
             TopologyServiceDependency.service.has(
+                and_(
+                    TopologyService.source_provider_id == provider_id,
+                    TopologyService.tenant_id == tenant_id,
+                )
+            )
+        ).delete(synchronize_session=False)
+
+        # delete service-application links before deleting services to avoid
+        # ForeignKeyViolation on topologyserviceapplication.service_id (fixes #5439)
+        session.query(TopologyServiceApplication).filter(
+            TopologyServiceApplication.service.has(
                 and_(
                     TopologyService.source_provider_id == provider_id,
                     TopologyService.tenant_id == tenant_id,

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import uuid
 import pytest
+from unittest.mock import patch
 from sqlmodel import select
 
 from keep.api.core.dependencies import SINGLE_TENANT_UUID
@@ -8,8 +9,10 @@ from keep.api.models.db.topology import (
     TopologyApplication,
     TopologyApplicationDtoIn,
     TopologyService,
+    TopologyServiceApplication,
     TopologyServiceDependency,
     TopologyServiceDtoIn,
+    TopologyServiceInDto,
 )
 from keep.topologies.topologies_service import (
     TopologiesService,
@@ -17,6 +20,7 @@ from keep.topologies.topologies_service import (
     InvalidApplicationDataException,
     ServiceNotFoundException,
 )
+from keep.api.tasks.process_topology_task import process_topology
 from tests.fixtures.client import setup_api_key, client, test_app  # noqa: F401
 
 
@@ -387,3 +391,77 @@ def test_import_to_db(db_session):
         assert len(dependencies) == 1
         assert dependencies[0].service_id == 1
         assert dependencies[0].depends_on_service_id == 2
+
+
+def test_process_topology_no_foreignkey_violation_when_service_has_application(
+    db_session,
+):
+    """Regression test: process_topology must delete TopologyServiceApplication rows
+    before deleting TopologyService rows, otherwise a ForeignKeyViolation is raised
+    when the services belong to an application (issue #5439).
+    """
+    tenant_id = SINGLE_TENANT_UUID
+    provider_id = "test-provider"
+
+    # Create services belonging to an application
+    service_1 = TopologyService(
+        tenant_id=tenant_id,
+        service="svc-a",
+        display_name="Service A",
+        source_provider_id=provider_id,
+        updated_at=datetime.now(),
+    )
+    service_2 = TopologyService(
+        tenant_id=tenant_id,
+        service="svc-b",
+        display_name="Service B",
+        source_provider_id=provider_id,
+        updated_at=datetime.now(),
+    )
+    db_session.add(service_1)
+    db_session.add(service_2)
+    db_session.flush()
+
+    # Link them to an application (this creates TopologyServiceApplication rows)
+    application = TopologyApplication(
+        tenant_id=tenant_id,
+        name="My App",
+        services=[service_1, service_2],
+    )
+    db_session.add(application)
+    db_session.commit()
+
+    # Verify setup: service-application links exist
+    assert db_session.exec(select(TopologyServiceApplication)).all()
+
+    # Reimport topology via process_topology — must NOT raise ForeignKeyViolation
+    new_topology = [
+        TopologyServiceInDto(
+            service="svc-a",
+            display_name="Service A",
+            source_provider_id=provider_id,
+            dependencies={},
+        ),
+    ]
+
+    with patch(
+        "keep.api.tasks.process_topology_task.get_session_sync",
+        return_value=db_session,
+    ), patch(
+        "keep.api.tasks.process_topology_task.get_pusher_client",
+        return_value=None,
+    ):
+        # Before the fix this raised:
+        # sqlalchemy.exc.IntegrityError: ForeignKeyViolation on topologyserviceapplication
+        process_topology(tenant_id, new_topology, provider_id, "test")
+
+    # Services should be replaced with only the new one
+    services = db_session.exec(
+        select(TopologyService).where(TopologyService.tenant_id == tenant_id)
+    ).all()
+    assert len(services) == 1
+    assert services[0].service == "svc-a"
+
+    # Stale service-application links for deleted services should be gone
+    service_apps = db_session.exec(select(TopologyServiceApplication)).all()
+    assert all(sa.service_id == services[0].id for sa in service_apps)


### PR DESCRIPTION
## Summary

Fixes a `ForeignKeyViolation` that crashes `process_topology` whenever a provider's topology services belong to a **TopologyApplication**.

### Root cause

`process_topology` refreshes topology data by deleting then re-inserting all `TopologyService` rows for a given provider. The deletion order was:

1. Delete `TopologyServiceDependency` (correct — has `CASCADE`)
2. Delete `TopologyService` (fails when a row is still referenced by `TopologyServiceApplication.service_id`)

The `TopologyServiceApplication` join table does **not** have `ON DELETE CASCADE`, so step 2 raised:

```
sqlalchemy.exc.IntegrityError: ForeignKeyViolation:
update or delete on table "topologyservice" violates
foreign key constraint "topologyserviceapplication_service_id_fkey"
```

This is the exact traceback reported in #5439.

### Fix

Delete the `TopologyServiceApplication` rows for the affected services *before* deleting the `TopologyService` rows, using the same filter pattern already used for `TopologyServiceDependency`.

### Changes

- `keep/api/tasks/process_topology_task.py` — add `TopologyServiceApplication` deletion step
- `tests/test_topology.py` — regression test that would have caught this (and confirms the fix)

Closes #5439

/claim #5439