### PR TITLE
fix(topology): persist incident before adding alerts (fixes #5463)

### DIFF
--- a/keep/topologies/topology_processor.py
+++ b/keep/topologies/topology_processor.py
@@ -359,6 +359,12 @@ class TopologyProcessor:
                 is_visible=True,  # Topology-based incidents are always confirmed
             )
 
+            # Persist incident to database before adding alerts
+            # This is required because assign_alert_to_incident creates LastAlertToIncident
+            # records that reference incident.id via foreign key
+            session.add(incident)
+            session.flush()  # Flush to get the incident.id without committing
+
             # Get all alerts for the services and find max severity
             for service in services_with_alerts:
                 service_alerts = services_with_alerts[service]


### PR DESCRIPTION
## Summary

Fixes `ForeignKeyViolation` when creating topology-based incidents in the topology processor.

### Root Cause

In `_create_application_based_incident()`, the `Incident` object was created in memory but **not persisted** to the database before calling `assign_alert_to_incident()`. This caused `LastAlertToIncident` inserts to fail with:

```
psycopg2.errors.ForeignKeyViolation: insert or update on table "lastalerttoincident" 
violates foreign key constraint "lastalerttoincident_incident_id_fkey"
DETAIL: Key (incident_id)=(...) is not present in table "incident".
```

### The Fix

Add `session.add(incident)` and `session.flush()` after creating the `Incident` object to ensure the `incident.id` exists in the database before any alert associations are created.

```python
# Before (broken):
incident = Incident(...)
for alert in alerts:
    assign_alert_to_incident(...)  # FAILS - incident.id doesn't exist

# After (fixed):
incident = Incident(...)
session.add(incident)
session.flush()  # Now incident.id exists in DB
for alert in alerts:
    assign_alert_to_incident(...)  # Works!
```

### Changes

- `keep/topologies/topology_processor.py` - Add `session.add()` and `session.flush()` before alert assignment

### Testing

- Verified the fix addresses the exact error reported in #5463
- The same pattern is already used elsewhere in Keep (e.g., manual incident creation)

Fixes #5463
Related to #4816