### PR TITLE
fix: strip HTML tags from note values in alert table columns

### DIFF
--- a/keep-ui/widgets/alerts-table/lib/alert-table-utils.tsx
+++ b/keep-ui/widgets/alerts-table/lib/alert-table-utils.tsx
@@ -188,6 +188,15 @@ export const getCellClassName = (
 
 const columnHelper = createColumnHelper<AlertDto>();
 
+/**
+ * Strips HTML tags from a string, returning plain text.
+ * Used to display note values (saved via a rich-text editor) as plain text
+ * in alert table columns.
+ */
+const stripHtml = (html: string): string => {
+  return html.replace(/<[^>]*>/g, " ").replace(/\s{2,}/g, " ").trim();
+};
+
 interface GenerateAlertTableColsArg {
   additionalColsToGenerate?: string[];
   isCheckboxDisplayed?: boolean;
@@ -344,6 +353,13 @@ export const useAlertTableCols = (
           }
 
           if (value) {
+            // Strip HTML tags from note values — notes are saved by a rich-text
+            // editor (Quill) which wraps content in HTML tags like <p>...</p>.
+            // Table columns should display plain text only.
+            const displayValue =
+              context.column.id === "note" && typeof value === "string"
+                ? stripHtml(value)
+                : value.toString();
             return (
               <div
                 className={clsx(
@@ -353,7 +369,7 @@ export const useAlertTableCols = (
                     (rowStyle === "default" ? "line-clamp-1" : "line-clamp-3")
                 )}
               >
-                {value.toString()}
+                {displayValue}
               </div>
             );
           }


### PR DESCRIPTION
## Summary

Fixes #5283

## Problem

When a user adds a note to an alert using the rich-text editor (Quill), the note content is stored with HTML markup (e.g., \<p>My note text</p>\). When the \
ote\ field is displayed in the alert table columns, the raw HTML string was rendered as plain text, causing the user to see \<p>My note text</p>\ instead of \My note text\.

## Fix

Added a \stripHtml\ utility function in \keep-ui/widgets/alerts-table/lib/alert-table-utils.tsx\ that removes HTML tags using a regex replacement. When the generic column cell renderer encounters the \
ote\ column, it now passes the value through \stripHtml\ before rendering — displaying clean, readable plain text in the table.

## Changes

- \keep-ui/widgets/alerts-table/lib/alert-table-utils.tsx\: Added \stripHtml\ helper and applied it to \
ote\ column cell rendering.