### PR TITLE
fix: improve Python step error messages for better debugging

### DIFF
--- a/keep/providers/python_provider/python_provider.py
+++ b/keep/providers/python_provider/python_provider.py
@@ -28,6 +28,20 @@ class PythonProvider(BaseProvider):
         Returns:
             _type_: _description_
         """
+        # Validate Python syntax before rendering to catch user code errors early
+        # and provide a clear, actionable error message (see: #5327)
+        try:
+            compile(code, "<python_step>", "eval")
+        except SyntaxError as e:
+            # Try exec mode (multi-statement) as well
+            try:
+                compile(code, "<python_step>", "exec")
+            except SyntaxError as exec_err:
+                raise ProviderException(
+                    f"SyntaxError in Python step '{self.provider_id}': {exec_err.msg} "
+                    f"(line {exec_err.lineno})"
+                )
+
         modules = imports
         loaded_modules = {}
         if modules:
@@ -47,9 +61,33 @@ class PythonProvider(BaseProvider):
                         f"{self.__class__.__name__} failed to import library: {module}",
                         provider_id=self.provider_id,
                     )
-        parsed_code = self.io_handler.parse(code)
+
+        try:
+            parsed_code = self.io_handler.parse(code)
+        except SyntaxError as e:
+            # SyntaxError during template rendering — report the original user code error
+            # without leaking provider configuration details (e.g. URLs, ports) that
+            # may end up in the rendered string (#5327).
+            raise ProviderException(
+                f"SyntaxError in Python step '{self.provider_id}': {e.msg} "
+                f"(line {e.lineno})"
+            )
+        except Exception as e:
+            # Other rendering errors: surface a concise message without raw token data
+            raise ProviderException(
+                f"Error rendering Python step '{self.provider_id}': {e}"
+            )
+
         try:
             output = eval(parsed_code, loaded_modules)
+        except SyntaxError as e:
+            # SyntaxError after template rendering — show the rendered code snippet
+            # and the exact location so the user can debug quickly (#5327).
+            code_preview = parsed_code[:200] + "..." if len(parsed_code) > 200 else parsed_code
+            raise ProviderException(
+                f"SyntaxError in Python step '{self.provider_id}': {e.msg} "
+                f"(line {e.lineno}). Code preview:\n{code_preview}"
+            )
         except Exception as e:
             raise ProviderException(e)
         return output


### PR DESCRIPTION
## Summary

Fixes #5327

## Problem

When a workflow uses a Python step provider and the code contains a syntax error, the error message was extremely unclear. Instead of surfacing the actual Python SyntaxError, Keep would dump the entire rendered provider config string (including unrelated details like Kibana endpoints, ports, and validation tokens) as the error message.

**Example of the confusing error (before this fix):**
\\\
Got SyntaxError while parsing token 'keep.kb.us-central1.gcp.cloud.es.io', 'validation': 'any_http_url'...
\\\

This message has nothing to do with the user's Python code and is actively misleading.

## Root Cause

In \python_provider.py\, the \_query\ method calls \self.io_handler.parse(code)\ to render Jinja templates inside the code string. When this rendering fails with a \SyntaxError\ (or when the rendered code fails inside \eval()\), the exception message includes the raw rendered token — which can contain provider configuration data (URLs, authentication tokens, ports, etc.) from the workflow context.

## Fix

- **Pre-validation:** Added a \compile()\ check on the raw user code *before* template rendering to catch syntax errors early with a clear message.
- **Specific \SyntaxError\ handling** on \io_handler.parse()\: If rendering raises a \SyntaxError\, we now surface the exact error message and line number without leaking provider config details.
- **Specific \SyntaxError\ handling** on \eval()\: If the rendered code fails to evaluate with a \SyntaxError\, we show the error with line number and a short preview of the rendered code (capped at 200 chars) for context.

**Example of the improved error (after this fix):**
\\\
SyntaxError in Python step 'my-python-step': invalid syntax (line 3)
\\\

## Testing

Manual verification that:
- Valid Python expressions continue to work correctly
- Syntax errors in user code now produce clear, actionable error messages
- Provider config data is no longer leaked in error messages