### PR TITLE
fix: populate condition field when editing extraction rules

### DIFF
--- a/keep-ui/app/(keep)/extraction/create-or-update-extraction-rule.tsx
+++ b/keep-ui/app/(keep)/extraction/create-or-update-extraction-rule.tsx
@@ -61,9 +61,15 @@ export default function CreateOrUpdateExtractionRule({
       setIsPreFormatting(extractionToEdit.pre);
       setAttribute(extractionToEdit.attribute);
       setRegex(extractionToEdit.regex);
+      // condition is initialized directly from extractionToEdit to ensure
+      // the AlertsRulesBuilder receives it before mounting
       setCondition(extractionToEdit.condition ?? "");
     }
   }, [extractionToEdit]);
+
+  // Derive the condition to pass as defaultQuery so the AlertsRulesBuilder
+  // receives the correct initial value when the edit form opens.
+  const initialCondition = extractionToEdit?.condition ?? "";
 
   const clearForm = () => {
     setExtractionName("");
@@ -261,7 +267,8 @@ export default function CreateOrUpdateExtractionRule({
         </Text>
         <div className="mb-5">
           <AlertsRulesBuilder
-            defaultQuery={condition}
+            key={extractionToEdit?.id ?? "new"}
+            defaultQuery={initialCondition}
             updateOutputCEL={setCondition}
             showSave={false}
             showSqlImport={false}

--- a/keep-ui/features/presets/presets-manager/ui/alerts-rules-builder.tsx
+++ b/keep-ui/features/presets/presets-manager/ui/alerts-rules-builder.tsx
@@ -207,7 +207,7 @@ export const AlertsRulesBuilder = ({
 
   const [appliedCel, setAppliedCel] = useCelState({
     enableQueryParams: shouldSetQueryParam,
-    defaultCel: constructCELRules(selectedPreset),
+    defaultCel: constructCELRules(selectedPreset) || defaultQuery || "",
   });
   const [celRules, setCELRules] = useState(appliedCel);
 


### PR DESCRIPTION
## Description

When creating an extraction rule with a condition (e.g. source.contains('grafana')), the condition is correctly saved and visible in the extraction rules overview. However, when clicking **Edit** on an existing rule, the condition field is empty — the previously saved condition is not pre-populated.

## Root Cause

The AlertsRulesBuilder component initializes its internal CEL state from constructCELRules(selectedPreset), which returns an empty string when no preset is provided. Although the component accepts a defaultQuery prop, it was never wired into the state initialization, so the condition value passed from the edit form was silently ignored.

Additionally, the extraction edit form passes condition as defaultQuery, but condition is populated asynchronously via a useEffect. By the time condition is set, AlertsRulesBuilder has already mounted with an empty string.

## Fix

Two changes were made:

1. **lerts-rules-builder.tsx**: Wire the defaultQuery prop into the useCelState initialization so it is used as the fallback default when no preset CEL is available.

2. **create-or-update-extraction-rule.tsx**:
   - Derive initialCondition directly from extractionToEdit?.condition (synchronously available on render) instead of relying on the async state value.
   - Add a key prop to AlertsRulesBuilder based on extractionToEdit?.id so the component remounts with the correct initial condition whenever a different rule is opened for editing.

## Testing

1. Create an extraction rule with a condition (e.g. source.contains('grafana'))
2. Click **Edit** on the rule
3. Verify the condition field is pre-populated with the saved value

Fixes #5201