### PR TITLE
fix: preserve original timestamps on workflow revisions

### DIFF
--- a/keep/api/models/db/migrations/versions/2025-07-01-00-00_fix_workflowversion_updated_at.py
+++ b/keep/api/models/db/migrations/versions/2025-07-01-00-00_fix_workflowversion_updated_at.py
@@ -1,0 +1,50 @@
+"""fix: remove onupdate from WorkflowVersion.updated_at to preserve revision timestamps
+
+Revision ID: fix_workflowversion_updated_at
+Revises: 9dd1be4539e0
+Create Date: 2025-07-01 00:00:00.000000
+
+The `updated_at` column on `workflowversion` had `ON UPDATE CURRENT_TIMESTAMP`
+(expressed via SQLAlchemy's `onupdate=func.now()`).  This caused every existing
+revision row to have its timestamp silently overwritten whenever any column on
+that row was updated — most notably when `is_current` was flipped to False on
+all revisions before inserting a new one.  The result was that every revision
+in the Versions panel showed the timestamp of the most-recent save.
+
+This migration replaces the column definition with one that only sets a default
+on INSERT, so once a revision row is created its `updated_at` is immutable.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "fix_workflowversion_updated_at"
+down_revision = "9dd1be4539e0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Re-define the column without ON UPDATE so existing timestamps are frozen.
+    # We use batch_alter_table for SQLite compatibility.
+    with op.batch_alter_table("workflowversion", schema=None) as batch_op:
+        batch_op.alter_column(
+            "updated_at",
+            existing_type=sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            # Explicitly do NOT set onupdate — this is the whole point of the fix.
+            nullable=False,
+        )
+
+
+def downgrade() -> None:
+    # Restore the original (buggy) ON UPDATE behaviour.
+    with op.batch_alter_table("workflowversion", schema=None) as batch_op:
+        batch_op.alter_column(
+            "updated_at",
+            existing_type=sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            server_onupdate=sa.FetchedValue(),
+            nullable=False,
+        )

--- a/keep/api/models/db/workflow.py
+++ b/keep/api/models/db/workflow.py
@@ -53,7 +53,6 @@ class WorkflowVersion(SQLModel, table=True):
         sa_column=Column(
             DateTime(timezone=True),
             name="updated_at",
-            onupdate=func.now(),
             server_default=func.now(),
             nullable=False,
         )


### PR DESCRIPTION
## Summary

Fixes #5328

## Problem

In the workflow **Versions** panel, every revision was displaying the same timestamp — the time of the most-recent save. Older revisions had their `updated_at` timestamp silently overwritten each time a new revision was created.

### Root Cause

`WorkflowVersion.updated_at` was defined with `onupdate=func.now()` in the SQLAlchemy model:

```python
updated_at: datetime = Field(
    sa_column=Column(
        DateTime(timezone=True),
        name="updated_at",
        onupdate=func.now(),   # <-- the culprit
        server_default=func.now(),
        nullable=False,
    )
)
```

When saving a new revision, the code first runs:

```python
session.exec(
    update(WorkflowVersion)
    .where(col(WorkflowVersion.workflow_id) == existing_workflow.id)
    .values(is_current=False)
)
```

This UPDATE statement touched every existing revision row, causing the database to fire the `ON UPDATE CURRENT_TIMESTAMP` trigger on each one. As a result, all prior revisions got their `updated_at` overwritten to the current time — making every revision appear to have been created at the same moment.

## Fix

1. **Model** (`keep/api/models/db/workflow.py`): Removed `onupdate=func.now()` from `WorkflowVersion.updated_at`. The column still gets a `server_default` so it is populated on INSERT, but subsequent UPDATEs no longer mutate the timestamp.

2. **Migration** (`2025-07-01-00-00_fix_workflowversion_updated_at.py`): Alters the column definition in-place (using `batch_alter_table` for SQLite compatibility) to drop the `ON UPDATE` behaviour while keeping existing data intact.

## Testing

- Create a workflow and save it (revision 1).
- Wait a few seconds, then save again (revision 2).
- Open the Versions panel — revision 1 should still show its original timestamp, not the time of the revision-2 save.

## Checklist

- [x] Bug fix (non-breaking change)
- [x] Includes a database migration
- [x] Existing revision timestamps are preserved (migration does not touch data, only column metadata)
