### PR TITLE
fix: apply lastReceived field format changes in custom feeds

### DIFF
--- a/keep-ui/types/react-table.d.ts
+++ b/keep-ui/types/react-table.d.ts
@@ -1,4 +1,5 @@
 import "@tanstack/react-table";
+import { TimeFormatOption } from "@/widgets/alerts-table/lib/alert-table-time-format";
 
 declare module "@tanstack/table-core" {
   interface ColumnMeta<TData extends RowData, TValue> {
@@ -6,5 +7,10 @@ declare module "@tanstack/table-core" {
     tdClassName?: string;
     sticky?: boolean;
     align?: "left" | "right" | "center";
+  }
+
+  interface TableMeta<TData extends RowData> {
+    columnTimeFormats?: Record<string, TimeFormatOption>;
+    setColumnTimeFormats?: (formats: Record<string, TimeFormatOption>) => void;
   }
 }

--- a/keep-ui/widgets/alerts-table/lib/alert-table-utils.tsx
+++ b/keep-ui/widgets/alerts-table/lib/alert-table-utils.tsx
@@ -286,9 +286,12 @@ export const useAlertTableCols = (
                 ? value
                 : new Date(value as string | number);
             const isoString = date.toISOString();
-            // Get the format from column format settings or use default
+            // Get the format from table meta (backend-synced for custom feeds) or
+            // fall back to local column time formats, defaulting to "timeago"
+            const activeColumnTimeFormats =
+              context.table.options.meta?.columnTimeFormats ?? columnTimeFormats;
             const formatOption =
-              columnTimeFormats[context.column.id] || "timeago";
+              activeColumnTimeFormats[context.column.id] || "timeago";
             return (
               <span title={isoString}>
                 {formatDateTime(date, formatOption)}
@@ -624,8 +627,12 @@ export const useAlertTableCols = (
         const date = value instanceof Date ? value : new Date(value);
         const isoString = date.toISOString();
 
-        // Get the format from column format settings or use default
-        const formatOption = columnTimeFormats[context.column.id] || "timeago";
+        // Get the format from table meta (backend-synced for custom feeds) or
+        // fall back to local column time formats, defaulting to "timeago"
+        const activeColumnTimeFormats =
+          context.table.options.meta?.columnTimeFormats ?? columnTimeFormats;
+        const formatOption =
+          activeColumnTimeFormats[context.column.id] || "timeago";
 
         return (
           <span title={isoString}>{formatDateTime(date, formatOption)}</span>


### PR DESCRIPTION
## Summary

Fixes #5236

## Problem

In custom (backend-persisted) feeds, changing the format of the `lastReceived` field via the column header dropdown had no visible effect. The format change appeared to succeed silently - no error was shown - but the column continued rendering timestamps in the previous format.

## Root Cause

Custom feeds (non-static presets) use a backend API to persist column configuration, including `columnTimeFormats`. This is managed by the `usePresetColumnState` hook, which reads and writes format settings via `usePresetColumnConfig`. The `AlertTableServerSide` component correctly passes the synced `columnTimeFormats` to the table via `table.options.meta`.

However, the cell renderers in `useAlertTableCols` (inside `alert-table-utils.tsx`) read `columnTimeFormats` exclusively from React local storage via `useLocalStorage` -- a closure-captured value that is never updated when the backend state changes. This caused the visual display to remain stale even after the backend was successfully updated.

## Fix

- Updated both time-aware cell renderers in `useAlertTableCols` (the `lastReceived` accessor and the generic date column renderer in `filteredAndGeneratedCols`) to prefer `context.table.options.meta?.columnTimeFormats` over the local storage fallback. This ensures custom feeds render using the authoritative, backend-synced format.
- Extended the `TableMeta` interface declaration in `keep-ui/types/react-table.d.ts` to include `columnTimeFormats` and `setColumnTimeFormats`, providing proper TypeScript typing for the table metadata already set by `AlertTableServerSide`.

Static presets and the deprecated `AlertTable` component are unaffected -- they do not set `meta.columnTimeFormats`, so the local storage fallback continues to apply.

## Files Changed

- `keep-ui/widgets/alerts-table/lib/alert-table-utils.tsx` -- read `columnTimeFormats` from table meta when available
- `keep-ui/types/react-table.d.ts` -- extend `TableMeta` with `columnTimeFormats` and `setColumnTimeFormats`