### PR TITLE
fix(site24x7): resolve status and tags/labels not sent via webhook

### DIFF
--- a/keep/providers/site24x7_provider/site24x7_provider.py
+++ b/keep/providers/site24x7_provider/site24x7_provider.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode, urljoin
 import pydantic
 import requests
 
-from keep.api.models.alert import AlertDto, AlertSeverity
+from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
 from keep.contextmanager.contextmanager import ContextManager
 from keep.providers.base.base_provider import BaseProvider
 from keep.providers.models.provider_config import ProviderConfig, ProviderScope
@@ -85,6 +85,12 @@ class Site24X7Provider(BaseProvider):
         "TROUBLE": AlertSeverity.HIGH,
         "UP": AlertSeverity.INFO,
         "CRITICAL": AlertSeverity.CRITICAL,
+    }
+    STATUS_MAP = {
+        "DOWN": AlertStatus.FIRING,
+        "TROUBLE": AlertStatus.FIRING,
+        "CRITICAL": AlertStatus.FIRING,
+        "UP": AlertStatus.RESOLVED,
     }
 
     def __init__(
@@ -217,13 +223,34 @@ class Site24X7Provider(BaseProvider):
     def _format_alert(
         event: dict, provider_instance: "BaseProvider" = None
     ) -> AlertDto:
+        status_raw = event.get("STATUS", "DOWN")
+        severity = Site24X7Provider.SEVERITIES_MAP.get(status_raw, AlertSeverity.WARNING)
+        status = Site24X7Provider.STATUS_MAP.get(status_raw, AlertStatus.FIRING)
+
+        # Extract tags and labels from webhook payload
+        tags = event.get("TAGS", "")
+        if isinstance(tags, str) and tags:
+            tags = [t.strip() for t in tags.split(",") if t.strip()]
+        elif not isinstance(tags, list):
+            tags = []
+
+        labels = event.get("LABELS", "")
+        if isinstance(labels, str) and labels:
+            labels = [l.strip() for l in labels.split(",") if l.strip()]
+        elif not isinstance(labels, list):
+            labels = []
+
         return AlertDto(
             url=event.get("MONITORURL", ""),
             lastReceived=event.get("INCIDENT_TIME_ISO", ""),
             description=event.get("INCIDENT_REASON", ""),
             name=event.get("MONITORNAME", ""),
             id=event.get("MONITOR_ID", ""),
-            severity=Site24X7Provider.SEVERITIES_MAP.get(event.get("STATUS", "DOWN")),
+            status=status,
+            severity=severity,
+            source=["site24x7"],
+            tags=tags,
+            labels=labels,
         )
 
     def _get_alerts(self) -> list[AlertDto]:


### PR DESCRIPTION
## What

Fix two bugs in the Site24x7 provider where webhook alerts weren't properly handling resolve status or tags/labels.

## Why

Closes #6195 — Alert status was never being set. When Site24x7 sends a webhook with `STATUS=UP` (monitor recovered), the alert should resolve, but the provider only mapped status to severity, not to the AlertDto status field. Alerts stayed permanently in "Firing" state.

Closes #6196 — Tags and labels configured on Site24x7 monitors were being sent in the webhook payload (as `TAGS` and `LABELS` fields) but the provider's `_format_alert` method was ignoring them entirely.

## How

1. **Added `STATUS_MAP`** — Maps Site24x7 statuses to Keep's `AlertStatus`: `DOWN`/`TROUBLE`/`CRITICAL` → `FIRING`, `UP` → `RESOLVED`
2. **Set `status` field** in `AlertDto` — Previously only `severity` was set
3. **Extract `TAGS` and `LABELS`** from webhook payload — Parses comma-separated strings into lists
4. **Added `source=["site24x7"]`** — Was missing from the AlertDto

## Testing

- [ ] Existing tests pass
- [ ] Manual test: Site24x7 webhook with `STATUS=UP` produces `AlertStatus.RESOLVED`
- [ ] Manual test: Site24x7 webhook with `STATUS=DOWN` produces `AlertStatus.FIRING`
- [ ] Manual test: Tags and labels from webhook appear in alert
