### PR TITLE
docs: fix broken Markdown link syntax in keep-with-litellm.mdx

### DIFF
--- a/docs/deployment/local-llm/keep-with-litellm.mdx
+++ b/docs/deployment/local-llm/keep-with-litellm.mdx
@@ -4,8 +4,7 @@ title: "Running Keep with LiteLLM"
 
 <Info>
   This guide is for users who want to run Keep with locally hosted LLM models.
-  If you encounter any issues, please talk to us at our (Slack
-  community)[https://slack.keephq.dev].
+  If you encounter any issues, please talk to us at our [Slack community](https://slack.keephq.dev).
 </Info>
 
 ## Overview


### PR DESCRIPTION
## 📋 Description

This PR fixes the broken Markdown link syntax reported in #5400.

## 🔧 Changes

- Fixed the Slack community link in `docs/deployment/local-llm/keep-with-litellm.mdx`
- Changed from reversed syntax `(Slack community)[URL]` to correct syntax `[Slack community](URL)`

## ✅ Checklist

- [x] Fixed Markdown link syntax
- [x] Verified no other occurrences exist in the docs
- [x] Closes #5400

## 🧪 Testing

The link should now render correctly as a clickable hyperlink instead of plain text.