### PR TITLE
docs: fix broken Markdown link syntax in keep-with-litellm.mdx

### DIFF
--- a/docs/deployment/local-llm/keep-with-litellm.mdx
+++ b/docs/deployment/local-llm/keep-with-litellm.mdx
@@ -4,8 +4,8 @@ title: "Running Keep with LiteLLM"
 
 <Info>
   This guide is for users who want to run Keep with locally hosted LLM models.
-  If you encounter any issues, please talk to us at our (Slack
-  community)[https://slack.keephq.dev].
+  If you encounter any issues, please talk to us at our [Slack
+  community](https://slack.keephq.dev).
 </Info>
 
 ## Overview


### PR DESCRIPTION
**Description**

Fixes #5400

The Slack community link in the "Running Keep with LiteLLM" documentation was incorrectly formatted with reversed parentheses and brackets: 
- ❌  
- ✅ 

This change corrects the Markdown syntax so the link renders properly as a clickable hyperlink.

**Changes**
- Fixed Markdown link syntax in 

**Testing**
- Verified the corrected Markdown syntax renders correctly

## 📋 Checklist

- [x] Documentation update (no functional changes)