### PR TITLE
fix: set event in foreach AlertDto path so incident resolution check runs

### DIFF
--- a/keep/providers/base/base_provider.py
+++ b/keep/providers/base/base_provider.py
@@ -222,6 +222,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
             if isinstance(foreach_context, AlertDto):
                 fingerprint = foreach_context.fingerprint
+                event = foreach_context
             # if we are in a dict context, use the fingerprint from the dict
             elif isinstance(foreach_context, dict) and "fingerprint" in foreach_context:
                 fingerprint = foreach_context.get("fingerprint")

--- a/keep/providers/site24x7_provider/site24x7_provider.py
+++ b/keep/providers/site24x7_provider/site24x7_provider.py
@@ -236,7 +236,7 @@ class Site24X7Provider(BaseProvider):
 
         labels = event.get("LABELS", "")
         if isinstance(labels, str) and labels:
-            labels = [part.strip() for part in labels.split(",") if part.strip()]
+            labels = [lbl.strip() for lbl in labels.split(",") if lbl.strip()]
         elif not isinstance(labels, list):
             labels = []
 


### PR DESCRIPTION
Fixes #6194

Problem: When enriching alerts to resolved via a workflow foreach loop with AlertDto objects, the incident resolution check is silently skipped.

Root Cause: In BaseProvider._enrich(), the event variable is set in the tuple path (line 221) but never set in the AlertDto path (line 223-224). The resolution check is gated on if event and should_check_incidents_resolution, so it always evaluates to False for AlertDto foreach.

Fix: One line - assign event = foreach_context in the isinstance(foreach_context, AlertDto) branch.