### PR TITLE
docs: fix broken Slack community link formatting

### DIFF
--- a/docs/deployment/local-llm/keep-with-litellm.mdx
+++ b/docs/deployment/local-llm/keep-with-litellm.mdx
@@ -4,8 +4,8 @@ title: "Running Keep with LiteLLM"
 
 <Info>
   This guide is for users who want to run Keep with locally hosted LLM models.
-  If you encounter any issues, please talk to us at our (Slack
-  community)[https://slack.keephq.dev].
+  If you encounter any issues, please talk to us at our [Slack
+  community](https://slack.keephq.dev).
 </Info>
 
 ## Overview


### PR DESCRIPTION
## Summary

Fixes #5400

Corrects the Markdown link syntax in the LiteLLM documentation page. The link was incorrectly formatted as 
`(Slack community)[https://slack.keephq.dev]` instead of `[Slack community](https://slack.keephq.dev)`.

### Changes
- Fixed reversed brackets/parentheses in Slack community link
- Changed from `(text)[url]` to `[text](url)` format

### Affected file
- `docs/deployment/local-llm/keep-with-litellm.mdx`