### PR TITLE
fix: generate UUID for prometheus alerts when id is not a valid uuid

### DIFF
--- a/keep/providers/prometheus_provider/prometheus_provider.py
+++ b/keep/providers/prometheus_provider/prometheus_provider.py
@@ -5,6 +5,7 @@ PrometheusProvider is a class that provides a way to read data from Prometheus.
 import dataclasses
 import datetime
 import os
+import uuid as uuid_module
 
 import pydantic
 import requests
@@ -179,7 +180,16 @@ receivers:
             alerts = event.get("alerts", [event])
 
         for alert in alerts:
-            alert_id = alert.get("id", alert.get("labels", {}).get("alertname"))
+            raw_id = alert.get("id")
+            if raw_id:
+                try:
+                    uuid_module.UUID(str(raw_id))
+                    alert_id = raw_id
+                except (ValueError, AttributeError):
+                    alert_id = str(uuid_module.uuid4())
+            else:
+                alert_name = alert.get("labels", {}).get("alertname")
+                alert_id = alert_name if alert_name else str(uuid_module.uuid4())
             description = alert.get("annotations", {}).pop(
                 "description", None
             ) or alert.get("annotations", {}).get("summary", alert_id)


### PR DESCRIPTION
Fixes #4985

When Prometheus sends alerts via Alertmanager webhook, the id field contains the alertname string (e.g., HostOomKillDetected) rather than a UUID. This causes 500 errors when clicking alerts in workflow 'Triggered by' links, which expect a valid alert ID.

## Changes
- Added UUID generation for alert IDs that are not valid UUIDs
- Preserves existing UUID-format IDs from the payload
- Falls back to generating a new UUID when neither id nor lertname is UUID-formatted

## How it works
- If id is present and is a valid UUID → use it as-is
- If id is present but not a valid UUID (e.g., alertname string) → generate a new UUID
- If id is missing → try labels.alertname, or generate a UUID as last resort

## Testing
- [ ] Existing prometheus provider tests pass
- [ ] Alert with UUID-format id preserves the original id
- [ ] Alert with string alertname (e.g., HostOomKillDetected) generates a new UUID