### PR TITLE
fix: Redis lacking authentication for public network development

### DIFF
--- a/docker-compose-with-arq.yml
+++ b/docker-compose-with-arq.yml
@@ -35,9 +35,8 @@ services:
   keep-arq-redis:
     image: redis/redis-stack
     ports:
-      - "6379:6379"
-      - "8081:8001"
-
+      - "127.0.0.1:6379:6379"
+      - "127.0.0.1:8081:8001"
   keep-arq-dashboard:
     image: us-central1-docker.pkg.dev/keephq/keep/keep-arq-dashboard
     ports:


### PR DESCRIPTION
Fix the security issue of Redis lacking authentication for public network development.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

We fixed a security issue with Redis lacking authentication for public network access, which caused serious security problems in our environment, ultimately leading to the server being compromised by a cryptocurrency mining virus.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [✅] My pull request adheres to the code style of this project
- [✅] My code requires changes to the documentation
- [✅] I have updated the documentation as required
- [✅] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
