### PR TITLE
fix(incidents): use correct RBAC scopes for delete and read endpoints (fixes #5363)

### DIFF
--- a/keep/api/routes/incidents.py
+++ b/keep/api/routes/incidents.py
@@ -427,7 +427,7 @@ def update_incident(
 def bulk_delete_incidents(
     incident_ids: List[UUID] = Body(..., embed=True),
     authenticated_entity: AuthenticatedEntity = Depends(
-        IdentityManagerFactory.get_auth_verifier(["write:incident"])
+        IdentityManagerFactory.get_auth_verifier(["delete:incident"])
     ),
     pusher_client: Pusher | None = Depends(get_pusher_client),
     session: Session = Depends(get_session),
@@ -445,7 +445,7 @@ def bulk_delete_incidents(
 def delete_incident(
     incident_id: UUID,
     authenticated_entity: AuthenticatedEntity = Depends(
-        IdentityManagerFactory.get_auth_verifier(["write:incident"])
+        IdentityManagerFactory.get_auth_verifier(["delete:incident"])
     ),
     pusher_client: Pusher | None = Depends(get_pusher_client),
     session: Session = Depends(get_session),
@@ -549,7 +549,7 @@ def get_incident_alerts(
     offset: int = 0,
     include_unlinked: bool = False,
     authenticated_entity: AuthenticatedEntity = Depends(
-        IdentityManagerFactory.get_auth_verifier(["read:incidents"])
+        IdentityManagerFactory.get_auth_verifier(["read:incident"])
     ),
 ) -> AlertWithIncidentLinkMetadataPaginatedResultsDto:
     tenant_id = authenticated_entity.tenant_id
@@ -601,7 +601,7 @@ def get_future_incidents_for_an_incident(
     limit: int = 25,
     offset: int = 0,
     authenticated_entity: AuthenticatedEntity = Depends(
-        IdentityManagerFactory.get_auth_verifier(["read:incidents"])
+        IdentityManagerFactory.get_auth_verifier(["read:incident"])
     ),
 ) -> IncidentsPaginatedResultsDto:
     tenant_id = authenticated_entity.tenant_id
@@ -653,7 +653,7 @@ def get_incident_workflows(
     limit: int = 25,
     offset: int = 0,
     authenticated_entity: AuthenticatedEntity = Depends(
-        IdentityManagerFactory.get_auth_verifier(["read:incidents"])
+        IdentityManagerFactory.get_auth_verifier(["read:incident"])
     ),
 ) -> WorkflowExecutionsPaginatedResultsDto:
     """
@@ -718,7 +718,7 @@ def delete_alerts_from_incident(
     incident_id: UUID,
     fingerprints: List[str],
     authenticated_entity: AuthenticatedEntity = Depends(
-        IdentityManagerFactory.get_auth_verifier(["write:incident"])
+        IdentityManagerFactory.get_auth_verifier(["delete:incident"])
     ),
     session=Depends(get_session),
     pusher_client: Pusher | None = Depends(get_pusher_client),


### PR DESCRIPTION
## Summary

Fixes incorrect RBAC scope assignments in `incidents.py` where delete endpoints used `write:incident` instead of `delete:incident`, and some read endpoints used `read:incidents` (plural) instead of `read:incident` (singular).

### Root Cause

The delete and bulk-delete incident API endpoints were guarded with `write:incident` scope instead of `delete:incident`. This makes it impossible to create a role that can modify incidents but not delete them. Additionally, 3 read endpoints used `read:incidents` (plural) which is inconsistent with every other scope in the codebase.

### The Fix

Update scope strings to follow CRUD conventions:

```python
# Before (wrong):
IdentityManagerFactory.get_auth_verifier(["write:incident"])  # on delete endpoints
IdentityManagerFactory.get_auth_verifier(["read:incidents"])   # plural typo

# After (correct):
IdentityManagerFactory.get_auth_verifier(["delete:incident"])  # proper delete scope
IdentityManagerFactory.get_auth_verifier(["read:incident"])    # singular, consistent
```

The `Admin` role already defines `delete:*` wildcard scope in `rbac.py`, so `delete:incident` is properly matched.

### Changes

- `keep/api/routes/incidents.py` — 6 scope string corrections (3 delete, 3 read)

### Testing

- Verified `Admin` role has `delete:*` wildcard in `rbac.py` which matches `delete:incident`
- Confirmed all other scopes in the codebase use singular form (`read:incident`, `write:incident`, `read:alert`, `write:alert`)
- No existing tests reference these scope strings

Fixes #5363