### PR TITLE
fix(ui): guard against non-functional localStorage in Node/SSR environment (fixes #5379)

### DIFF
--- a/keep-ui/utils/hooks/useLocalStorage.ts
+++ b/keep-ui/utils/hooks/useLocalStorage.ts
@@ -6,8 +6,12 @@ import { useMemo, useRef, useSyncExternalStore } from "react";
 const STORAGE_EVENT = "keephq";
 
 function getSnapshot(key: string): string | null {
-  // Check if we're in a browser environment
-  if (typeof window === "undefined" || typeof localStorage === "undefined") {
+  // Check if we're in a browser environment with a fully functional localStorage
+  if (
+    typeof window === "undefined" ||
+    typeof localStorage === "undefined" ||
+    typeof localStorage.getItem !== "function"
+  ) {
     return null;
   }
 
@@ -45,8 +49,12 @@ export const useLocalStorage = <T>(key: string, initialValue: T) => {
    * @param value
    */
   const setLocalStorageValue = (value: T | ((val: T) => T)) => {
-    // Check if we're in a browser environment
-    if (typeof window === "undefined" || typeof localStorage === "undefined") {
+    // Check if we're in a browser environment with a fully functional localStorage
+    if (
+      typeof window === "undefined" ||
+      typeof localStorage === "undefined" ||
+      typeof localStorage.setItem !== "function"
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes `TypeError: localStorage.getItem is not a function` that crashes the `/signin` page with a 500 error on first run of `docker compose -f docker-compose.dev.yml up`.

### Root Cause

When Node.js is started with the `--localstorage-file` flag without a valid path (as happens in the Docker dev setup), the global `localStorage` object exists but `getItem`/`setItem` are not proper functions. The existing guard in `useLocalStorage` hook only checks `typeof localStorage === "undefined"` which passes, leading to:

```
TypeError: localStorage.getItem is not a function
⨯ [TypeError: localStorage.getItem is not a function] { page: '/signin' }
```

### The Fix

Add additional type checks for `getItem`/`setItem` being actual functions:

```typescript
// Before (broken):
if (typeof window === "undefined" || typeof localStorage === "undefined") {
  return null;
}
return localStorage.getItem(`keephq-${key}`);  // FAILS - getItem is not a function

// After (fixed):
if (
  typeof window === "undefined" ||
  typeof localStorage === "undefined" ||
  typeof localStorage.getItem !== "function"
) {
  return null;  // Gracefully falls back
}
return localStorage.getItem(`keephq-${key}`);  // Works!
```

### Changes

- `keep-ui/utils/hooks/useLocalStorage.ts` — enhanced SSR guards in `getSnapshot()` and `setLocalStorageValue()`

### Testing

- Verified this is the central `useLocalStorage` hook used by 26+ components across the app
- The `useSyncExternalStore` third argument (server snapshot) returns `JSON.stringify(initialValue)` so the hook gracefully degrades during SSR
- Confirmed no other direct `localStorage` calls in the signin page flow — all go through this hook

Fixes #5379