### PR TITLE
fix(workflows): sync workflow_raw YAML when toggling disabled state (fixes #5361)

### DIFF
--- a/keep/api/routes/workflows.py
+++ b/keep/api/routes/workflows.py
@@ -1184,9 +1184,13 @@ def toggle_workflow_state(
     if workflow.provisioned:
         raise HTTPException(403, detail="Cannot modify a provisioned workflow")
 
-    # Toggle the disabled state
-    # TODO: update workflow_raw
+    # Toggle the disabled state and sync workflow_raw YAML
     workflow.is_disabled = not workflow.is_disabled
+
+    workflow_raw_data = cyaml.safe_load(workflow.workflow_raw)
+    workflow_raw_data["disabled"] = workflow.is_disabled
+    workflow.workflow_raw = cyaml.dump(workflow_raw_data, width=99999)
+
     workflow.last_updated = datetime.datetime.now()
 
     session.add(workflow)


### PR DESCRIPTION
## Summary

Fixes mismatch between the workflow card's "Disabled" label and the actual YAML `disabled` field when toggling a workflow's enabled/disabled state via the API.

### Root Cause

In `toggle_workflow_state()`, only the `is_disabled` DB column was updated — the raw YAML stored in `workflow_raw` was never touched. This caused the UI card to show one state while the YAML contained a different `disabled` value. There was already a `TODO` comment acknowledging this:

```python
# Toggle the disabled state
# TODO: update workflow_raw
workflow.is_disabled = not workflow.is_disabled
```

### The Fix

Parse the stored YAML, update the `disabled` key to match the new state, and write it back:

```python
# Before (broken):
workflow.is_disabled = not workflow.is_disabled
# workflow_raw still has the old "disabled" value

# After (fixed):
workflow.is_disabled = not workflow.is_disabled
workflow_raw_data = cyaml.safe_load(workflow.workflow_raw)
workflow_raw_data["disabled"] = workflow.is_disabled
workflow.workflow_raw = cyaml.dump(workflow_raw_data, width=99999)
```

This follows the same `cyaml.dump(data, width=99999)` pattern used in the workflow update endpoint (line 848).

### Changes

- `keep/api/routes/workflows.py` — sync `workflow_raw` YAML in `toggle_workflow_state()`

### Testing

- Verified `cyaml.safe_load` / `cyaml.dump` are used throughout the codebase for YAML serialization
- The update workflow endpoint already reads `disabled` from YAML via `workflow_raw_data.get("disabled", False)` — this fix ensures round-trip consistency
- The `width=99999` parameter matches existing usage to prevent unwanted line wrapping

Fixes #5361