### PR TITLE
fix(db): change secret.value from VARCHAR(255) to TEXT (fixes #5353)

### DIFF
--- a/keep/api/models/db/migrations/versions/2025-06-19-10-00_a1b2c3d4e5f6.py
+++ b/keep/api/models/db/migrations/versions/2025-06-19-10-00_a1b2c3d4e5f6.py
@@ -1,0 +1,36 @@
+"""fix: Change secret.value from VARCHAR to TEXT
+
+Revision ID: a1b2c3d4e5f6
+Revises: 9dd1be4539e0
+Create Date: 2025-06-19 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "9dd1be4539e0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("secret") as batch_op:
+        batch_op.alter_column(
+            "value",
+            existing_type=sa.String(length=255),
+            type_=sa.Text(),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("secret") as batch_op:
+        batch_op.alter_column(
+            "value",
+            existing_type=sa.Text(),
+            type_=sa.String(length=255),
+            existing_nullable=False,
+        )

--- a/keep/api/models/db/secret.py
+++ b/keep/api/models/db/secret.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 
+from sqlalchemy import TEXT, Column
 from sqlmodel import Field, SQLModel
 
 class Secret(SQLModel, table=True):
     key: str = Field(primary_key=True)
-    value: str
+    value: str = Field(sa_column=Column(TEXT, nullable=False))
     
     last_updated: datetime = Field(
         default_factory=datetime.utcnow, 


### PR DESCRIPTION
## Summary

Fixes silent truncation of OAuth tokens in the `secret` table when using `SECRET_MANAGER_TYPE=db` with MySQL, which caused JSON parse errors and HTTP 400/500 during provider installation.

### Root Cause

The `Secret` model defines `value: str` without an explicit column type, which SQLModel/SQLAlchemy maps to `VARCHAR(255)` on MySQL. OAuth tokens from providers like PagerDuty and Flux routinely exceed 255 characters, causing silent truncation:

```python
# Before (broken):
class Secret(SQLModel, table=True):
    key: str = Field(primary_key=True)
    value: str  # Maps to VARCHAR(255) on MySQL — tokens get truncated!
```

The truncated JSON then fails to parse:
```
Unterminated string starting at: line 1 column 247 (char 246)
```

### The Fix

Change the column type to `TEXT` which has no practical size limit:

```python
# Before (broken):
value: str  # VARCHAR(255) — truncates OAuth tokens

# After (fixed):
value: str = Field(sa_column=Column(TEXT, nullable=False))  # TEXT — no size limit
```

Added an Alembic migration using `batch_alter_table` (SQLite-safe) to alter the column for existing deployments.

### Changes

- `keep/api/models/db/secret.py` — change `value` field to use `TEXT` column type
- `keep/api/models/db/migrations/versions/2025-06-19-10-00_a1b2c3d4e5f6.py` — Alembic migration to alter existing `VARCHAR(255)` to `TEXT`

### Testing

- The same `sa_column=Column(TEXT)` pattern is used throughout Keep's models (e.g., `workflow_raw`, `name`, `description` in `workflow.py`)
- Migration uses `batch_alter_table` for SQLite compatibility
- No data loss — `VARCHAR` → `TEXT` is a safe, non-destructive migration
- Existing short secrets remain unaffected

Fixes #5353