### PR TITLE
fix(ui): use name instead of id in workflow execution triggered-by alert CEL filter

### DIFF
--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, R
 from fastapi.responses import JSONResponse
 from pusher import Pusher
 from sqlalchemy_utils import UUIDType
+from sqlalchemy.exc import DataError
 from sqlmodel import Session
 
 from keep.api.arq_pool import get_pool
@@ -227,6 +228,14 @@ def query_alerts(
         logger.exception(f'Error parsing CEL expression "{query.cel}". {str(e)}')
         raise HTTPException(
             status_code=400, detail=f"Error parsing CEL expression: {query.cel}"
+        ) from e
+    except DataError as e:
+        logger.exception(
+            f'Database type error while executing query "{query.cel}". {str(e)}'
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid value in query - a field may contain a non-UUID value: {query.cel}",
         ) from e
 
     db_alerts = enrich_alerts_with_incidents(tenant_id, db_alerts)


### PR DESCRIPTION
Based on the suggestion in #6237, this PR was repurposed from the original frontend fix to instead add a defensive `DataError` handler at the `/alerts/query` API layer.

The root cause is that the Prometheus provider stores `alertname` as the alert `id` instead of a UUID (tracked in #6219). The workflow scheduler embeds this non-UUID string into `triggered_by`, the frontend builds a CEL filter `id=="<alertname>"`, and the backend maps `id` to `lastalert.alert_id` (a UUID column). PostgreSQL rejects the query with `invalid input syntax for type uuid` — this `DataError` was not caught, so FastAPI returned a `500`.

PR #6219 fixes this at the provider level. This PR adds a complementary safety net at the API layer so any provider storing a non-UUID alert `id` returns a `400` with a clear message instead of an unhandled `500`, regardless of whether #6219 has been merged.

Closes #6237

## 📑 Description

- [x] `keep/api/routes/alerts.py`: add `except DataError` in `query_alerts` alongside the existing `except CelToSqlException`, returning `400` instead of `500`

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

**Before:** any CEL query containing a non-UUID value against a UUID-typed column causes an unhandled `DataError` → `500 An internal server error occurred. URL: /alerts/query`.

**After:** the same query returns `400 Invalid value in query - a field may contain a non-UUID value` with the offending CEL expression in the response detail.

No breaking changes. No new dependencies. Related: #6219.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized error-handling change that only alters the HTTP response for previously-unhandled database type errors (500 -> 400) when running alert queries.
> 
> **Overview**
> Prevents `/alerts/query` from returning an unhandled 500 when a CEL filter supplies an invalid value for a UUID-typed field.
> 
> `query_alerts` now catches SQLAlchemy `DataError` and returns a **400** with a clearer message (including the offending CEL expression), alongside the existing `CelToSqlException` handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd88610b78f61aeaf61e1dc85dcd4480d2d2f5ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->