### PR TITLE
fix: apply custom dedup rules to pulled alerts (closes #5370)

### DIFF
--- a/keep/providers/base/base_provider.py
+++ b/keep/providers/base/base_provider.py
@@ -569,6 +569,20 @@ class BaseProvider(metaclass=abc.ABCMeta):
             for alert in alerts:
                 alert.providerId = self.provider_id
                 alert.providerType = self.provider_type
+
+            # Apply custom deduplication rules to pulled alerts
+            # (mirrors the logic in format_alert() for webhook alerts)
+            custom_deduplication_rule = get_custom_deduplication_rule(
+                tenant_id=self.context_manager.tenant_id,
+                provider_id=self.provider_id,
+                provider_type=self.provider_type,
+            )
+            if custom_deduplication_rule:
+                for alert in alerts:
+                    alert.fingerprint = self.get_alert_fingerprint(
+                        alert, custom_deduplication_rule.fingerprint_fields
+                    )
+
             return alerts
 
     def get_alerts_by_fingerprint(self, tenant_id: str) -> dict[str, list[AlertDto]]:

--- a/tests/test_get_alerts_custom_dedup.py
+++ b/tests/test_get_alerts_custom_dedup.py
@@ -1,0 +1,141 @@
+import hashlib
+import unittest
+from unittest.mock import MagicMock, patch
+
+from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
+from keep.providers.base.base_provider import BaseProvider
+
+
+def _make_alert(name, labels=None, fingerprint=None):
+    return AlertDto(
+        id=name,
+        name=name,
+        status=AlertStatus.FIRING,
+        severity=AlertSeverity.WARNING,
+        lastReceived="2025-01-01T00:00:00Z",
+        labels=labels or {},
+        fingerprint=fingerprint,
+        source=["test"],
+    )
+
+
+class _StubProvider(BaseProvider):
+    """Concrete stub so we can instantiate BaseProvider for testing."""
+
+    def dispose(self):
+        pass
+
+    def validate_config(self):
+        pass
+
+
+def _make_provider(alerts):
+    """Create a minimal provider instance that returns canned alerts."""
+    provider = object.__new__(_StubProvider)
+    provider.provider_id = "test-provider-id"
+    provider.provider_type = "prometheus"
+    provider.context_manager = MagicMock()
+    provider.context_manager.tenant_id = "test-tenant"
+    provider.logger = MagicMock()
+    provider._get_alerts = MagicMock(return_value=alerts)
+    return provider
+
+
+class TestGetAlertsCustomDedup(unittest.TestCase):
+    @patch("keep.providers.base.base_provider.get_custom_deduplication_rule")
+    def test_custom_dedup_rule_overwrites_fingerprint(self, mock_get_rule):
+        """Pulled alerts should get fingerprints recalculated when a custom dedup rule exists."""
+        alert_a = _make_alert(
+            "HighCPU",
+            labels={"alertname": "HighCPU", "env": "prod"},
+            fingerprint="native-fp-1",
+        )
+        alert_b = _make_alert(
+            "HighCPU",
+            labels={"alertname": "HighCPU", "env": "staging"},
+            fingerprint="native-fp-1",  # same native fingerprint
+        )
+
+        rule = MagicMock()
+        rule.fingerprint_fields = ["labels.alertname", "labels.env"]
+        mock_get_rule.return_value = rule
+
+        provider = _make_provider([alert_a, alert_b])
+
+        with patch(
+            "keep.providers.base.base_provider.tracer"
+        ) as mock_tracer:
+            mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock()
+            mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock()
+            alerts = provider.get_alerts()
+
+        # fingerprints should now differ because env differs
+        self.assertNotEqual(alerts[0].fingerprint, alerts[1].fingerprint)
+
+        # verify fingerprint matches expected sha256
+        expected_a = hashlib.sha256()
+        expected_a.update(b"HighCPU")
+        expected_a.update(b"prod")
+        self.assertEqual(alerts[0].fingerprint, expected_a.hexdigest())
+
+        expected_b = hashlib.sha256()
+        expected_b.update(b"HighCPU")
+        expected_b.update(b"staging")
+        self.assertEqual(alerts[1].fingerprint, expected_b.hexdigest())
+
+    @patch("keep.providers.base.base_provider.get_custom_deduplication_rule")
+    def test_no_custom_rule_keeps_original_fingerprint(self, mock_get_rule):
+        """Without a custom dedup rule, pulled alerts keep their original fingerprint."""
+        alert = _make_alert(
+            "DiskFull",
+            labels={"alertname": "DiskFull"},
+            fingerprint="original-fp",
+        )
+
+        mock_get_rule.return_value = None
+
+        provider = _make_provider([alert])
+
+        with patch(
+            "keep.providers.base.base_provider.tracer"
+        ) as mock_tracer:
+            mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock()
+            mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock()
+            alerts = provider.get_alerts()
+
+        self.assertEqual(alerts[0].fingerprint, "original-fp")
+
+    @patch("keep.providers.base.base_provider.get_custom_deduplication_rule")
+    def test_custom_dedup_with_dot_notation_fields(self, mock_get_rule):
+        """Custom dedup should support dot-notation to access nested dict fields."""
+        alert = _make_alert(
+            "NodeDown",
+            labels={"alertname": "NodeDown", "env_dc": "us-east", "group": "infra"},
+        )
+
+        rule = MagicMock()
+        rule.fingerprint_fields = [
+            "labels.alertname",
+            "labels.env_dc",
+            "labels.group",
+        ]
+        mock_get_rule.return_value = rule
+
+        provider = _make_provider([alert])
+
+        with patch(
+            "keep.providers.base.base_provider.tracer"
+        ) as mock_tracer:
+            mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock()
+            mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock()
+            alerts = provider.get_alerts()
+
+        expected = hashlib.sha256()
+        expected.update(b"NodeDown")
+        expected.update(b"us-east")
+        expected.update(b"infra")
+        self.assertEqual(alerts[0].fingerprint, expected.hexdigest())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #5370 - Prometheus (and all other) providers now respect custom deduplication rules when pulling alerts.

## Root Cause

Custom dedup rules (`fingerprint_fields`) were applied in `format_alert()` (webhook path) but **not** in `get_alerts()` (pull path). When alerts are pulled via the provider's `_get_alerts()` method, the fingerprint from the source system was used as-is, ignoring any user-configured `fingerprint_fields`.

For Prometheus specifically, the native fingerprint is based on `alertname` alone, so alerts with different labels (e.g. `env_dc`, `group`) were incorrectly matching as duplicates:
```
echo -n 'NodeLowDiskSpace4Hours' | sha256sum
6211e97de90695be41b49c773306001204872a6ebb36f4aa72a5bbd998ce7ac5
```

## Fix

Added custom dedup rule application to `BaseProvider.get_alerts()`, mirroring the existing logic in `format_alert()`. This means ALL providers benefit from the fix when pulling alerts, not just Prometheus.

### Changed files:
- `keep/providers/base/base_provider.py` - Apply `get_custom_deduplication_rule` + `get_alert_fingerprint` in `get_alerts()` after setting provider metadata
- `tests/test_get_alerts_custom_dedup.py` - Unit tests verifying custom dedup rules are applied to pulled alerts

## Testing

Added 3 unit tests:
1. Custom dedup rule overwrites native fingerprint (different labels produce different fingerprints)
2. No custom rule preserves original fingerprint
3. Dot-notation field access works for nested label keys (matches issue reporter's `labels.alertname`, `labels.env_dc`, `labels.group` config)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how alert `fingerprint`s are computed for all pulled alerts when a tenant has custom dedup rules, which can affect deduplication/grouping behavior across the system. Scope is small and covered by new unit tests, but behavior changes may impact existing alert correlation expectations.
> 
> **Overview**
> Pulled alerts returned by `BaseProvider.get_alerts()` now **respect tenant custom deduplication rules** by recalculating each alert’s `fingerprint` using the configured `fingerprint_fields` (mirroring the existing webhook `format_alert()` behavior).
> 
> Adds unit tests to ensure a custom rule overwrites the source/native fingerprint, the original fingerprint is preserved when no rule exists, and dot-notation field paths (e.g. `labels.env_dc`) work when building the fingerprint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 492a69e9f3750de6b3fba5a6e80ed8dd6a94cf55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->