### PR TITLE
feat: trigger workflows when alert is assigned via UI (closes #5570)

### DIFF
--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -462,6 +462,23 @@ def assign_alert(
             "fingerprint": fingerprint,
         },
     )
+
+    # Trigger workflows so that assign/unassign changes are picked up
+    # by workflows with only_on_change: [assignee]
+    try:
+        alert = get_alerts_by_fingerprint(tenant_id, fingerprint, limit=1)
+        if alert:
+            enriched_alerts_dto = convert_db_alerts_to_dto_alerts(alert)
+            workflow_manager = WorkflowManager.get_instance()
+            workflow_manager.insert_events(
+                tenant_id=tenant_id, events=enriched_alerts_dto
+            )
+    except Exception:
+        logger.exception(
+            "Failed to trigger workflows after alert assignment",
+            extra={"fingerprint": fingerprint, "tenant_id": tenant_id},
+        )
+
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Summary

Fixes #5570 - Alert assignment/unassignment via the UI now triggers workflows.

## Problem

The `/{fingerprint}/assign/{last_received}` endpoint enriches the alert (updating assignee and status) but never calls `workflow_manager.insert_events()`. This means workflows with `only_on_change: [assignee]` triggers are never fired when users assign alerts through the Keep UI.

## Fix

Added `workflow_manager.insert_events()` call after the enrichment, following the same pattern used by the `/enrich` and `/batch_enrich` endpoints:

1. Fetch the alert by fingerprint
2. Convert to DTO with enrichments applied
3. Call `workflow_manager.insert_events()` to trigger matching workflows

The call is wrapped in a try/except so that workflow trigger failures don't break the assignment operation itself.

### Changed files:
- `keep/api/routes/alerts.py` - Add workflow trigger to `assign_alert()` endpoint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds workflow event insertion to the alert assignment endpoint, which can trigger additional automation and side effects on each assign/unassign. Failures are swallowed, but incorrect/duplicate event insertion or extra DB/workflow load could affect downstream workflow behavior.
> 
> **Overview**
> Alert assignment/unassignment via `/{fingerprint}/assign/{last_received}` now **triggers workflows** by re-fetching the updated alert, converting it to DTOs, and calling `WorkflowManager.insert_events()` so workflows with `only_on_change: [assignee]` can fire.
> 
> The workflow trigger is wrapped in `try/except` so assignment still succeeds even if workflow insertion fails, with errors logged for visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbce69173beb1e6ffc4f2181d205a9d456f31779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->