### PR TITLE
fix: seed tenant for SSO auth types (OKTA/KEYCLOAK/AZUREAD) on fresh database

### DIFF
--- a/keep/api/config.py
+++ b/keep/api/config.py
@@ -59,12 +59,18 @@ def on_starting(server=None):
         IdentityManagerTypes.NOAUTH.value,
         IdentityManagerTypes.OAUTH2PROXY.value,
         IdentityManagerTypes.ONELOGIN.value,
+        IdentityManagerTypes.OKTA.value,
+        IdentityManagerTypes.KEYCLOAK.value,
+        "azuread",  # enterprise-only, no enum entry
         "no_auth",  # backwards compatibility
         "single_tenant",  # backwards compatibility
     ]:
         excluded_from_default_user = [
             IdentityManagerTypes.OAUTH2PROXY.value,
             IdentityManagerTypes.ONELOGIN.value,
+            IdentityManagerTypes.OKTA.value,
+            IdentityManagerTypes.KEYCLOAK.value,
+            "azuread",
         ]
         # for oauth2proxy, we don't want to create the default user
         try_create_single_tenant(


### PR DESCRIPTION
on_starting() skipped try_create_single_tenant() for OKTA, KEYCLOAK, and AZUREAD auth types because they were missing from the allowlist. On a fresh database this leaves the tenant table empty, causing an infinite redirect loop after successful SSO login.

Add all three to the allowlist and to excluded_from_default_user (SSO types delegate auth to the IdP so no local user is needed).

try_create_single_tenant() is already idempotent, so existing deployments are unaffected.

Closes #6246  <!-- paste issue number after filing -->

## 📑 Description

When `AUTH_TYPE` is set to `OKTA`, `KEYCLOAK`, or `AZUREAD` and the database is fresh (new PG cluster, PVC recreated, etc.), `on_starting()` in `keep/api/config.py` never calls `try_create_single_tenant()` because these auth types are missing from the allowlist. The `tenant` table stays empty, and authenticated users hit an infinite redirect loop between `/signin` and `/incidents`.

This PR adds the three missing auth types to the allowlist and to `excluded_from_default_user` so the tenant row is seeded on startup without creating a local default user (SSO delegates auth to the IdP).

Note: `AZUREAD` has no `IdentityManagerTypes` enum entry (it is enterprise-only under `ee/` and loaded dynamically), so the raw string `"azuread"` is used.

- [x] Add `OKTA`, `KEYCLOAK`, `"azuread"` to auth-type allowlist
- [x] Add `OKTA`, `KEYCLOAK`, `"azuread"` to `excluded_from_default_user`

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

The bug went unnoticed because the PVC normally persists across redeployments — the tenant row created during initial setup survives indefinitely. It only surfaces on a fresh database bootstrap.

Workaround for anyone on older versions: add an idempotent `INSERT INTO tenant (id, name) VALUES ('keep', 'Single Tenant') ON CONFLICT (id) DO NOTHING;` to the backend init container.