### PR TITLE
fix: add OKTA and KEYCLOAK to tenant seeding allowlist

### DIFF
--- a/keep/api/config.py
+++ b/keep/api/config.py
@@ -59,12 +59,16 @@ def on_starting(server=None):
         IdentityManagerTypes.NOAUTH.value,
         IdentityManagerTypes.OAUTH2PROXY.value,
         IdentityManagerTypes.ONELOGIN.value,
+        IdentityManagerTypes.KEYCLOAK.value,
+        IdentityManagerTypes.OKTA.value,
         "no_auth",  # backwards compatibility
         "single_tenant",  # backwards compatibility
     ]:
         excluded_from_default_user = [
             IdentityManagerTypes.OAUTH2PROXY.value,
             IdentityManagerTypes.ONELOGIN.value,
+            IdentityManagerTypes.KEYCLOAK.value,
+            IdentityManagerTypes.OKTA.value,
         ]
         # for oauth2proxy, we don't want to create the default user
         try_create_single_tenant(


### PR DESCRIPTION
## Summary

Fixes #6246

OKTA and KEYCLOAK auth types were missing from the tenant seeding allowlist in `on_starting()` (`keep/api/config.py`), causing the `tenant` table to remain empty on fresh database deployments. Users experienced an infinite redirect loop between `/signin` and `/incidents` after successful SSO login because no tenant row existed.

## Changes

- Added `IdentityManagerTypes.KEYCLOAK.value` and `IdentityManagerTypes.OKTA.value` to the auth type allowlist that gates `try_create_single_tenant()`
- Added both types to `excluded_from_default_user` since users authenticate through the external IdP (consistent with OAUTH2PROXY and ONELOGIN behavior)

## Root Cause

The allowlist in `on_starting()` only included DB, NOAUTH, OAUTH2PROXY, and ONELOGIN. OKTA and KEYCLOAK were missing despite being valid single-tenant auth types in the `IdentityManagerTypes` enum.

## Testing

- Verified the `IdentityManagerTypes` enum includes both KEYCLOAK and OKTA
- The change is additive — no existing behavior is modified for other auth types

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive change to startup tenant seeding logic; main impact is ensuring fresh deployments using Okta/Keycloak create the expected tenant row and avoid redirect loops.
> 
> **Overview**
> Ensures single-tenant seeding runs when `AUTH_TYPE` is `keycloak` or `okta` by adding both to the allowlist gating `try_create_single_tenant()`.
> 
> Also excludes these auth types from default-user creation (matching `oauth2proxy`/`onelogin` behavior) since users authenticate via the external IdP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eec7d72fc6bbbec6c0a3d96abb14f1213979b9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->