### PR TITLE
fix(auth): restore get_roles() for Okta — API key creation broken under AUTH_TYPE=OKTA

### DIFF
--- a/keep/identitymanager/identity_managers/okta/okta_authverifier.py
+++ b/keep/identitymanager/identity_managers/okta/okta_authverifier.py
@@ -10,7 +10,7 @@ from keep.identitymanager.authverifierbase import AuthVerifierBase, oauth2_schem
 logger = logging.getLogger(__name__)
 
 # Define constant locally instead of importing it
-DEFAULT_ROLE_NAME = "user"  # Default role name for user access
+DEFAULT_ROLE_NAME = "noc"  # Default role name for user access
 
 class OktaAuthVerifier(AuthVerifierBase):
     """Handles authentication and authorization for Okta"""

--- a/keep/identitymanager/identity_managers/okta/okta_identitymanager.py
+++ b/keep/identitymanager/identity_managers/okta/okta_identitymanager.py
@@ -114,12 +114,7 @@ class OktaIdentityManager(BaseIdentityManager):
         """Create a role in Okta - disabled"""
         self.logger.info("create_role called but management functions are disabled")
         return ""
-    
-    def get_roles(self) -> list[Role]:
-        """Get all roles from Okta - disabled"""
-        self.logger.info("get_roles called but management functions are disabled")
-        return []
-    
+
     def delete_role(self, role_id: str) -> None:
         """Delete a role from Okta - disabled"""
         self.logger.info("delete_role called but management functions are disabled")


### PR DESCRIPTION
OktaIdentityManager.get_roles() was overriding the base class with return [] — causing the role dropdown in Settings → API Keys to render "No options" and blocking API key creation entirely under AUTH_TYPE=OKTA.

Predefined roles (admin, noc, webhook, workflowrunner) are defined locally in rbac.py and require no Okta API call, so the base class implementation is correct as-is. Remove the stub override so it falls through to BaseIdentityManager.get_roles().

Also fix DEFAULT_ROLE_NAME in OktaAuthVerifier: "user" is not a valid role in rbac.py and causes a 403 for tokens without an explicit role claim. Change to "noc" (least-privileged predefined role).

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #6253

## 📑 Description

- [x] Remove `get_roles()` override in `OktaIdentityManager` — falls through to `BaseIdentityManager.get_roles()` which correctly returns predefined roles from `rbac.py`
- [x] Fix `DEFAULT_ROLE_NAME` in `OktaAuthVerifier` from `"user"` to `"noc"`

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

The same stub pattern may be present in other SSO identity managers (`KEYCLOAK`, `AZUREAD`, `ONELOGIN`) — worth a follow-up audit of their `get_roles()` overrides.