### PR TITLE
feat: add client and client_url support to PagerDuty Event API

### DIFF
--- a/keep/providers/pagerduty_provider/pagerduty_provider.py
+++ b/keep/providers/pagerduty_provider/pagerduty_provider.py
@@ -437,6 +437,12 @@ class PagerdutyProvider(
         if kwargs.get("class"):
             payload["payload"]["class"] = kwargs.get("class")
 
+        if kwargs.get("client"):
+            payload["client"] = kwargs.get("client")
+
+        if kwargs.get("client_url"):
+            payload["client_url"] = kwargs.get("client_url")
+
         if kwargs.get("images"):
             images = kwargs.get("images", [])
             if isinstance(images, str):


### PR DESCRIPTION
## Summary
Adds `client` and `client_url` optional parameters to PagerDuty Event API.

## Changes
- Added `client` and `client_url` as top-level payload fields in `_build_alert` method
- These fields display a "Client view in {client}" link in PagerDuty UI

## Reference
- Fixes #6233
- PagerDuty Events API v2: https://developer.pagerduty.com/api-reference/368ae3d938c9e-send-an-event-to-pager-duty

## Comparison with existing PR #6234
This PR is cleaner - it does NOT include the unrelated version bump in pyproject.toml.