### PR TITLE
feat: add Syslog TCP Provider

### DIFF
--- a/keep/providers/syslog_provider/__init__.py
+++ b/keep/providers/syslog_provider/__init__.py
@@ -1,0 +1,1 @@
+# Syslog provider

--- a/keep/providers/syslog_provider/syslog_provider.py
+++ b/keep/providers/syslog_provider/syslog_provider.py
@@ -1,0 +1,296 @@
+"""
+SyslogProvider is a class that provides a way to ingest syslog messages received on a TCP port.
+"""
+
+import asyncio
+import dataclasses
+import re
+import typing
+import uuid
+
+import pydantic
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.base.base_provider import BaseProvider
+from keep.providers.models.provider_config import ProviderConfig, ProviderScope
+
+
+SYSLOG_SEVERITY_MAP = {
+    0: "critical",   # Emergency
+    1: "critical",   # Alert
+    2: "critical",   # Critical
+    3: "high",       # Error
+    4: "warning",    # Warning
+    5: "info",       # Notice
+    6: "info",       # Informational
+    7: "low",        # Debug
+}
+
+SYSLOG_SEVERITY_NAMES = {
+    0: "emergency",
+    1: "alert",
+    2: "critical",
+    3: "error",
+    4: "warning",
+    5: "notice",
+    6: "informational",
+    7: "debug",
+}
+
+SYSLOG_FACILITY_NAMES = {
+    0: "kern", 1: "user", 2: "mail", 3: "daemon",
+    4: "auth", 5: "syslog", 6: "lpr", 7: "news",
+    8: "uucp", 9: "cron", 10: "authpriv", 11: "ftp",
+    12: "ntp", 13: "security", 14: "console", 15: "solaris-cron",
+    16: "local0", 17: "local1", 18: "local2", 19: "local3",
+    20: "local4", 21: "local5", 22: "local6", 23: "local7",
+}
+
+# RFC 3164: <priority>timestamp hostname app-name[pid]: message
+RFC3164_RE = re.compile(
+    r"^<(\d+)>"                          # priority
+    r"(\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+"  # timestamp (BSD)
+    r"(\S+)\s+"                           # hostname
+    r"(\S+?)(?:\[(\d+)\])?:\s*"          # app-name[pid]:
+    r"(.*)$"                              # message
+)
+
+# RFC 5424: <priority>version timestamp hostname app-name procid msgid structured-data msg
+RFC5424_RE = re.compile(
+    r"^<(\d+)>"                          # priority
+    r"(\d+)\s+"                           # version
+    r"(\S+)\s+"                           # timestamp
+    r"(\S+)\s+"                           # hostname
+    r"(\S+)\s+"                           # app-name
+    r"(\S+)\s+"                           # procid
+    r"(\S+)\s+"                           # msgid
+    r"(\S+)\s+"                           # structured-data
+    r"(.*)$"                              # message
+)
+
+
+@pydantic.dataclasses.dataclass
+class SyslogProviderAuthConfig:
+    """Syslog authentication configuration."""
+
+    host: str = dataclasses.field(
+        default="0.0.0.0",
+        metadata={
+            "required": False,
+            "description": "Host to listen on",
+            "hint": "e.g. 0.0.0.0",
+        },
+    )
+
+    port: int = dataclasses.field(
+        default=514,
+        metadata={
+            "required": False,
+            "description": "TCP port to listen on",
+            "hint": "Default: 514 (standard syslog port)",
+        },
+    )
+
+
+class SyslogProvider(BaseProvider):
+    """Ingest syslog messages received on a TCP port."""
+
+    PROVIDER_CATEGORY = ["Infrastructure"]
+    PROVIDER_DISPLAY_NAME = "Syslog"
+    PROVIDER_SCOPES = [
+        ProviderScope(
+            name="receive_syslog",
+            mandatory=True,
+            alias="Receive Syslog",
+        )
+    ]
+    PROVIDER_TAGS = ["monitoring", "syslog"]
+
+    def __init__(
+        self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
+    ):
+        super().__init__(context_manager, provider_id, config)
+        self.consume = False
+        self._server = None
+        self._loop = None
+
+    def validate_config(self):
+        self.authentication_config = SyslogProviderAuthConfig(
+            **self.config.authentication
+        )
+
+    def validate_scopes(self) -> dict[str, bool | str]:
+        return {"receive_syslog": True}
+
+    def dispose(self):
+        self.stop_consume()
+
+    @staticmethod
+    def _parse_priority(priority: int) -> tuple[int, int, str, str]:
+        """Parse syslog priority into facility and severity."""
+        facility = priority >> 3
+        severity = priority & 0x07
+        facility_name = SYSLOG_FACILITY_NAMES.get(facility, f"unknown-{facility}")
+        severity_name = SYSLOG_SEVERITY_NAMES.get(severity, f"unknown-{severity}")
+        return facility, severity, facility_name, severity_name
+
+    @staticmethod
+    def _map_severity(severity: int) -> str:
+        """Map syslog severity to Keep alert severity."""
+        return SYSLOG_SEVERITY_MAP.get(severity, "info")
+
+    def _parse_syslog_message(self, raw: str) -> dict | None:
+        """Parse a raw syslog message string into an alert dict."""
+        raw = raw.strip()
+        if not raw:
+            return None
+
+        # Try RFC 5424 first (has version number after priority)
+        match = RFC5424_RE.match(raw)
+        if match:
+            priority = int(match.group(1))
+            timestamp = match.group(3)
+            hostname = match.group(4)
+            app_name = match.group(5)
+            pid = match.group(6)
+            message = match.group(9)
+        else:
+            # Try RFC 3164
+            match = RFC3164_RE.match(raw)
+            if match:
+                priority = int(match.group(1))
+                timestamp = match.group(2)
+                hostname = match.group(3)
+                app_name = match.group(4)
+                pid = match.group(5) or ""
+                message = match.group(6)
+            else:
+                # Fallback: treat entire line as message with minimal parsing
+                self.logger.warning(f"Could not parse syslog message: {raw[:100]}")
+                # Try to extract just the priority
+                pri_match = re.match(r"^<(\d+)>", raw)
+                if pri_match:
+                    priority = int(pri_match.group(1))
+                    message = raw[pri_match.end():].strip()
+                else:
+                    priority = 6  # informational
+                    message = raw
+                facility, severity, facility_name, severity_name = self._parse_priority(priority)
+                return {
+                    "name": f"syslog - {message[:50]}",
+                    "message": message,
+                    "severity": self._map_severity(severity),
+                    "source": "syslog",
+                    "syslog_facility": facility_name,
+                    "syslog_severity": severity_name,
+                    "syslog_hostname": "",
+                    "syslog_app_name": "",
+                    "syslog_pid": "",
+                    "syslog_timestamp": "",
+                }
+
+        facility, severity, facility_name, severity_name = self._parse_priority(priority)
+
+        return {
+            "name": f"{app_name} - {message[:50]}",
+            "message": message,
+            "severity": self._map_severity(severity),
+            "source": "syslog",
+            "syslog_facility": facility_name,
+            "syslog_severity": severity_name,
+            "syslog_hostname": hostname,
+            "syslog_app_name": app_name,
+            "syslog_pid": pid,
+            "syslog_timestamp": timestamp,
+        }
+
+    async def _handle_connection(self, reader, writer):
+        """Handle a single TCP connection."""
+        peer = writer.get_extra_info("peername")
+        try:
+            while self.consume:
+                data = await reader.read(4096)
+                if not data:
+                    break
+                text = data.decode("utf-8", errors="replace")
+                for line in text.splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    alert = self._parse_syslog_message(line)
+                    if alert:
+                        try:
+                            self._push_alert(alert)
+                        except Exception:
+                            self.logger.warning(
+                                "Error pushing syslog alert",
+                                extra={"peer": peer, "line": line[:100]},
+                            )
+        except Exception:
+            self.logger.exception(f"Error handling syslog connection from {peer}")
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    async def _run_server(self):
+        """Run the TCP server."""
+        host = self.authentication_config.host
+        port = self.authentication_config.port
+        self._server = await asyncio.start_server(
+            self._handle_connection, host, port
+        )
+        self.logger.info(f"Syslog TCP server listening on {host}:{port}")
+        async with self._server:
+            await self._server.serve_forever()
+
+    def start_consume(self):
+        """Start listening for syslog messages on TCP port."""
+        self.consume = True
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        try:
+            self._loop.run_until_complete(self._run_server())
+        except Exception:
+            self.logger.exception("Syslog TCP server error")
+        finally:
+            self._loop.close()
+            self._loop = None
+
+    def stop_consume(self):
+        """Stop listening for syslog messages."""
+        self.consume = False
+        if self._server:
+            self._server.close()
+        if self._loop and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._loop.stop)
+
+
+if __name__ == "__main__":
+    import logging
+    import os
+
+    logging.basicConfig(level=logging.INFO, handlers=[logging.StreamHandler()])
+
+    os.environ["KEEP_API_URL"] = "http://localhost:8080"
+
+    from keep.api.core.dependencies import SINGLE_TENANT_UUID
+
+    context_manager = ContextManager(tenant_id=SINGLE_TENANT_UUID)
+    config = {
+        "authentication": {
+            "host": "0.0.0.0",
+            "port": 514,
+        }
+    }
+    from keep.providers.providers_factory import ProvidersFactory
+
+    provider = ProvidersFactory.get_provider(
+        context_manager,
+        provider_id="syslog-keephq",
+        provider_type="syslog",
+        provider_config=config,
+    )
+    provider.start_consume()

--- a/tests/test_syslog_provider.py
+++ b/tests/test_syslog_provider.py
@@ -1,0 +1,225 @@
+"""Tests for SyslogProvider."""
+
+import asyncio
+import json
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock, patch, AsyncMock
+
+# Add the repo root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from keep.providers.syslog_provider.syslog_provider import (
+    SyslogProvider,
+    SyslogProviderAuthConfig,
+    SYSLOG_SEVERITY_MAP,
+    SYSLOG_SEVERITY_NAMES,
+    SYSLOG_FACILITY_NAMES,
+)
+
+
+class TestSyslogParsing(unittest.TestCase):
+    """Test syslog message parsing."""
+
+    def setUp(self):
+        """Set up a mock provider instance for parsing tests."""
+        self.mock_context = MagicMock()
+        self.mock_config = MagicMock()
+        self.mock_config.authentication = {"host": "0.0.0.0", "port": 514}
+        self.provider = SyslogProvider.__new__(SyslogProvider)
+        self.provider.logger = MagicMock()
+        self.provider.authentication_config = SyslogProviderAuthConfig(
+            **self.mock_config.authentication
+        )
+
+    def test_parse_priority(self):
+        """Test priority parsing into facility and severity."""
+        # priority = facility * 8 + severity
+        # kern.emergency = 0*8+0 = 0
+        facility, severity, fac_name, sev_name = SyslogProvider._parse_priority(0)
+        self.assertEqual(facility, 0)
+        self.assertEqual(severity, 0)
+        self.assertEqual(fac_name, "kern")
+        self.assertEqual(sev_name, "emergency")
+
+        # user.error = 1*8+3 = 11
+        facility, severity, fac_name, sev_name = SyslogProvider._parse_priority(11)
+        self.assertEqual(facility, 1)
+        self.assertEqual(severity, 3)
+        self.assertEqual(fac_name, "user")
+        self.assertEqual(sev_name, "error")
+
+        # local7.debug = 23*8+7 = 191
+        facility, severity, fac_name, sev_name = SyslogProvider._parse_priority(191)
+        self.assertEqual(facility, 23)
+        self.assertEqual(severity, 7)
+        self.assertEqual(fac_name, "local7")
+        self.assertEqual(sev_name, "debug")
+
+    def test_map_severity(self):
+        """Test syslog severity to Keep alert severity mapping."""
+        self.assertEqual(SyslogProvider._map_severity(0), "critical")  # Emergency
+        self.assertEqual(SyslogProvider._map_severity(1), "critical")  # Alert
+        self.assertEqual(SyslogProvider._map_severity(2), "critical")  # Critical
+        self.assertEqual(SyslogProvider._map_severity(3), "high")     # Error
+        self.assertEqual(SyslogProvider._map_severity(4), "warning")  # Warning
+        self.assertEqual(SyslogProvider._map_severity(5), "info")     # Notice
+        self.assertEqual(SyslogProvider._map_severity(6), "info")     # Informational
+        self.assertEqual(SyslogProvider._map_severity(7), "low")      # Debug
+
+    def test_parse_rfc3164(self):
+        """Test RFC 3164 (BSD) syslog message parsing."""
+        # <34>Jan 11 22:14:15 myhost sshd[1234]: Failed password for root
+        result = self.provider._parse_syslog_message(
+            "<34>Jan 11 22:14:15 myhost sshd[1234]: Failed password for root"
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["syslog_hostname"], "myhost")
+        self.assertEqual(result["syslog_app_name"], "sshd")
+        self.assertEqual(result["syslog_pid"], "1234")
+        self.assertEqual(result["message"], "Failed password for root")
+        self.assertEqual(result["severity"], "critical")  # priority 34 = 4*8+2 = auth.critical
+        self.assertEqual(result["source"], "syslog")
+
+    def test_parse_rfc3164_no_pid(self):
+        """Test RFC 3164 message without PID."""
+        result = self.provider._parse_syslog_message(
+            "<13>Jan 11 22:14:15 myhost kernel: Out of memory"
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["syslog_hostname"], "myhost")
+        self.assertEqual(result["syslog_app_name"], "kernel")
+        self.assertEqual(result["message"], "Out of memory")
+
+    def test_parse_rfc5424(self):
+        """Test RFC 5424 syslog message parsing."""
+        # <34>1 2024-01-11T22:14:15.003Z myhost sshd 1234 - - Failed password for root
+        result = self.provider._parse_syslog_message(
+            "<34>1 2024-01-11T22:14:15.003Z myhost sshd 1234 - - Failed password for root"
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["syslog_hostname"], "myhost")
+        self.assertEqual(result["syslog_app_name"], "sshd")
+        self.assertEqual(result["syslog_pid"], "1234")
+        self.assertEqual(result["message"], "Failed password for root")
+        self.assertEqual(result["severity"], "high")
+
+    def test_parse_malformed_fallback(self):
+        """Test fallback for malformed messages."""
+        # Message with priority but non-standard format
+        result = self.provider._parse_syslog_message(
+            "<133>Some random message without standard format"
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("syslog", result["source"])
+        self.assertIn("Some random message", result["message"])
+
+    def test_parse_empty_message(self):
+        """Test empty message returns None."""
+        result = self.provider._parse_syslog_message("")
+        self.assertIsNone(result)
+
+        result = self.provider._parse_syslog_message("   ")
+        self.assertIsNone(result)
+
+    def test_parse_no_priority(self):
+        """Test message without priority gets default informational."""
+        result = self.provider._parse_syslog_message("just a plain message")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["severity"], "info")  # default to informational
+
+
+class TestSyslogProviderConfig(unittest.TestCase):
+    """Test provider configuration."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = SyslogProviderAuthConfig()
+        self.assertEqual(config.host, "0.0.0.0")
+        self.assertEqual(config.port, 514)
+
+    def test_custom_config(self):
+        """Test custom configuration values."""
+        config = SyslogProviderAuthConfig(host="127.0.0.1", port=1514)
+        self.assertEqual(config.host, "127.0.0.1")
+        self.assertEqual(config.port, 1514)
+
+
+class TestSyslogTCPServer(unittest.TestCase):
+    """Test TCP server functionality."""
+
+    def setUp(self):
+        self.mock_context = MagicMock()
+        self.mock_config = MagicMock()
+        self.mock_config.authentication = {"host": "127.0.0.1", "port": 1514}
+        self.provider = SyslogProvider.__new__(SyslogProvider)
+        self.provider.logger = MagicMock()
+        self.provider.authentication_config = SyslogProviderAuthConfig(
+            **self.mock_config.authentication
+        )
+        self.provider.consume = True
+        self.provider._push_alert = MagicMock()
+
+    def test_handle_connection_pushes_alerts(self):
+        """Test that received syslog messages are parsed and pushed as alerts."""
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            # Simulate a connection that sends a syslog message
+            reader = asyncio.StreamReader()
+            reader.feed_data(b"<34>Jan 11 22:14:15 myhost sshd[1234]: Test message\n")
+            reader.feed_eof()
+
+            writer = MagicMock()
+            writer.get_extra_info.return_value = ("127.0.0.1", 12345)
+            writer.close = MagicMock()
+            writer.wait_closed = AsyncMock()
+
+            loop.run_until_complete(
+                self.provider._handle_connection(reader, writer)
+            )
+
+            self.provider._push_alert.assert_called_once()
+            alert = self.provider._push_alert.call_args[0][0]
+            self.assertEqual(alert["syslog_hostname"], "myhost")
+            self.assertEqual(alert["message"], "Test message")
+        finally:
+            loop.close()
+
+    def test_handle_connection_multiple_messages(self):
+        """Test multiple messages in a single connection."""
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            reader = asyncio.StreamReader()
+            reader.feed_data(
+                b"<34>Jan 11 22:14:15 host1 app1[1]: msg1\n"
+                b"<13>Jan 11 22:14:16 host2 app2[2]: msg2\n"
+            )
+            reader.feed_eof()
+
+            writer = MagicMock()
+            writer.get_extra_info.return_value = ("127.0.0.1", 12345)
+            writer.close = MagicMock()
+            writer.wait_closed = AsyncMock()
+
+            loop.run_until_complete(
+                self.provider._handle_connection(reader, writer)
+            )
+
+            self.assertEqual(self.provider._push_alert.call_count, 2)
+        finally:
+            loop.close()
+
+    def test_stop_consume(self):
+        """Test stop_consume sets flag and closes server."""
+        self.provider._server = MagicMock()
+        self.provider._loop = None
+        self.provider.stop_consume()
+        self.assertFalse(self.provider.consume)
+        self.provider._server.close.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a new **Syslog TCP Provider** that listens for syslog messages on a configurable TCP port and processes them as Keep alerts.

Closes #1750

### Features
- Listens on configurable host/port (default: `0.0.0.0:514`)
- Supports **RFC 3164** (BSD) and **RFC 5424** syslog message formats
- Parses syslog priority into facility and severity
- Maps syslog severity to Keep alert severity levels
- Graceful fallback for malformed/non-standard messages
- Consumer pattern with `start_consume()`/`stop_consume()` (same as Kafka provider)
- Full test coverage for parsing, severity mapping, and TCP handling

### Usage

Configure the provider with host and port:
```yaml
providers:
  - type: syslog
    authentication:
      host: 0.0.0.0
      port: 514
```

Then configure your syslog sources (e.g., vCenter, network devices) to forward to Keep on the configured port.

### Alert Fields

Each syslog message is pushed as an alert with:
- `name`: `app-name - message[:50]`
- `message`: full syslog message
- `severity`: mapped from syslog severity
- `syslog_facility`, `syslog_severity`, `syslog_hostname`, `syslog_app_name`, `syslog_pid`, `syslog_timestamp`

### Severity Mapping

| Syslog | Keep |
|--------|------|
| Emergency/Alert/Critical | critical |
| Error | high |
| Warning | warning |
| Notice/Informational | info |
| Debug | low |