### PR TITLE
fix: expose is_visible in IncidentDto for workflow conditions

### DIFF
--- a/keep/api/models/incident.py
+++ b/keep/api/models/incident.py
@@ -76,6 +76,7 @@ class IncidentDto(IncidentDtoIn):
 
     is_predicted: bool
     is_candidate: bool
+    is_visible: bool = True
 
     generated_summary: str | None
     ai_generated_name: str | None
@@ -190,6 +191,7 @@ class IncidentDto(IncidentDtoIn):
             generated_summary=db_incident.generated_summary,
             is_predicted=db_incident.is_predicted,
             is_candidate=db_incident.is_candidate,
+            is_visible=db_incident.is_visible,
             creation_time=db_incident.creation_time,
             start_time=db_incident.start_time,
             last_seen_time=db_incident.last_seen_time,
@@ -245,6 +247,7 @@ class IncidentDto(IncidentDtoIn):
             sources=self.alert_sources,
             is_predicted=self.is_predicted,
             is_candidate=self.is_candidate,
+            is_visible=self.is_visible,
             rule_fingerprint=self.rule_fingerprint,
             fingerprint=self.fingerprint,
             same_incident_in_the_past_id=self.same_incident_in_the_past_id,

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -1981,3 +1981,77 @@ def test_create_incident_after_maintenance_window(
     )
     assert total == 1
     assert incidents[total-1].user_generated_name == "Rule-test-after-mw"
+
+
+def test_incident_dto_is_visible_from_db(db_session, create_alert):
+    """Test that is_visible is correctly mapped in IncidentDto.from_db_incident()."""
+    from keep.api.models.db.incident import Incident as DbIncident
+    from keep.api.models.incident import IncidentDto
+    from keep.api.models.db.incident import IncidentSeverity, IncidentStatus
+    import datetime
+
+    # Create a DB incident with is_visible=False
+    db_incident = DbIncident(
+        id=uuid4(),
+        tenant_id=SINGLE_TENANT_UUID,
+        user_generated_name="Test invisible incident",
+        severity=IncidentSeverity.INFO.order,
+        status=IncidentStatus.FIRING.value,
+        is_visible=False,
+        is_predicted=False,
+        is_candidate=False,
+        alerts_count=0,
+        creation_time=datetime.datetime.utcnow(),
+        start_time=datetime.datetime.utcnow(),
+        last_seen_time=datetime.datetime.utcnow(),
+    )
+    db_session.add(db_incident)
+    db_session.commit()
+
+    # Convert to DTO
+    dto = IncidentDto.from_db_incident(db_incident)
+    assert dto.is_visible is False, "is_visible should be False when DB has is_visible=False"
+
+    # Also test the default (True)
+    db_incident2 = DbIncident(
+        id=uuid4(),
+        tenant_id=SINGLE_TENANT_UUID,
+        user_generated_name="Test visible incident",
+        severity=IncidentSeverity.INFO.order,
+        status=IncidentStatus.FIRING.value,
+        is_visible=True,
+        is_predicted=False,
+        is_candidate=False,
+        alerts_count=0,
+        creation_time=datetime.datetime.utcnow(),
+        start_time=datetime.datetime.utcnow(),
+        last_seen_time=datetime.datetime.utcnow(),
+    )
+    db_session.add(db_incident2)
+    db_session.commit()
+
+    dto2 = IncidentDto.from_db_incident(db_incident2)
+    assert dto2.is_visible is True, "is_visible should be True when DB has is_visible=True"
+
+
+def test_incident_dto_is_visible_to_db():
+    """Test that is_visible is correctly mapped in IncidentDto.to_db_incident()."""
+    from keep.api.models.incident import IncidentDto
+    import datetime
+
+    dto = IncidentDto(
+        id=uuid4(),
+        user_generated_name="Test",
+        is_predicted=False,
+        is_candidate=False,
+        is_visible=False,
+        alerts_count=0,
+        alert_sources=[],
+        services=[],
+        creation_time=datetime.datetime.utcnow(),
+        start_time=datetime.datetime.utcnow(),
+        last_seen_time=datetime.datetime.utcnow(),
+    )
+
+    db_incident = dto.to_db_incident()
+    assert db_incident.is_visible is False, "to_db_incident should preserve is_visible=False"


### PR DESCRIPTION
## Problem

`{{ incident.is_visible }}` resolves to an empty string in workflow if-conditions, even though the database has `is_visible = t`. This causes actions to be incorrectly skipped.

Reported in #6279.

## Root Cause

The `is_visible` field exists on the database `Incident` model but was not included in `IncidentDto`. The `from_db_incident()` method maps many fields but skipped `is_visible`, so when the workflow engine renders `{{ incident.is_visible }}`, Mustache finds an empty value.

Notably, the similar boolean flags `is_candidate` and `is_predicted` are already exposed in the DTO — `is_visible` was just missed when it was introduced.

## Fix

Add `is_visible` to `IncidentDto` and its serialization methods, following the exact same pattern as `is_predicted` and `is_candidate`:

1. Add `is_visible: bool = True` field to `IncidentDto`
2. Include `is_visible=db_incident.is_visible` in `from_db_incident()`
3. Include `is_visible=self.is_visible` in `to_db_incident()` for round-trip consistency

## Testing

Added two unit tests:
- `test_incident_dto_is_visible_from_db`: verifies `from_db_incident()` correctly maps `is_visible` for both True and False values
- `test_incident_dto_is_visible_to_db`: verifies `to_db_incident()` preserves `is_visible`

Closes #6279