### PR TITLE
fix: handle None alert_results in _notify_alert when no if_condition

### DIFF
--- a/keep/providers/keep_provider/keep_provider.py
+++ b/keep/providers/keep_provider/keep_provider.py
@@ -538,7 +538,7 @@ class KeepProvider(BaseProvider):
         # if no if_condition, trigger all alerts
         else:
             self.logger.info("No 'if' condition - triggering all alerts")
-            trigger_alerts = alert_results
+            trigger_alerts = alert_results or []
 
         # build the alert dtos
         alert_dtos = []

--- a/tests/test_keep_provider_notify_alert_none.py
+++ b/tests/test_keep_provider_notify_alert_none.py
@@ -1,0 +1,104 @@
+"""
+Test for Keep Provider _notify_alert crash with None alert_results.
+
+This test reproduces the issue described in https://github.com/keephq/keep/issues/6272
+where _notify_alert crashes with TypeError: object of type 'NoneType' has no len()
+when invoked via enrich_alert workflow action (no if_condition, alert_results is None).
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from keep.api.core.dependencies import SINGLE_TENANT_UUID
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.models.provider_config import ProviderConfig
+from keep.providers.keep_provider.keep_provider import KeepProvider
+
+
+def test_notify_alert_with_none_alert_results_no_crash():
+    """
+    When alert_results is None and no if_condition is provided,
+    _notify_alert should handle it gracefully instead of crashing
+    with TypeError: object of type 'NoneType' has no len().
+
+    This is the enrich_alert scenario: the action is purely enrichment,
+    no new alert is triggered, so alert_results is None.
+    """
+    tenant_id = SINGLE_TENANT_UUID
+    context_manager = ContextManager(
+        tenant_id=tenant_id,
+        workflow_id=str(uuid.uuid4()),
+    )
+
+    provider_config = ProviderConfig(authentication={})
+    provider = KeepProvider(
+        context_manager=context_manager,
+        provider_id="test-keep",
+        config=provider_config,
+    )
+
+    # Simulate the enrich_alert scenario: context returns None for alert_results
+    # (no foreach items, and step results are not a list)
+    mock_context = {
+        "foreach": {"items": None},
+        "steps": {"this": {"results": {}}},  # not a list -> alert_results becomes None
+    }
+
+    with patch.object(
+        context_manager, "get_full_context", return_value=mock_context
+    ):
+        # Mock the io_handler to avoid needing real alert infrastructure
+        provider.io_handler = MagicMock()
+        provider.io_handler.render_context.return_value = {}
+
+        # Mock pusher and alert DAO to avoid DB dependency
+        with patch("keep.providers.keep_provider.keep_provider.Pusher"), \
+             patch.object(provider, "logger"):
+            # Before the fix, this would raise:
+            # TypeError: object of type 'NoneType' has no len()
+            result = provider._notify_alert()
+
+            # Should return an empty list, not crash
+            assert isinstance(result, list)
+            assert len(result) == 0
+
+
+def test_notify_alert_with_none_alert_results_and_alert_param():
+    """
+    When alert_results is None but an alert dict is provided,
+    _notify_alert should create the alert from the parameter
+    (this path already works, but we verify it still does).
+    """
+    tenant_id = SINGLE_TENANT_UUID
+    context_manager = ContextManager(
+        tenant_id=tenant_id,
+        workflow_id=str(uuid.uuid4()),
+    )
+
+    provider_config = ProviderConfig(authentication={})
+    provider = KeepProvider(
+        context_manager=context_manager,
+        provider_id="test-keep",
+        config=provider_config,
+    )
+
+    mock_context = {
+        "foreach": {"items": None},
+        "steps": {"this": {"results": {}}},
+    }
+
+    alert_data = {"name": "test-alert", "status": "firing"}
+
+    with patch.object(
+        context_manager, "get_full_context", return_value=mock_context
+    ):
+        provider.io_handler = MagicMock()
+        provider.io_handler.render_context.return_value = alert_data
+
+        with patch("keep.providers.keep_provider.keep_provider.Pusher"), \
+             patch.object(provider, "logger"):
+            # This should work: alert param provides the alert data
+            result = provider._notify_alert(alert=alert_data)
+
+            # Should return a list (may be empty if no DB, but should not crash)
+            assert isinstance(result, list)


### PR DESCRIPTION
## Summary

Fixes #6272 — `_notify_alert` crashes with `TypeError: object of type 'NoneType' has no len()` when invoked via `enrich_alert` workflow action.

## Root Cause

In `keep_provider.py` line 544, when no `if_condition` is provided:
```python
trigger_alerts = alert_results
```

For pure enrichment actions (like `enrich_alert`), `alert_results` is `None` because no new alert is triggered. Subsequent `len(trigger_alerts)` and iteration both fail.

## Fix

```python
trigger_alerts = alert_results or []
```

This makes downstream `len()` and iteration work uniformly without defensive checks elsewhere.

## Testing

Added `test_keep_provider_notify_alert_none.py` with two test cases:
1. `test_notify_alert_with_none_alert_results_no_crash` — verifies the crash is fixed
2. `test_notify_alert_with_none_alert_results_and_alert_param` — verifies the alert parameter path still works

## Checklist

- [x] The PR follows the contributing guidelines
- [x] I have added tests that prove my fix is effective
- [x] I have checked that the fix does not break existing functionality