### PR TITLE
fix: Docker deploy script exit on error

### DIFF
--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -16,7 +16,7 @@ set -e
 
 echo "Creating state directory."
 mkdir -p state
-test -e state
+test -e state || echo "Unable to create folder"
 echo "Changing directory ownership to non-privileged user."
 chown -R 999:999 state || echo "Unable to change directory ownership, changing permissions instead." && chmod -R 0777 state
 which curl &> /dev/null || echo "curl not installed"

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -12,6 +12,7 @@ curl https://raw.githubusercontent.com/keephq/keep/main/start.sh | sh
 ```bash start.sh
 #!/bin/bash
 # Keep install script for docker compose
+set -e
 
 echo "Creating state directory."
 mkdir -p state

--- a/start.sh
+++ b/start.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "Creating state directory."
 mkdir -p state
-test -e state
+test -e state || echo "Unable to create folder"
 echo "Changing directory ownership to non-privileged user."
 chown -R 999:999 state || echo "Unable to change directory ownership, changing permissions instead." && chmod -R 0777 state
 which curl &> /dev/null || echo "curl not installed" 

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Keep install script for docker compose
+set -e
 
 echo "Creating state directory."
 mkdir -p state


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #6287

## 📑 Description
<!-- Add a brief description of the pr -->
The Docker deployment script of Keep does not exit or act when one of the checks fails. For example: it checks whether the folder "state" exists and whether "curl" is installed, but it doesn't act when the exit code is greater than 0. Setting the -e flag in the script solves this and makes sure the script stops when the exit code is 1 or higher.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
