### PR TITLE
feat(providers): add ServiceNow maintenance window pulling

### DIFF
--- a/docs/snippets/providers/servicenow-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/servicenow-snippet-autogenerated.mdx
@@ -9,6 +9,8 @@ This provider requires authentication.
 - **client_id**: The client ID to use OAuth 2.0 based authentication (required: False, sensitive: False)
 - **client_secret**: The client secret to use OAuth 2.0 based authentication (required: False, sensitive: True)
 - **ticket_creation_url**: URL for creating new tickets (required: False, sensitive: False)
+- **maintenance_window_table**: ServiceNow table for maintenance windows (default: cmdb_ci_outage) (required: False, sensitive: False)
+- **maintenance_window_cel_template**: CEL expression template for matching alerts. Use {ci} as placeholder for CI name. (required: False, sensitive: False)
 
 Certain scopes may be required to perform specific actions or queries via the provider. Below is a summary of relevant scopes and their use cases:
 - **itil**: The user can read/write tickets from the table (mandatory) ([Documentation](https://docs.servicenow.com/bundle/sandiego-platform-administration/page/administer/roles/reference/r_BaseSystemRoles.html))
@@ -76,3 +78,5 @@ The provider exposes the following [Provider Methods](/providers/provider-method
     - `incident_id`: The incident number (e.g. INC0010001) or sys_id.
     - `content`: The text content to add.
     - `activity_type`: Either 'work_notes' or 'comments'. Defaults to 'work_notes'.
+- **get_maintenance_windows** Fetch maintenance windows from ServiceNow (view, scopes: itil)
+

--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -5939,6 +5939,53 @@ def create_single_tenant_for_e2e(tenant_id: str) -> None:
             logger.exception("Failed to create single tenant")
             pass
 
+def upsert_maintenance_window_from_provider(
+    tenant_id: str,
+    name: str,
+    cel_query: str,
+    start_time: datetime,
+    end_time: datetime,
+    provider_type: str,
+    session: Optional[Session] = None,
+) -> MaintenanceWindowRule:
+    """Create or update a maintenance window rule from a provider.
+
+    Uses name + created_by as the dedup key.
+    """
+    with existed_or_new_session(session) as session:
+        created_by = f"{provider_type}_provider"
+        existing = session.query(MaintenanceWindowRule).filter(
+            MaintenanceWindowRule.tenant_id == tenant_id,
+            MaintenanceWindowRule.name == name,
+            MaintenanceWindowRule.created_by == created_by,
+        ).first()
+
+        if existing:
+            existing.cel_query = cel_query
+            existing.start_time = start_time
+            existing.end_time = end_time
+            existing.duration_seconds = int((end_time - start_time).total_seconds())
+            session.commit()
+            session.refresh(existing)
+            return existing
+
+        rule = MaintenanceWindowRule(
+            name=name,
+            tenant_id=tenant_id,
+            cel_query=cel_query,
+            start_time=start_time,
+            end_time=end_time,
+            duration_seconds=int((end_time - start_time).total_seconds()),
+            suppress=True,
+            enabled=True,
+            created_by=created_by,
+        )
+        session.add(rule)
+        session.commit()
+        session.refresh(rule)
+        return rule
+
+
 def get_maintenance_windows_started(session: Optional[Session] = None) -> List[MaintenanceWindowRule]:
     """
     It will return all windows started, i.e start_time < currentTime

--- a/keep/api/models/provider.py
+++ b/keep/api/models/provider.py
@@ -45,7 +45,7 @@ class Provider(BaseModel):
     docs: str | None = None
     tags: list[
         Literal[
-            "alert", "ticketing", "messaging", "data", "queue", "topology", "incident"
+            "alert", "ticketing", "messaging", "data", "queue", "topology", "incident", "maintenance"
         ]
     ] = Field(default_factory=list)
     categories: list[str] = Field(default_factory=lambda: ["Others"])

--- a/keep/api/routes/preset.py
+++ b/keep/api/routes/preset.py
@@ -21,6 +21,7 @@ from keep.api.core.db import (
     get_session,
     update_preset_options,
     update_provider_last_pull_time,
+    upsert_maintenance_window_from_provider,
 )
 from keep.api.models.alert import AlertDto
 from keep.api.models.db.preset import (
@@ -37,7 +38,7 @@ from keep.api.tasks.process_incident_task import process_incident
 from keep.api.tasks.process_topology_task import process_topology
 from keep.identitymanager.authenticatedentity import AuthenticatedEntity
 from keep.identitymanager.identitymanagerfactory import IdentityManagerFactory
-from keep.providers.base.base_provider import BaseIncidentProvider, BaseTopologyProvider
+from keep.providers.base.base_provider import BaseIncidentProvider, BaseTopologyProvider, BaseMaintenanceWindowProvider
 from keep.providers.providers_factory import ProvidersFactory
 from keep.searchengine.searchengine import SearchEngine
 
@@ -170,6 +171,30 @@ def pull_data_from_providers(
                     f"Unknown error pulling topology from provider {provider.type} ({provider.id})",
                     extra={**extra, "exception": str(e)},
                 )
+
+            if isinstance(provider_class, BaseMaintenanceWindowProvider):
+                try:
+                    windows = provider_class.get_maintenance_windows()
+                    for window in windows:
+                        window.tenant_id = tenant_id
+                        upsert_maintenance_window_from_provider(
+                            tenant_id=tenant_id,
+                            name=window.name,
+                            cel_query=window.cel_query,
+                            start_time=window.start_time,
+                            end_time=window.end_time,
+                            provider_type=provider.type,
+                        )
+                except NotImplementedError:
+                    logger.debug(
+                        f"Provider {provider.type} ({provider.id}) does not implement pulling maintenance windows",
+                        extra=extra,
+                    )
+                except Exception:
+                    logger.exception(
+                        f"Unknown error pulling maintenance windows from provider {provider.type} ({provider.id})",
+                        extra={**extra, "trace_id": trace_id},
+                    )
 
             for fingerprint, alert in sorted_provider_alerts_by_fingerprint.items():
                 process_event(

--- a/keep/providers/base/base_provider.py
+++ b/keep/providers/base/base_provider.py
@@ -74,7 +74,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
     ]  # tb: Default category for providers that don't declare a category
     PROVIDER_TAGS: list[
         Literal[
-            "alert", "ticketing", "messaging", "data", "queue", "topology", "incident"
+            "alert", "ticketing", "messaging", "data", "queue", "topology", "incident", "maintenance"
         ]
     ] = []
     WEBHOOK_INSTALLATION_REQUIRED = False  # webhook installation is required for this provider, making it required in the UI
@@ -939,6 +939,14 @@ class BaseIncidentProvider(BaseProvider):
             NotImplementedError: _description_
         """
         raise NotImplementedError("setup_webhook() method not implemented")
+
+
+class BaseMaintenanceWindowProvider(BaseProvider):
+    def _get_maintenance_windows(self) -> list:
+        raise NotImplementedError("_get_maintenance_windows() not implemented")
+
+    def get_maintenance_windows(self) -> list:
+        return self._get_maintenance_windows()
 
 
 class ProviderHealthMixin:

--- a/keep/providers/providers_factory.py
+++ b/keep/providers/providers_factory.py
@@ -27,6 +27,7 @@ from keep.api.models.provider import Provider
 from keep.contextmanager.contextmanager import ContextManager
 from keep.providers.base.base_provider import (
     BaseIncidentProvider,
+    BaseMaintenanceWindowProvider,
     BaseProvider,
     BaseTopologyProvider,
 )
@@ -378,8 +379,9 @@ class ProvidersFactory:
                 )
                 can_fetch_topology = issubclass(provider_class, BaseTopologyProvider)
                 can_fetch_incidents = issubclass(provider_class, BaseIncidentProvider)
+                can_fetch_maintenance_windows = issubclass(provider_class, BaseMaintenanceWindowProvider)
                 pulling_available = (
-                    can_fetch_alerts or can_fetch_topology or can_fetch_incidents
+                    can_fetch_alerts or can_fetch_topology or can_fetch_incidents or can_fetch_maintenance_windows
                 )
 
                 provider_tags = set(provider_class.PROVIDER_TAGS)
@@ -397,6 +399,8 @@ class ProvidersFactory:
                     provider_tags.add("messaging")
                 if can_fetch_incidents and "incident" not in provider_tags:
                     provider_tags.add("incident")
+                if can_fetch_maintenance_windows and "maintenance" not in provider_tags:
+                    provider_tags.add("maintenance")
                 provider_tags = list(provider_tags)
 
                 try:

--- a/keep/providers/servicenow_provider/servicenow_provider.py
+++ b/keep/providers/servicenow_provider/servicenow_provider.py
@@ -488,8 +488,6 @@ class ServicenowProvider(BaseTopologyProvider, BaseIncidentProvider, BaseMainten
 
     def _get_maintenance_windows(self) -> list:
         """Pull maintenance windows from ServiceNow."""
-        from keep.api.models.db.maintenance_window import MaintenanceWindowRule
-
         self.logger.info("Pulling maintenance windows from ServiceNow")
         all_windows = []
         offset = 0

--- a/keep/providers/servicenow_provider/servicenow_provider.py
+++ b/keep/providers/servicenow_provider/servicenow_provider.py
@@ -17,7 +17,7 @@ from keep.api.models.db.topology import TopologyServiceInDto
 from keep.api.models.incident import IncidentDto, IncidentStatus, IncidentSeverity
 from keep.contextmanager.contextmanager import ContextManager
 from keep.exceptions.provider_exception import ProviderException
-from keep.providers.base.base_provider import BaseTopologyProvider, BaseIncidentProvider
+from keep.providers.base.base_provider import BaseTopologyProvider, BaseIncidentProvider, BaseMaintenanceWindowProvider
 from keep.providers.models.provider_config import ProviderConfig, ProviderScope
 from keep.providers.models.provider_method import ProviderMethod
 from keep.validation.fields import HttpsUrl
@@ -82,8 +82,28 @@ class ServicenowProviderAuthConfig:
         default="",
     )
 
+    maintenance_window_table: str = dataclasses.field(
+        metadata={
+            "required": False,
+            "description": "ServiceNow table for maintenance windows (default: cmdb_ci_outage)",
+            "sensitive": False,
+            "hint": "cmdb_ci_outage",
+        },
+        default="cmdb_ci_outage",
+    )
 
-class ServicenowProvider(BaseTopologyProvider, BaseIncidentProvider):
+    maintenance_window_cel_template: str = dataclasses.field(
+        metadata={
+            "required": False,
+            "description": "CEL expression template for matching alerts. Use {ci} as placeholder for CI name.",
+            "sensitive": False,
+            "hint": 'service == "{ci}"',
+        },
+        default='service == "{ci}"',
+    )
+
+
+class ServicenowProvider(BaseTopologyProvider, BaseIncidentProvider, BaseMaintenanceWindowProvider):
     """Manage ServiceNow tickets and incidents with bidirectional activity sync."""
 
     PROVIDER_CATEGORY = ["Ticketing", "Incident Management"]
@@ -96,7 +116,7 @@ class ServicenowProvider(BaseTopologyProvider, BaseIncidentProvider):
             alias="Read from datahase",
         )
     ]
-    PROVIDER_TAGS = ["ticketing"]
+    PROVIDER_TAGS = ["ticketing", "maintenance"]
     PROVIDER_DISPLAY_NAME = "Service Now"
     FINGERPRINT_FIELDS = ["number"]
 
@@ -139,6 +159,13 @@ class ServicenowProvider(BaseTopologyProvider, BaseIncidentProvider):
             scopes=["itil"],
             description="Add a work note or comment to a ServiceNow incident",
             type="action",
+        ),
+        ProviderMethod(
+            name="Get Maintenance Windows",
+            func_name="get_maintenance_windows",
+            scopes=["itil"],
+            description="Fetch maintenance windows from ServiceNow",
+            type="view",
         ),
     ]
 
@@ -453,6 +480,93 @@ class ServicenowProvider(BaseTopologyProvider, BaseIncidentProvider):
             is_predicted=False,
             is_candidate=False,
             fingerprint=number,
+        )
+
+    # -------------------------------------------------------------------------
+    # Maintenance window pulling (BaseMaintenanceWindowProvider)
+    # -------------------------------------------------------------------------
+
+    def _get_maintenance_windows(self) -> list:
+        """Pull maintenance windows from ServiceNow."""
+        from keep.api.models.db.maintenance_window import MaintenanceWindowRule
+
+        self.logger.info("Pulling maintenance windows from ServiceNow")
+        all_windows = []
+        offset = 0
+        limit = 100
+        table = self.authentication_config.maintenance_window_table
+
+        while True:
+            records = self._query(
+                table_name=table,
+                sysparm_limit=limit,
+                sysparm_offset=offset,
+            )
+            if not records:
+                break
+
+            for record in records:
+                try:
+                    rule = self._format_maintenance_window(record)
+                    if rule:
+                        all_windows.append(rule)
+                except Exception:
+                    self.logger.exception(
+                        "Failed to format ServiceNow maintenance window",
+                        extra={"sys_id": record.get("sys_id")},
+                    )
+
+            if len(records) < limit:
+                break
+            offset += limit
+
+        self.logger.info(
+            "Finished pulling maintenance windows from ServiceNow",
+            extra={"count": len(all_windows)},
+        )
+        return all_windows
+
+    def _format_maintenance_window(self, record: dict):
+        """Convert a ServiceNow cmdb_ci_outage record to MaintenanceWindowRule."""
+        from keep.api.models.db.maintenance_window import MaintenanceWindowRule
+
+        begin_date = record.get("begin_date")
+        end_date = record.get("end_date")
+        if not begin_date or not end_date:
+            return None
+
+        start_time = datetime.strptime(begin_date, "%Y-%m-%d %H:%M:%S").replace(
+            tzinfo=timezone.utc
+        )
+        end_time = datetime.strptime(end_date, "%Y-%m-%d %H:%M:%S").replace(
+            tzinfo=timezone.utc
+        )
+
+        ci_ref = record.get("cmdb_ci", "")
+        ci_name = (
+            ci_ref.get("display_value", "")
+            if isinstance(ci_ref, dict)
+            else str(ci_ref)
+        )
+
+        cel_query = self.authentication_config.maintenance_window_cel_template.format(
+            ci=ci_name
+        )
+
+        description = record.get("description", "") or f"ServiceNow maintenance: {ci_name}"
+        sys_id = record.get("sys_id", "")
+
+        return MaintenanceWindowRule(
+            name=f"SN-MW-{sys_id[:8] if sys_id else 'unknown'}",
+            description=description,
+            cel_query=cel_query,
+            start_time=start_time,
+            end_time=end_time,
+            duration_seconds=int((end_time - start_time).total_seconds()),
+            suppress=True,
+            enabled=True,
+            created_by="servicenow_provider",
+            tenant_id="",
         )
 
     # -------------------------------------------------------------------------

--- a/tests/fixtures/servicenow_maintenance_windows.json
+++ b/tests/fixtures/servicenow_maintenance_windows.json
@@ -1,0 +1,28 @@
+{
+  "result": [
+    {
+      "sys_id": "abc123def456",
+      "cmdb_ci": {"display_value": "Production Server", "value": "ci001"},
+      "begin_date": "2025-03-20 02:00:00",
+      "end_date": "2025-03-20 06:00:00",
+      "type": "planned",
+      "description": "Scheduled maintenance for Production Server"
+    },
+    {
+      "sys_id": "def789ghi012",
+      "cmdb_ci": {"display_value": "DB Cluster", "value": "ci002"},
+      "begin_date": "2025-04-01 00:00:00",
+      "end_date": "2025-04-01 02:00:00",
+      "type": "unplanned",
+      "description": "Emergency DB maintenance"
+    },
+    {
+      "sys_id": "jkl345mno678",
+      "cmdb_ci": "Web Server",
+      "begin_date": "2025-05-10 08:00:00",
+      "end_date": "2025-05-10 10:00:00",
+      "type": "planned",
+      "description": "Web server upgrade"
+    }
+  ]
+}

--- a/tests/test_servicenow_provider.py
+++ b/tests/test_servicenow_provider.py
@@ -321,6 +321,7 @@ class TestProviderConfig:
         assert "Get Incidents" in method_names
         assert "Get Incident Activities" in method_names
         assert "Add Incident Activity" in method_names
+        assert "Get Maintenance Windows" in method_names
 
     def test_status_mapping_coverage(self):
         """Test that all common ServiceNow states are mapped."""
@@ -332,3 +333,185 @@ class TestProviderConfig:
         """Test that all ServiceNow impact levels are mapped."""
         for impact in ["1", "2", "3"]:
             assert impact in ServicenowProvider.INCIDENT_SEVERITY_MAP
+
+
+class TestFormatMaintenanceWindow:
+    """Tests for _format_maintenance_window method."""
+
+    def test_format_maintenance_window_basic(self, servicenow_provider):
+        """Test basic cmdb_ci_outage record formatting."""
+        record = {
+            "sys_id": "abc123def456",
+            "cmdb_ci": {"display_value": "Production Server", "value": "ci001"},
+            "begin_date": "2025-03-20 02:00:00",
+            "end_date": "2025-03-20 06:00:00",
+            "type": "planned",
+            "description": "Scheduled maintenance for Production Server",
+        }
+
+        result = servicenow_provider._format_maintenance_window(record)
+
+        assert result is not None
+        assert result.name == "SN-MW-abc123de"
+        assert result.cel_query == 'service == "Production Server"'
+        assert result.suppress is True
+        assert result.enabled is True
+        assert result.created_by == "servicenow_provider"
+        assert result.description == "Scheduled maintenance for Production Server"
+        assert result.duration_seconds == 4 * 3600  # 4 hours
+
+    def test_format_maintenance_window_missing_dates(self, servicenow_provider):
+        """Test that missing begin_date/end_date returns None."""
+        record_no_begin = {
+            "sys_id": "abc123",
+            "end_date": "2025-03-20 06:00:00",
+            "cmdb_ci": "Server",
+        }
+        assert servicenow_provider._format_maintenance_window(record_no_begin) is None
+
+        record_no_end = {
+            "sys_id": "abc123",
+            "begin_date": "2025-03-20 02:00:00",
+            "cmdb_ci": "Server",
+        }
+        assert servicenow_provider._format_maintenance_window(record_no_end) is None
+
+    def test_format_maintenance_window_ci_reference(self, servicenow_provider):
+        """Test cmdb_ci as a reference object extracts display_value."""
+        record = {
+            "sys_id": "ref123456789",
+            "cmdb_ci": {"display_value": "DB Cluster", "value": "ci002"},
+            "begin_date": "2025-04-01 00:00:00",
+            "end_date": "2025-04-01 02:00:00",
+        }
+
+        result = servicenow_provider._format_maintenance_window(record)
+        assert result is not None
+        assert 'service == "DB Cluster"' == result.cel_query
+
+    def test_format_maintenance_window_ci_string(self, servicenow_provider):
+        """Test cmdb_ci as a plain string."""
+        record = {
+            "sys_id": "str123456789",
+            "cmdb_ci": "Web Server",
+            "begin_date": "2025-05-10 08:00:00",
+            "end_date": "2025-05-10 10:00:00",
+        }
+
+        result = servicenow_provider._format_maintenance_window(record)
+        assert result is not None
+        assert 'service == "Web Server"' == result.cel_query
+
+    def test_format_maintenance_window_cel_template(self, servicenow_provider):
+        """Test custom CEL template."""
+        servicenow_provider.authentication_config.maintenance_window_cel_template = (
+            'source == "{ci}"'
+        )
+        record = {
+            "sys_id": "tmpl12345678",
+            "cmdb_ci": "API Gateway",
+            "begin_date": "2025-06-01 12:00:00",
+            "end_date": "2025-06-01 14:00:00",
+        }
+
+        result = servicenow_provider._format_maintenance_window(record)
+        assert result is not None
+        assert result.cel_query == 'source == "API Gateway"'
+
+    def test_format_maintenance_window_fallback_description(self, servicenow_provider):
+        """Test fallback description when record has none."""
+        record = {
+            "sys_id": "nodesc123456",
+            "cmdb_ci": "Cache Server",
+            "begin_date": "2025-07-01 00:00:00",
+            "end_date": "2025-07-01 01:00:00",
+        }
+
+        result = servicenow_provider._format_maintenance_window(record)
+        assert result is not None
+        assert result.description == "ServiceNow maintenance: Cache Server"
+
+
+class TestGetMaintenanceWindows:
+    """Tests for _get_maintenance_windows method."""
+
+    def test_get_maintenance_windows_success(self, servicenow_provider):
+        """Test successful maintenance window pulling."""
+        mock_records = [
+            {
+                "sys_id": "abc123def456",
+                "cmdb_ci": {"display_value": "Production Server", "value": "ci001"},
+                "begin_date": "2025-03-20 02:00:00",
+                "end_date": "2025-03-20 06:00:00",
+                "description": "Scheduled maintenance",
+            },
+        ]
+
+        with patch.object(
+            servicenow_provider, "_query", return_value=mock_records
+        ):
+            windows = servicenow_provider._get_maintenance_windows()
+
+        assert len(windows) == 1
+        assert windows[0].name == "SN-MW-abc123de"
+
+    def test_get_maintenance_windows_empty(self, servicenow_provider):
+        """Test pulling when no maintenance windows exist."""
+        with patch.object(servicenow_provider, "_query", return_value=[]):
+            windows = servicenow_provider._get_maintenance_windows()
+
+        assert windows == []
+
+    def test_get_maintenance_windows_pagination(self, servicenow_provider):
+        """Test pagination: two pages of results."""
+        page1 = [
+            {
+                "sys_id": f"page1{i:012d}",
+                "cmdb_ci": f"Server {i}",
+                "begin_date": "2025-01-01 00:00:00",
+                "end_date": "2025-01-01 01:00:00",
+            }
+            for i in range(100)
+        ]
+        page2 = [
+            {
+                "sys_id": f"page2{i:012d}",
+                "cmdb_ci": f"Server {100 + i}",
+                "begin_date": "2025-01-01 00:00:00",
+                "end_date": "2025-01-01 01:00:00",
+            }
+            for i in range(50)
+        ]
+
+        with patch.object(
+            servicenow_provider,
+            "_query",
+            side_effect=[page1, page2],
+        ):
+            windows = servicenow_provider._get_maintenance_windows()
+
+        assert len(windows) == 150
+
+    def test_get_maintenance_windows_skips_invalid(self, servicenow_provider):
+        """Test that records with missing dates are skipped."""
+        mock_records = [
+            {
+                "sys_id": "valid12345678",
+                "cmdb_ci": "Good Server",
+                "begin_date": "2025-03-20 02:00:00",
+                "end_date": "2025-03-20 06:00:00",
+            },
+            {
+                "sys_id": "invalid1234567",
+                "cmdb_ci": "Bad Server",
+                # missing dates
+            },
+        ]
+
+        with patch.object(
+            servicenow_provider, "_query", return_value=mock_records
+        ):
+            windows = servicenow_provider._get_maintenance_windows()
+
+        assert len(windows) == 1
+        assert windows[0].name == "SN-MW-valid123"


### PR DESCRIPTION
Adds maintenance window pulling from ServiceNow to Keep.

Queries the `cmdb_ci_outage` table (configurable) and syncs maintenance windows into Keep's suppression system.

Closes #2346

**Changes:**
- Add `BaseMaintenanceWindowProvider` base class
- Extend `ServicenowProvider` with maintenance window pulling
- Add DB upsert with dedup (name + created_by)
- Integrate into `pull_data_from_providers()` scheduling
- 10 unit tests + mock fixtures