### PR TITLE
fix: validate AlertDto.id as UUID for all providers

### DIFF
--- a/keep/api/models/alert.py
+++ b/keep/api/models/alert.py
@@ -52,7 +52,7 @@ class AlertStatus(Enum):
     SUPPRESSED = "suppressed"
     # No Data
     PENDING = "pending"
-    #Affected by Maintenance Windows
+    # Affected by Maintenance Windows
     MAINTENANCE = "maintenance"
 
 
@@ -243,8 +243,18 @@ class AlertDto(BaseModel):
 
     @root_validator(pre=True)
     def set_default_values(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        # Check and set id:
-        if not values.get("id"):
+        # Check and set id -- must be a valid UUID for database compatibility.
+        # Many providers pass their external numeric/string IDs (e.g. Zabbix
+        # event IDs, Datadog numeric IDs, Grafana fingerprints) which cause
+        # "invalid input syntax for type uuid" errors when queried via CEL
+        # filters.  Generate a proper UUID in those cases.
+        alert_id = values.get("id")
+        if alert_id:
+            try:
+                uuid.UUID(str(alert_id))
+            except (ValueError, AttributeError):
+                values["id"] = str(uuid.uuid4())
+        else:
             values["id"] = str(uuid.uuid4())
 
         # Check and set default severity

--- a/tests/test_alert_dto.py
+++ b/tests/test_alert_dto.py
@@ -1,5 +1,6 @@
 import hashlib
 import urllib.parse
+import uuid
 from datetime import datetime, timedelta, timezone
 
 import freezegun
@@ -262,6 +263,48 @@ def test_alert_dismiss_forever():
     with freezegun.freeze_time(now + timedelta(days=365)):
         revalidated_alert = AlertDto(**alert.dict())
         assert revalidated_alert.dismissed is True
+
+
+def test_alert_dto_valid_uuid_id_preserved():
+    """A valid UUID id should be kept as-is."""
+    valid_uuid = str(uuid.uuid4())
+    alert = create_basic_alert(
+        name="UUID Test",
+        last_received="2024-01-01T00:00:00.000Z",
+        id=valid_uuid,
+    )
+    assert alert.id == valid_uuid
+
+
+def test_alert_dto_non_uuid_id_replaced():
+    """Non-UUID ids (e.g. numeric Zabbix event IDs, Grafana fingerprints)
+    should be replaced with a valid UUID to prevent database errors."""
+    non_uuid_ids = [
+        "12345",  # numeric (Zabbix, Checkly, etc.)
+        "JanusHighAudioJitter",  # alert name (Prometheus before #6219)
+        "a1b2c3d4e5f6",  # hex fingerprint (Grafana)
+        "-8718624884464498498",  # negative number (Dynatrace)
+        "P1234ABC",  # alphanumeric (PagerDuty)
+    ]
+    for non_uuid in non_uuid_ids:
+        alert = create_basic_alert(
+            name="Non-UUID Test",
+            last_received="2024-01-01T00:00:00.000Z",
+            id=non_uuid,
+        )
+        assert alert.id != non_uuid, f"Expected {non_uuid!r} to be replaced"
+        # Verify the replacement is a valid UUID
+        uuid.UUID(alert.id)
+
+
+def test_alert_dto_missing_id_gets_uuid():
+    """When no id is provided, a valid UUID should be generated."""
+    alert = create_basic_alert(
+        name="No ID Test",
+        last_received="2024-01-01T00:00:00.000Z",
+    )
+    assert alert.id is not None
+    uuid.UUID(alert.id)
 
 
 def test_alert_dto_environment_default_is_none():


### PR DESCRIPTION
Closes #6237 (partially -- prevents the 500 at the data layer)
Related to #6219 (extends the Prometheus-specific fix to all providers)

## Summary

Extends the fix from #6219 (Prometheus-specific) to **all providers** by adding centralized UUID validation in `AlertDto.set_default_values`.

32+ providers set `AlertDto.id` to non-UUID values (numeric IDs, hex fingerprints, alert names, etc.) which causes `invalid input syntax for type uuid` errors when the frontend queries alerts via CEL filters that map to the `lastalert.alert_id` UUID column. Rather than patching each provider individually, this validates the `id` field in the existing `root_validator` -- non-UUID values are replaced with a generated UUID, matching the try/except pattern from #6219.

Affected providers include: Grafana (6 locations), Datadog, PagerDuty, Zabbix, Dynatrace, NewRelic, Sentry, Splunk, CloudWatch, Checkly, Centreon, GCP Monitoring, iLert, Rollbar, StatusCake, ThousandEyes, Pingdom, UptimeKuma, and more.

## Changes

- `keep/api/models/alert.py`: Added UUID validation in the existing `set_default_values` root_validator. Valid UUIDs are preserved; non-UUID strings are replaced with `uuid.uuid4()`.
- `tests/test_alert_dto.py`: Added 3 test cases covering UUID preservation, non-UUID replacement, and missing ID generation.

## Test plan

- [x] Unit tests pass for valid UUID preservation
- [x] Unit tests pass for non-UUID replacement (numeric, hex, string, negative numbers)
- [x] Unit tests pass for missing ID generation
- [x] Formatted with `black` and `isort`
- [ ] CI tests