### PR TITLE
fix: Database migration race condition in docker with Redis

### DIFF
--- a/keep/api/config.py
+++ b/keep/api/config.py
@@ -6,7 +6,7 @@ from keep.api.alert_deduplicator.deduplication_rules_provisioning import (
     provision_deduplication_rules_from_env,
 )
 from keep.api.api import AUTH_TYPE
-from keep.api.core.db_on_start import migrate_db, try_create_single_tenant
+from keep.api.core.db_on_start import try_create_single_tenant
 from keep.api.core.dependencies import SINGLE_TENANT_UUID
 from keep.api.core.tenant_configuration import TenantConfiguration
 from keep.api.routes.dashboard import provision_dashboards

--- a/keep/api/config.py
+++ b/keep/api/config.py
@@ -44,8 +44,6 @@ def on_starting(server=None):
     """This function is called by the gunicorn server when it starts"""
     logger.info("Keep server starting")
 
-    migrate_db()
-
     # Load this early and use preloading
     # https://www.joelsleppy.com/blog/gunicorn-application-preloading/
     # @tb: 👏 @Matvey-Kuk

--- a/keep/entrypoint.sh
+++ b/keep/entrypoint.sh
@@ -18,6 +18,12 @@ python "$SCRIPT_DIR/server_jobs_bg.py" &
     echo "Failed to build providers cache, skipping"
 }
 
+PYTHONPATH=$PYTHONPATH
+
+# Run database migration
+# If the user has set SKIP_DB_CREATION, it will catch it in migrate_db().
+python -c "from keep.api.core.db_on_start import migrate_db; migrate_db()" || exit 1
+    
 # Check for REDIS env variable == true
 if [ "$REDIS" != "true" ]; then
     # Just run gunicorn for the API
@@ -32,12 +38,6 @@ else
     ARQ_WORKER_PORT=${ARQ_WORKER_PORT:-8001}
     ARQ_WORKER_TIMEOUT=${ARQ_WORKER_TIMEOUT:-120}
     LOG_LEVEL=${LOG_LEVEL:-INFO}
-
-    PYTHONPATH=$PYTHONPATH
-
-    # Run database migration
-    # If the user has set SKIP_DB_CREATION, it will catch it in migrate_db().
-    python -c "from keep.api.core.db_on_start import migrate_db; migrate_db()" || exit 1
 
     echo "Starting ARQ workers under Gunicorn (workers: $KEEP_WORKERS)"
 

--- a/keep/entrypoint.sh
+++ b/keep/entrypoint.sh
@@ -33,10 +33,15 @@ else
     ARQ_WORKER_TIMEOUT=${ARQ_WORKER_TIMEOUT:-120}
     LOG_LEVEL=${LOG_LEVEL:-INFO}
 
+    PYTHONPATH=$PYTHONPATH
+
+    # Run database migration
+    # If the user has set SKIP_DB_CREATION, it will catch it in migrate_db().
+    python -c "from keep.api.core.db_on_start import migrate_db; migrate_db()" || exit 1
+
     echo "Starting ARQ workers under Gunicorn (workers: $KEEP_WORKERS)"
 
     # Run Gunicorn directly for ARQ workers
-    PYTHONPATH=$PYTHONPATH \
     REDIS=true \
     KEEP_WORKERS=$KEEP_WORKERS \
     LOG_LEVEL=$LOG_LEVEL \
@@ -58,10 +63,9 @@ else
     # Give ARQ workers time to start up
     sleep 5
 
-
     echo "Running API gunicorn"
     # migration will run from arq worker
-    SKIP_DB_CREATION=true exec "$@" &
+    exec "$@" &
 
     KEEP_API_PID=$!
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #6294

## 📑 Description
<!-- Add a brief description of the pr -->

As stated in issue #6294, when deploying in Docker with Redis a race condition is triggered which only allows for a little over 5 seconds for database migration until the API workers start, and try to query the database. In this PR, database migration is moved up and out of the workers. Now it will run before the workers start. The migrate_db() function handles if the user has set SKIP_DB_CREATION to true.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [N] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
