### PR TITLE
fix: show zero-config providers in Connect Provider catalog

### DIFF
--- a/keep-ui/app/(keep)/providers/page.client.tsx
+++ b/keep-ui/app/(keep)/providers/page.client.tsx
@@ -1,5 +1,9 @@
 "use client";
-import { defaultProvider, Provider } from "@/shared/api/providers";
+import {
+  defaultProvider,
+  Provider,
+  isConnectCatalogVisible,
+} from "@/shared/api/providers";
 import ProvidersTiles from "./providers-tiles";
 import React, { useState, useEffect } from "react";
 import Loading from "@/app/(keep)/loading";
@@ -196,11 +200,8 @@ export default function ProvidersPage({
       searchCategories(provider)
   );
 
-  const displayableProviders = filteredProviders.filter(
-    (provider) =>
-      Object.keys(provider.config || {}).length > 0 ||
-      (provider.tags && provider.tags.includes("alert"))
-  );
+  const displayableProviders =
+    filteredProviders.filter(isConnectCatalogVisible);
 
   return (
     <>

--- a/keep-ui/app/(keep)/providers/providers-tiles.tsx
+++ b/keep-ui/app/(keep)/providers/providers-tiles.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Title } from "@tremor/react";
-import { Providers, Provider } from "@/shared/api/providers";
+import { Providers, Provider, isConnectCatalogVisible } from "@/shared/api/providers";
 import { useEffect, useState } from "react";
 import ProviderForm from "./provider-form";
 import ProviderTile from "./provider-tile";
@@ -85,11 +85,7 @@ const ProvidersTiles = ({
   };
 
   const sortedProviders = providers
-    .filter(
-      (provider) =>
-        Object.keys(provider.config || {}).length > 0 ||
-        (provider.tags && provider.tags.includes("alert"))
-    )
+    .filter(isConnectCatalogVisible)
     .sort(
       (a, b) =>
         // Put coming_soon providers at the end

--- a/keep-ui/shared/api/providers.ts
+++ b/keep-ui/shared/api/providers.ts
@@ -140,6 +140,19 @@ export interface Provider {
   docs_slug?: string;
 }
 
+/**
+ * Whether a provider appears in the Connect Provider catalog.
+ * Stateless workflow/action providers (e.g. http, bash, python, console) have
+ * empty auth config and no `alert` tag but expose notify + query — include those.
+ */
+export function isConnectCatalogVisible(provider: Provider): boolean {
+  return (
+    Object.keys(provider.config || {}).length > 0 ||
+    (provider.tags?.includes("alert") ?? false) ||
+    (provider.can_notify && provider.can_query)
+  );
+}
+
 export type Providers = Provider[];
 
 export const defaultProvider: Provider = {


### PR DESCRIPTION
## Problem
HTTP, bash, python, and console providers are hidden from the Connect Provider UI because the catalog filter excludes providers with empty auth config and no `alert` tag.

## Change
Add shared `isConnectCatalogVisible()` and include providers that expose both `can_notify` and `can_query` (stateless workflow/action providers), in addition to providers with auth fields or alert ingestion.

Fixes #6273.