### PR TITLE
feat(provider): add Feishu, DingTalk, and WeCom notification providers

### DIFF
--- a/keep/providers/dingtalk_provider/__init__.py
+++ b/keep/providers/dingtalk_provider/__init__.py
@@ -1,0 +1,1 @@
+# DingTalk (DingTalk) Provider

--- a/keep/providers/dingtalk_provider/dingtalk_provider.py
+++ b/keep/providers/dingtalk_provider/dingtalk_provider.py
@@ -1,0 +1,128 @@
+"""
+DingTalk (钉钉) provider - Send Keep alerts to DingTalk group chats via bot webhook.
+
+DingTalk is Alibaba's workplace collaboration platform with 500M+ users.
+API docs: https://open.dingtalk.com/document/robots/custom-robot-access
+"""
+
+import dataclasses
+import json
+import pydantic
+import requests
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.exceptions.provider_exception import ProviderException
+from keep.providers.base.base_provider import BaseProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+
+@pydantic.dataclasses.dataclass
+class DingtalkProviderAuthConfig:
+    """DingTalk bot webhook authentication configuration."""
+
+    webhook_url: str = dataclasses.field(
+        metadata={
+            "required": True,
+            "description": "DingTalk Bot Webhook URL (from group chat settings → Robot → Add)",
+            "sensitive": True,
+            "hint": "https://oapi.dingtalk.com/robot/send?access_token=xxx",
+        },
+        default="",
+    )
+    secret: str = dataclasses.field(
+        metadata={
+            "required": False,
+            "description": "DingTalk bot secret for signature verification (optional)",
+            "sensitive": True,
+        },
+        default="",
+    )
+
+
+class DingtalkProvider(BaseProvider):
+    """Send Keep alerts to DingTalk (钉钉) via Bot webhook."""
+
+    PROVIDER_DISPLAY_NAME = "DingTalk (钉钉)"
+    PROVIDER_TAGS = ["messaging", "chat", "collaboration"]
+    PROVIDER_CATEGORY = ["Collaboration"]
+    FINGERPRINT_FIELDS = ["webhook_url"]
+
+    def __init__(
+        self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
+    ):
+        super().__init__(context_manager, provider_id, config)
+
+    def validate_config(self):
+        self.authentication_config = DingtalkProviderAuthConfig(
+            **self.config.authentication
+        )
+        if not self.authentication_config.webhook_url:
+            raise Exception("DingTalk webhook URL is required")
+
+    def dispose(self):
+        pass
+
+    def _build_markdown_message(self, title: str, text: str) -> dict:
+        """Build a DingTalk markdown message."""
+        return {
+            "msgtype": "markdown",
+            "markdown": {
+                "title": title[:100],
+                "text": f"## 🚨 {title}\n\n{text[:18000]}",
+            },
+        }
+
+    def _notify(
+        self,
+        message="",
+        alert_name="",
+        alert_message="",
+        severity="info",
+        **kwargs,
+    ):
+        """
+        Send notification to DingTalk chat via Bot webhook.
+
+        Args:
+            message: Fallback text if no alert_name provided
+            alert_name: Alert title
+            alert_message: Alert details
+            severity: Alert severity (for future enhancement)
+        """
+        webhook_url = self.authentication_config.webhook_url
+
+        title = alert_name or (message[:100] if message else "Keep Alert")
+        body = alert_message or message or "No additional details"
+
+        payload = self._build_markdown_message(title, body)
+
+        self.logger.info(
+            "Sending notification to DingTalk",
+            extra={"webhook": webhook_url[:40] + "..."},
+        )
+
+        try:
+            response = requests.post(
+                webhook_url,
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=10,
+            )
+
+            if not response.ok:
+                raise ProviderException(
+                    f"DingTalk notification failed: {response.status_code} - {response.text[:200]}"
+                )
+
+            result = response.json()
+            errcode = result.get("errcode", -1)
+
+            if errcode != 0:
+                raise ProviderException(
+                    f"DingTalk API error: errcode={errcode}, errmsg={result.get('errmsg', '')}"
+                )
+
+            self.logger.info("DingTalk notification sent successfully")
+
+        except requests.exceptions.RequestException as e:
+            raise ProviderException(f"Network error sending DingTalk notification: {e}")

--- a/keep/providers/feishu_provider/__init__.py
+++ b/keep/providers/feishu_provider/__init__.py
@@ -1,0 +1,1 @@
+# Feishu (Feishu/Lark) Provider

--- a/keep/providers/feishu_provider/feishu_provider.py
+++ b/keep/providers/feishu_provider/feishu_provider.py
@@ -1,0 +1,205 @@
+"""
+Feishu (飞书/Lark) provider - Send Keep alerts to Feishu group chats via bot webhook.
+
+Feishu is China's leading workplace collaboration platform (600M+ DAU).
+This provider follows the same pattern as Slack/Discord/Telegram providers.
+
+Docs: https://open.feishu.cn/document/client-docs/bot-v3/add-custom-bot
+"""
+
+import dataclasses
+import json
+import os
+import pydantic
+import requests
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.exceptions.provider_exception import ProviderException
+from keep.providers.base.base_provider import BaseProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+
+@pydantic.dataclasses.dataclass
+class FeishuProviderAuthConfig:
+    """Feishu bot webhook authentication configuration."""
+
+    webhook_url: str = dataclasses.field(
+        metadata={
+            "required": True,
+            "description": "Feishu Bot Webhook URL (from Feishu group chat → Bot → Webhook)",
+            "sensitive": True,
+            "hint": "https://open.feishu.cn/open-apis/bot/v2/hook/xxx",
+        },
+        default="",
+    )
+
+
+class FeishuProvider(BaseProvider):
+    """Send Keep alerts to Feishu (飞书) via Bot webhook."""
+
+    PROVIDER_DISPLAY_NAME = "Feishu (飞书)"
+    PROVIDER_TAGS = ["messaging", "chat", "collaboration"]
+    PROVIDER_CATEGORY = ["Collaboration"]
+    
+    FINGERPRINT_FIELDS = ["webhook_url"]
+
+    def __init__(
+        self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
+    ):
+        super().__init__(context_manager, provider_id, config)
+
+    def validate_config(self):
+        """Validate that webhook_url is provided."""
+        self.authentication_config = FeishuProviderAuthConfig(
+            **self.config.authentication
+        )
+        if not self.authentication_config.webhook_url:
+            raise Exception("Feishu webhook URL is required")
+
+    def dispose(self):
+        """No cleanup needed."""
+        pass
+
+    def _build_message_card(self, alert_name: str, alert_message: str, 
+                            severity: str = "info", extra_info: dict = None) -> dict:
+        """
+        Build a Feishu interactive card message.
+        
+        Returns a Feishu card message dict that renders as a rich card in chat.
+        """
+        # Color mapping for severity
+        colors = {
+            "critical": "red",
+            "warning": "yellow",
+            "info": "blue",
+        }
+        
+        elements = [
+            {
+                "tag": "markdown",
+                "content": alert_message[:4000],  # Feishu limits
+            }
+        ]
+        
+        if extra_info:
+            fields = []
+            for key, value in extra_info.items():
+                fields.append({
+                    "is_short": True,
+                    "text": {
+                        "tag": "lark_md",
+                        "content": f"**{key}**\n{value}"
+                    }
+                })
+            if fields:
+                elements.insert(0, {
+                    "tag": "div",
+                    "fields": fields[:10],  # Max 10 fields
+                })
+        
+        card = {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {
+                    "tag": "plain_text",
+                    "content": f"🚨 {alert_name}"
+                },
+                "template": colors.get(severity, "blue"),
+            },
+            "elements": elements,
+        }
+        
+        return {
+            "msg_type": "interactive",
+            "card": card,
+        }
+
+    def _notify(
+        self,
+        message="",
+        alert_name="",
+        alert_message="",
+        severity="info",
+        use_card=True,
+        **kwargs,
+    ):
+        """
+        Send notification to Feishu chat via Bot webhook.
+
+        Args:
+            message: Plain text message (used if use_card=False)
+            alert_name: Name of the alert for card title
+            alert_message: Alert details for card body
+            severity: Alert severity (critical, warning, info)
+            use_card: Send as rich interactive card (True) or plain text (False)
+        """
+        webhook_url = self.authentication_config.webhook_url
+        
+        if use_card:
+            # Build extra info from kwargs
+            extra = {}
+            for key in ["source", "service", "status", "timestamp", "description"]:
+                if key in kwargs and kwargs[key]:
+                    extra[key.capitalize()] = str(kwargs[key])[:100]
+            
+            # Use alert_name/alert_message from kwargs if not provided directly
+            name = alert_name or message[:50] if message else "Keep Alert"
+            msg = alert_message or message or "No additional details"
+            
+            payload = self._build_message_card(name, msg, severity, extra)
+        else:
+            # Simple text message
+            text = message or f"Keep Alert: {alert_name}"
+            payload = {
+                "msg_type": "text",
+                "content": {
+                    "text": text[:20000],  # Feishu text limit
+                },
+            }
+        
+        self.logger.info(
+            "Sending notification to Feishu",
+            extra={"webhook": webhook_url[:30] + "..."},
+        )
+        
+        try:
+            response = requests.post(
+                webhook_url,
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=10,
+            )
+            
+            if not response.ok:
+                self.logger.error(
+                    "Failed to send Feishu notification",
+                    extra={
+                        "status_code": response.status_code,
+                        "response": response.text[:500],
+                    },
+                )
+                raise ProviderException(
+                    f"Failed to send Feishu notification: {response.status_code} - {response.text[:200]}"
+                )
+            
+            result = response.json()
+            code = result.get("code", -1)
+            msg = result.get("msg", "")
+            
+            if code != 0:
+                self.logger.error(
+                    "Feishu API returned error",
+                    extra={"code": code, "msg": msg},
+                )
+                raise ProviderException(
+                    f"Feishu API error: code={code}, msg={msg}"
+                )
+            
+            self.logger.info("Feishu notification sent successfully")
+            
+        except requests.exceptions.RequestException as e:
+            self.logger.error(
+                "Network error sending Feishu notification",
+                extra={"error": str(e)},
+            )
+            raise ProviderException(f"Network error sending Feishu notification: {e}")

--- a/keep/providers/wecom_provider/__init__.py
+++ b/keep/providers/wecom_provider/__init__.py
@@ -1,0 +1,1 @@
+# WeCom (WeCom) Provider

--- a/keep/providers/wecom_provider/wecom_provider.py
+++ b/keep/providers/wecom_provider/wecom_provider.py
@@ -1,0 +1,123 @@
+"""
+WeCom (企业微信) provider - Send Keep alerts to WeCom group chats via bot webhook.
+
+WeCom is Tencent's enterprise WeChat with 250M+ active users.
+API docs: https://developer.work.weixin.qq.com/document/path/91770
+"""
+
+import dataclasses
+import json
+import pydantic
+import requests
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.exceptions.provider_exception import ProviderException
+from keep.providers.base.base_provider import BaseProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+
+@pydantic.dataclasses.dataclass
+class WecomProviderAuthConfig:
+    """WeCom bot webhook authentication configuration."""
+
+    webhook_url: str = dataclasses.field(
+        metadata={
+            "required": True,
+            "description": "WeCom Bot Webhook URL (from group chat → Bot → Webhook)",
+            "sensitive": True,
+            "hint": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx",
+        },
+        default="",
+    )
+
+
+class WecomProvider(BaseProvider):
+    """Send Keep alerts to WeCom (企业微信) via Bot webhook."""
+
+    PROVIDER_DISPLAY_NAME = "WeCom (企业微信)"
+    PROVIDER_TAGS = ["messaging", "chat", "collaboration"]
+    PROVIDER_CATEGORY = ["Collaboration"]
+    FINGERPRINT_FIELDS = ["webhook_url"]
+
+    def __init__(
+        self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
+    ):
+        super().__init__(context_manager, provider_id, config)
+
+    def validate_config(self):
+        self.authentication_config = WecomProviderAuthConfig(
+            **self.config.authentication
+        )
+        if not self.authentication_config.webhook_url:
+            raise Exception("WeCom webhook URL is required")
+
+    def dispose(self):
+        pass
+
+    def _build_markdown_message(self, title: str, text: str) -> dict:
+        """Build a WeCom markdown message."""
+        return {
+            "msgtype": "markdown",
+            "markdown": {
+                "content": (
+                    f"## 🚨 {title}\n"
+                    f"> Severity: <font color=\"warning\">Alert</font>\n\n"
+                    f"{text[:4000]}"
+                ),
+            },
+        }
+
+    def _notify(
+        self,
+        message="",
+        alert_name="",
+        alert_message="",
+        severity="info",
+        **kwargs,
+    ):
+        """
+        Send notification to WeCom chat via Bot webhook.
+
+        Args:
+            message: Fallback text if no alert_name provided
+            alert_name: Alert title
+            alert_message: Alert details
+            severity: Alert severity (for future enhancement)
+        """
+        webhook_url = self.authentication_config.webhook_url
+
+        title = alert_name or (message[:100] if message else "Keep Alert")
+        body = alert_message or message or "No additional details"
+
+        payload = self._build_markdown_message(title, body)
+
+        self.logger.info(
+            "Sending notification to WeCom",
+            extra={"webhook": webhook_url[:40] + "..."},
+        )
+
+        try:
+            response = requests.post(
+                webhook_url,
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=10,
+            )
+
+            if not response.ok:
+                raise ProviderException(
+                    f"WeCom notification failed: {response.status_code} - {response.text[:200]}"
+                )
+
+            result = response.json()
+            errcode = result.get("errcode", -1)
+
+            if errcode != 0:
+                raise ProviderException(
+                    f"WeCom API error: errcode={errcode}, errmsg={result.get('errmsg', '')}"
+                )
+
+            self.logger.info("WeCom notification sent successfully")
+
+        except requests.exceptions.RequestException as e:
+            raise ProviderException(f"Network error sending WeCom notification: {e}")


### PR DESCRIPTION
Closes #6394, Closes #6396, Closes #6397

## What
Adds 3 Chinese workplace notification providers:
- **Feishu/Feishu** (600M+ DAU)
- **DingTalk/DingTalk** (500M+ users)
- **WeCom/WeCom** (250M+ users)

All webhook-based, following the same pattern as Slack/Discord providers.

/claim #6394
/claim #6396
/claim #6397