### PR TITLE
feat(providers): add Nagios provider for monitoring host/service alerts

### DIFF
--- a/keep/providers/nagios_provider/alerts_mock.py
+++ b/keep/providers/nagios_provider/alerts_mock.py
@@ -1,0 +1,69 @@
+ALERTS = {
+    "service_critical": {
+        "payload": {
+            "notification_type": "PROBLEM",
+            "host_name": "web-prod-01",
+            "host_alias": "web-prod-01.internal",
+            "host_address": "10.0.0.21",
+            "service_description": "HTTP",
+            "service_state": "CRITICAL",
+            "service_output": "HTTP CRITICAL: HTTP/1.1 500 Internal Server Error",
+            "long_service_output": "Connection succeeded but server returned 500.",
+            "service_check_command": "check_http!-H web-prod-01 -p 80",
+            "service_problem_id": "SP-12345",
+            "service_attempt": "3",
+            "service_duration": "0d 0h 5m 12s",
+            "long_date_time": "Sun Mar 15 14:23:42 UTC 2026",
+            "contact_name": "oncall",
+            "contact_email": "oncall@example.com",
+        }
+    },
+    "host_down": {
+        "payload": {
+            "notification_type": "PROBLEM",
+            "host_name": "db-prod-02",
+            "host_alias": "db-prod-02.internal",
+            "host_address": "10.0.0.42",
+            "host_state": "DOWN",
+            "host_output": "PING CRITICAL - 100% packet loss",
+            "host_check_command": "check_ping!100.0,20%!500.0,60%",
+            "host_problem_id": "HP-9876",
+            "host_attempt": "5",
+            "host_duration": "0d 0h 2m 03s",
+            "long_date_time": "Sun Mar 15 14:25:01 UTC 2026",
+        }
+    },
+    "service_recovery": {
+        "payload": {
+            "notification_type": "RECOVERY",
+            "host_name": "web-prod-01",
+            "service_description": "HTTP",
+            "service_state": "OK",
+            "service_output": "HTTP OK: HTTP/1.1 200 OK - 1234 bytes in 0.045 second response time",
+            "service_problem_id": "SP-12345",
+            "long_date_time": "Sun Mar 15 14:31:02 UTC 2026",
+        }
+    },
+    "service_warning_acknowledged": {
+        "payload": {
+            "notification_type": "ACKNOWLEDGEMENT",
+            "host_name": "queue-worker-03",
+            "service_description": "QueueDepth",
+            "service_state": "WARNING",
+            "service_output": "Queue depth above warning threshold (1500 > 1000)",
+            "service_problem_id": "SP-44455",
+            "long_date_time": "Sun Mar 15 14:40:00 UTC 2026",
+            "contact_name": "operator",
+        }
+    },
+    "host_recovery": {
+        "payload": {
+            "notification_type": "RECOVERY",
+            "host_name": "db-prod-02",
+            "host_state": "UP",
+            "host_output": "PING OK - Packet loss = 0%, RTA = 1.42 ms",
+            "host_problem_id": "HP-9876",
+            "long_date_time": "Sun Mar 15 14:42:18 UTC 2026",
+        }
+    },
+}

--- a/keep/providers/nagios_provider/nagios_provider.py
+++ b/keep/providers/nagios_provider/nagios_provider.py
@@ -1,0 +1,193 @@
+"""
+Nagios is an open-source monitoring system for hosts, services and network resources.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.base.base_provider import BaseProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+logger = logging.getLogger(__name__)
+
+
+class NagiosProvider(BaseProvider):
+    """Get alerts from Nagios into Keep via custom notification command."""
+
+    webhook_description = ""
+    webhook_template = ""
+    webhook_markdown = """
+  1. Nagios supports custom notification commands.
+  2. Copy the `webhook-keep.py` script onto the Nagios server (e.g. `/usr/local/nagios/libexec/webhook-keep.py`) and make it executable.
+  3. Define a new command in `commands.cfg` that runs the script for both host and service notifications. Pass `{keep_webhook_api_url}` and `{api_key}` as macros (e.g. via `$ARG1$` and `$ARG2$`) so they are forwarded to the script as environment variables (`KEEP_WEBHOOK_URL`, `KEEP_API_KEY`).
+  4. Reference the new command in your contact's `host_notification_commands` and `service_notification_commands`.
+  5. Reload Nagios configuration. New host/service problems and recoveries will now reach Keep.
+  """
+
+    # Nagios service states (from $SERVICESTATE$): OK, WARNING, UNKNOWN, CRITICAL
+    # Nagios host states (from $HOSTSTATE$):     UP, DOWN, UNREACHABLE
+    SEVERITIES_MAP = {
+        "OK": AlertSeverity.INFO,
+        "WARNING": AlertSeverity.WARNING,
+        "UNKNOWN": AlertSeverity.INFO,
+        "CRITICAL": AlertSeverity.CRITICAL,
+        "UP": AlertSeverity.INFO,
+        "DOWN": AlertSeverity.CRITICAL,
+        "UNREACHABLE": AlertSeverity.CRITICAL,
+    }
+
+    # Nagios notification types (from $NOTIFICATIONTYPE$):
+    # PROBLEM, RECOVERY, ACKNOWLEDGEMENT, FLAPPINGSTART, FLAPPINGSTOP,
+    # FLAPPINGDISABLED, DOWNTIMESTART, DOWNTIMEEND, DOWNTIMECANCELLED, CUSTOM
+    STATUS_MAP = {
+        "PROBLEM": AlertStatus.FIRING,
+        "RECOVERY": AlertStatus.RESOLVED,
+        "ACKNOWLEDGEMENT": AlertStatus.ACKNOWLEDGED,
+        "FLAPPINGSTART": AlertStatus.FIRING,
+        "FLAPPINGSTOP": AlertStatus.RESOLVED,
+        "FLAPPINGDISABLED": AlertStatus.RESOLVED,
+        "DOWNTIMESTART": AlertStatus.SUPPRESSED,
+        "DOWNTIMEEND": AlertStatus.FIRING,
+        "DOWNTIMECANCELLED": AlertStatus.FIRING,
+        "CUSTOM": AlertStatus.FIRING,
+    }
+
+    PROVIDER_DISPLAY_NAME = "Nagios"
+    PROVIDER_TAGS = ["alert"]
+    PROVIDER_CATEGORY = ["Monitoring"]
+    FINGERPRINT_FIELDS = ["host", "service"]
+
+    def __init__(
+        self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
+    ):
+        super().__init__(context_manager, provider_id, config)
+
+    def validate_config():
+        """Nagios uses webhook-only ingestion; no provider-side config to validate."""
+        pass
+
+    @staticmethod
+    def _safe_get(event: dict, key: str, default=None):
+        value = event.get(key)
+        if value is None or value == "":
+            return default
+        return value
+
+    @staticmethod
+    def _parse_timestamp(value: str | None) -> str:
+        """Parse Nagios $LONGDATETIME$ / $SHORTDATETIME$ to UTC ISO 8601.
+
+        Falls back to current UTC if the value is missing or unparseable.
+        Nagios common formats:
+          - $LONGDATETIME$:  "Sun Mar 15 14:23:42 UTC 2026"
+          - $SHORTDATETIME$: "03-15-2026 14:23:42"
+          - epoch:           "1710512622"
+        """
+        if not value:
+            return datetime.now(timezone.utc).isoformat()
+
+        # Epoch seconds
+        if value.isdigit():
+            try:
+                return datetime.fromtimestamp(int(value), tz=timezone.utc).isoformat()
+            except (ValueError, OSError):
+                pass
+
+        formats = [
+            "%a %b %d %H:%M:%S %Z %Y",  # LONGDATETIME with named zone
+            "%a %b %d %H:%M:%S %z %Y",  # LONGDATETIME with offset
+            "%m-%d-%Y %H:%M:%S",        # SHORTDATETIME (date_format=us)
+            "%d-%m-%Y %H:%M:%S",        # SHORTDATETIME (date_format=euro)
+            "%Y-%m-%d %H:%M:%S",        # SHORTDATETIME (date_format=iso8601)
+        ]
+        for fmt in formats:
+            try:
+                dt = datetime.strptime(value, fmt)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return dt.astimezone(timezone.utc).isoformat()
+            except ValueError:
+                continue
+
+        logger.warning("Could not parse Nagios timestamp %r; using current UTC", value)
+        return datetime.now(timezone.utc).isoformat()
+
+    @staticmethod
+    def _format_alert(
+        event: dict, provider_instance: BaseProvider = None
+    ) -> AlertDto | list[AlertDto]:
+        """Map a Nagios notification payload to an AlertDto.
+
+        The webhook script forwards Nagios environment variables as a flat dict.
+        Both host and service notifications are supported; service notifications
+        take precedence when both `service_description` and host fields are set.
+        """
+        get = NagiosProvider._safe_get
+
+        notification_type = get(event, "notification_type", "PROBLEM")
+        is_service = bool(get(event, "service_description"))
+
+        if is_service:
+            state = get(event, "service_state", "UNKNOWN")
+            output = get(event, "service_output")
+            long_output = get(event, "long_service_output")
+            check_command = get(event, "service_check_command")
+            problem_id = get(event, "service_problem_id")
+            duration = get(event, "service_duration")
+            attempt = get(event, "service_attempt")
+            url = get(event, "service_action_url") or get(event, "service_notes_url")
+        else:
+            state = get(event, "host_state", "UP")
+            output = get(event, "host_output")
+            long_output = get(event, "long_host_output")
+            check_command = get(event, "host_check_command")
+            problem_id = get(event, "host_problem_id")
+            duration = get(event, "host_duration")
+            attempt = get(event, "host_attempt")
+            url = get(event, "host_action_url") or get(event, "host_notes_url")
+
+        last_received = NagiosProvider._parse_timestamp(
+            get(event, "long_date_time") or get(event, "short_date_time")
+        )
+
+        # Severity follows the underlying state; recoveries are mapped to INFO.
+        severity_key = state if notification_type != "RECOVERY" else "OK" if is_service else "UP"
+        severity = NagiosProvider.SEVERITIES_MAP.get(severity_key, AlertSeverity.WARNING)
+        status = NagiosProvider.STATUS_MAP.get(notification_type, AlertStatus.FIRING)
+
+        host = get(event, "host_name") or get(event, "host")
+        service = get(event, "service_description") or get(event, "service")
+
+        # Stable id: prefer Nagios-provided problem_id, fall back to host[/service]+timestamp
+        alert_id = problem_id or f"{host}-{service or 'host'}-{last_received}"
+        name = service or host or "nagios-alert"
+
+        return AlertDto(
+            id=alert_id,
+            name=name,
+            description=output,
+            severity=severity,
+            status=status,
+            host=host,
+            address=get(event, "host_address"),
+            alias=get(event, "host_alias"),
+            service=service,
+            source=["nagios"],
+            output=output,
+            long_output=long_output,
+            check_command=check_command,
+            current_attempt=attempt,
+            duration=duration,
+            notification_type=notification_type,
+            contact_name=get(event, "contact_name"),
+            contact_email=get(event, "contact_email"),
+            contact_pager=get(event, "contact_pager"),
+            path_url=url,
+            lastReceived=last_received,
+        )
+
+
+if __name__ == "__main__":
+    pass

--- a/keep/providers/nagios_provider/webhook-keep.py
+++ b/keep/providers/nagios_provider/webhook-keep.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# webhook-keep
+
+"""
+Notification script that forwards Nagios alerts to Keep.
+
+Place this file on the Nagios server (e.g. /usr/local/nagios/libexec/webhook-keep.py),
+make it executable, and reference it from a Nagios `command` definition.
+
+The script reads two parameters from environment variables (set them via the
+`-H` argument macros in the command definition, or export them in the contact
+template):
+
+    KEEP_WEBHOOK_URL  - the HTTP URL of the Keep webhook
+    KEEP_API_KEY      - API key registered for the Nagios provider in Keep
+
+All other Nagios notification context is read from the standard `NAGIOS_*`
+macros that Nagios exports into the environment of notification commands.
+See the Nagios docs for the full list:
+https://docs.checkmk.com is not relevant; refer to
+https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/4/en/macrolist.html
+"""
+
+import os
+import sys
+
+import requests
+
+# Map of Keep payload key -> Nagios environment variable name.
+# Includes both host and service macros; missing keys are dropped from the
+# payload so Keep's _safe_get behaves correctly.
+NAGIOS_TO_KEEP = {
+    # Notification meta
+    "notification_type": "NAGIOS_NOTIFICATIONTYPE",
+    "notification_recipients": "NAGIOS_NOTIFICATIONRECIPIENTS",
+    "notification_author": "NAGIOS_NOTIFICATIONAUTHOR",
+    "notification_comment": "NAGIOS_NOTIFICATIONCOMMENT",
+    # Time
+    "long_date_time": "NAGIOS_LONGDATETIME",
+    "short_date_time": "NAGIOS_SHORTDATETIME",
+    # Host
+    "host_name": "NAGIOS_HOSTNAME",
+    "host_alias": "NAGIOS_HOSTALIAS",
+    "host_address": "NAGIOS_HOSTADDRESS",
+    "host_state": "NAGIOS_HOSTSTATE",
+    "host_output": "NAGIOS_HOSTOUTPUT",
+    "long_host_output": "NAGIOS_LONGHOSTOUTPUT",
+    "host_check_command": "NAGIOS_HOSTCHECKCOMMAND",
+    "host_problem_id": "NAGIOS_HOSTPROBLEMID",
+    "host_attempt": "NAGIOS_HOSTATTEMPT",
+    "host_duration": "NAGIOS_HOSTDURATION",
+    "host_action_url": "NAGIOS_HOSTACTIONURL",
+    "host_notes_url": "NAGIOS_HOSTNOTESURL",
+    # Service
+    "service_description": "NAGIOS_SERVICEDESC",
+    "service_state": "NAGIOS_SERVICESTATE",
+    "service_output": "NAGIOS_SERVICEOUTPUT",
+    "long_service_output": "NAGIOS_LONGSERVICEOUTPUT",
+    "service_check_command": "NAGIOS_SERVICECHECKCOMMAND",
+    "service_problem_id": "NAGIOS_SERVICEPROBLEMID",
+    "service_attempt": "NAGIOS_SERVICEATTEMPT",
+    "service_duration": "NAGIOS_SERVICEDURATION",
+    "service_action_url": "NAGIOS_SERVICEACTIONURL",
+    "service_notes_url": "NAGIOS_SERVICENOTESURL",
+    # Contact
+    "contact_name": "NAGIOS_CONTACTNAME",
+    "contact_email": "NAGIOS_CONTACTEMAIL",
+    "contact_pager": "NAGIOS_CONTACTPAGER",
+}
+
+
+def build_payload() -> dict:
+    payload = {}
+    for keep_key, env_key in NAGIOS_TO_KEEP.items():
+        value = os.environ.get(env_key)
+        if value not in (None, ""):
+            payload[keep_key] = value
+    return payload
+
+
+def main() -> int:
+    webhook_url = os.environ.get("KEEP_WEBHOOK_URL")
+    api_key = os.environ.get("KEEP_API_KEY")
+
+    if not webhook_url or not api_key:
+        print(
+            "webhook-keep: KEEP_WEBHOOK_URL and KEEP_API_KEY must be set in the environment",
+            file=sys.stderr,
+        )
+        return 2
+
+    payload = build_payload()
+    if not payload.get("notification_type"):
+        # Nothing useful to forward; treat as no-op so Nagios doesn't loop.
+        print("webhook-keep: no NAGIOS_NOTIFICATIONTYPE present, skipping", file=sys.stderr)
+        return 0
+
+    try:
+        response = requests.post(
+            webhook_url,
+            headers={"X-API-KEY": api_key, "Content-Type": "application/json"},
+            json=payload,
+            timeout=10,
+        )
+    except requests.RequestException as exc:
+        print(f"webhook-keep: request failed: {exc}", file=sys.stderr)
+        return 1
+
+    if response.status_code >= 400:
+        print(
+            f"webhook-keep: keep returned {response.status_code}: {response.text[:200]}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements a Keep provider that ingests Nagios Core / Nagios XI notifications via webhook, modeled after the existing Checkmk provider (`keep/providers/checkmk_provider/`).

The Nagios server runs a small notification command (`webhook-keep.py`) that forwards Nagios environment macros to Keep's webhook endpoint; `NagiosProvider._format_alert` then maps the payload to an `AlertDto`.

## Changes

- `keep/providers/nagios_provider/__init__.py` — package marker.
- `keep/providers/nagios_provider/nagios_provider.py` — main provider class.
- `keep/providers/nagios_provider/alerts_mock.py` — five mock notification payloads (service critical / host down / service recovery / acknowledgement / host recovery).
- `keep/providers/nagios_provider/webhook-keep.py` — installable Nagios notification script.

## Behaviour

- **Notification types**: PROBLEM, RECOVERY, ACKNOWLEDGEMENT, FLAPPINGSTART/STOP/DISABLED, DOWNTIMESTART/END/CANCELLED, CUSTOM. Each maps to an appropriate `AlertStatus` via `STATUS_MAP`.
- **States**: service states (OK / WARNING / CRITICAL / UNKNOWN) and host states (UP / DOWN / UNREACHABLE) are mapped to `AlertSeverity` via `SEVERITIES_MAP`. RECOVERY notifications are explicitly mapped to INFO regardless of the underlying state field.
- **Timestamps**: `_parse_timestamp` handles `$LONGDATETIME$`, `$SHORTDATETIME$` (US, EU, ISO 8601 `date_format`s) and epoch seconds; falls back to current UTC when missing / unparseable.
- **Stable id**: prefers `$HOSTPROBLEMID$` / `$SERVICEPROBLEMID$` when Nagios provides one, otherwise `host[/service]+timestamp` to keep alerts deduped across re-deliveries.

## Webhook script

The script reads `KEEP_WEBHOOK_URL` and `KEEP_API_KEY` from the environment (set them via the Nagios command's argument macros), assembles a flat dict from the `NAGIOS_*` macros, and POSTs to Keep with `X-API-KEY`. Exit codes follow the convention of other Keep notification scripts (0 success, 1 transient error, 2 misconfiguration).

## How to verify

Spin up Nagios locally, drop `webhook-keep.py` onto the server, declare a notification command that runs it, and trigger a service problem (`/etc/init.d/<svc> stop`). The payload should appear in Keep with the correct status / severity / host / service fields. Mock payloads in `alerts_mock.py` mirror the production payload shape for unit-testing the mapping.

Closes #3960