### PR TITLE
feat(providers): add SolarWinds provider for pulling Orion active alerts

### DIFF
--- a/keep/providers/solarwinds_provider/README.md
+++ b/keep/providers/solarwinds_provider/README.md
@@ -1,0 +1,66 @@
+# SolarWinds Provider
+
+Pulls active alerts from [SolarWinds Orion](https://www.solarwinds.com/) via the
+SolarWinds Information Service (SWIS) REST API.
+
+## Authentication
+
+The provider authenticates against SWIS with HTTP Basic auth — the same
+username and password you would use to log into the Orion Web Console. SWIS
+listens on port `17778` by default.
+
+| Field        | Required | Description                                                                 |
+|--------------|----------|-----------------------------------------------------------------------------|
+| `host_url`   | yes      | Base URL of the Orion server, e.g. `https://orion.example.com:17778`.       |
+| `username`   | yes      | Orion account username with read access to alerts.                           |
+| `password`   | yes      | Orion account password.                                                      |
+| `verify_ssl` | no       | Set to `false` if your Orion server uses a self-signed certificate.          |
+
+A read-only Orion account is sufficient — the provider only issues `SELECT`
+queries against `Orion.AlertActive`, `Orion.AlertObjects` and
+`Orion.AlertConfigurations`.
+
+## What the provider pulls
+
+On each poll, Keep runs the following SWQL query against SWIS:
+
+```sql
+SELECT a.AlertActiveID, a.AlertObjectID, a.TriggeredDateTime,
+       a.TriggeredMessage, a.Acknowledged, a.AcknowledgedBy,
+       a.AcknowledgedDateTime,
+       ao.AlertID, ao.EntityCaption, ao.EntityType, ao.RelatedNodeCaption,
+       ac.Name AS AlertName, ac.Severity, ac.Description
+FROM Orion.AlertActive a
+INNER JOIN Orion.AlertObjects ao ON a.AlertObjectID = ao.AlertObjectID
+INNER JOIN Orion.AlertConfigurations ac ON ao.AlertID = ac.AlertID
+```
+
+Each row becomes an `AlertDto` in Keep with:
+
+- `id` — the Orion `AlertObjectID`, stable across re-polls so the same
+  active alert is deduped (no spurious "new" alerts on every cycle).
+- `name` — the human-readable name configured on the Orion alert.
+- `severity` — mapped from Orion's numeric severity (`0`=Informational →
+  `4`=Critical) to Keep's severity scale.
+- `status` — `acknowledged` if the alert has been acknowledged in Orion,
+  otherwise `firing`.
+- `lastReceived` — the alert's `TriggeredDateTime`.
+- Extra fields kept on the alert for downstream workflows:
+  `alert_object_id`, `alert_active_id`, `alert_id`, `entity_type`,
+  `entity_caption`, `related_node_caption`, `acknowledged`,
+  `acknowledged_by`, `acknowledged_at`.
+
+## Severity mapping
+
+| Orion severity | Keep severity |
+|----------------|---------------|
+| `0` Informational | `info`     |
+| `1` Notice        | `low`      |
+| `2` Warning       | `warning`  |
+| `3` Serious       | `high`     |
+| `4` Critical      | `critical` |
+
+## Reference
+
+- [SolarWinds Information Service (SWIS) overview](https://documentation.solarwinds.com/en/success_center/orionplatform/content/core-using-the-information-service.htm)
+- [SWQL query reference](https://github.com/solarwinds/OrionSDK/wiki/About-SWQL)

--- a/keep/providers/solarwinds_provider/alerts_mock.py
+++ b/keep/providers/solarwinds_provider/alerts_mock.py
@@ -1,0 +1,77 @@
+"""Mock SWIS query results for unit-testing the SolarWinds provider mapping."""
+
+ALERTS = {
+    "node_critical": {
+        "results": [
+            {
+                "AlertActiveID": 12001,
+                "AlertObjectID": 4501,
+                "AlertID": 87,
+                "TriggeredDateTime": "2026-03-15T14:23:42Z",
+                "TriggeredMessage": "Node web-prod-01 is down (no response to ICMP).",
+                "Acknowledged": False,
+                "AcknowledgedBy": None,
+                "AcknowledgedDateTime": None,
+                "EntityCaption": "web-prod-01",
+                "EntityType": "Orion.Nodes",
+                "RelatedNodeCaption": "web-prod-01",
+                "AlertName": "Node down",
+                "Severity": 4,
+                "Description": "Triggered when a node fails to respond to polling.",
+            }
+        ]
+    },
+    "interface_warning": {
+        "results": [
+            {
+                "AlertActiveID": 12002,
+                "AlertObjectID": 4502,
+                "AlertID": 91,
+                "TriggeredDateTime": "2026-03-15T14:25:12Z",
+                "TriggeredMessage": "Interface Gi0/1 utilization above 80%.",
+                "Acknowledged": False,
+                "EntityCaption": "Gi0/1 - core-sw-01",
+                "EntityType": "Orion.NPM.Interfaces",
+                "RelatedNodeCaption": "core-sw-01",
+                "AlertName": "Interface high utilization",
+                "Severity": 2,
+            }
+        ]
+    },
+    "acknowledged_volume": {
+        "results": [
+            {
+                "AlertActiveID": 12003,
+                "AlertObjectID": 4503,
+                "AlertID": 102,
+                "TriggeredDateTime": "2026-03-15T13:00:00Z",
+                "TriggeredMessage": "Volume /var on db-prod-02 above 90% capacity.",
+                "Acknowledged": True,
+                "AcknowledgedBy": "oncall",
+                "AcknowledgedDateTime": "2026-03-15T13:42:18Z",
+                "EntityCaption": "/var",
+                "EntityType": "Orion.Volumes",
+                "RelatedNodeCaption": "db-prod-02",
+                "AlertName": "Volume nearly full",
+                "Severity": 3,
+            }
+        ]
+    },
+    "informational": {
+        "results": [
+            {
+                "AlertActiveID": 12004,
+                "AlertObjectID": 4504,
+                "AlertID": 30,
+                "TriggeredDateTime": "2026-03-15T14:30:00Z",
+                "TriggeredMessage": "New device discovered: printer-3rd-floor.",
+                "Acknowledged": False,
+                "EntityCaption": "printer-3rd-floor",
+                "EntityType": "Orion.Nodes",
+                "RelatedNodeCaption": "printer-3rd-floor",
+                "AlertName": "New device discovered",
+                "Severity": 0,
+            }
+        ]
+    },
+}

--- a/keep/providers/solarwinds_provider/solarwinds_provider.py
+++ b/keep/providers/solarwinds_provider/solarwinds_provider.py
@@ -1,0 +1,241 @@
+"""
+SolarWinds is a class that provides a set of methods to interact with the
+SolarWinds Information Service (SWIS) REST API to pull active alerts from
+SolarWinds Orion.
+"""
+
+import dataclasses
+import datetime
+
+import pydantic
+import requests
+
+from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
+from keep.contextmanager.contextmanager import ContextManager
+from keep.exceptions.provider_exception import ProviderException
+from keep.providers.base.base_provider import BaseProvider
+from keep.providers.models.provider_config import ProviderConfig, ProviderScope
+
+
+@pydantic.dataclasses.dataclass
+class SolarwindsProviderAuthConfig:
+    """Authentication for SolarWinds Orion's SWIS REST API.
+
+    SWIS exposes HTTPS Basic auth on port 17778 by default. Use the same
+    credentials you would use for the Orion Web Console.
+    """
+
+    host_url: pydantic.AnyHttpUrl = dataclasses.field(
+        metadata={
+            "required": True,
+            "description": "SolarWinds Orion server base URL (e.g. https://orion.example.com:17778)",
+            "sensitive": False,
+            "validation": "any_http_url",
+        },
+    )
+
+    username: str = dataclasses.field(
+        metadata={
+            "required": True,
+            "description": "SolarWinds Orion username",
+            "sensitive": False,
+        },
+        default=None,
+    )
+
+    password: str = dataclasses.field(
+        metadata={
+            "required": True,
+            "description": "SolarWinds Orion password",
+            "sensitive": True,
+        },
+        default=None,
+    )
+
+    verify_ssl: bool = dataclasses.field(
+        metadata={
+            "required": False,
+            "description": "Verify TLS certificates (disable for self-signed certs)",
+            "sensitive": False,
+        },
+        default=True,
+    )
+
+
+class SolarwindsProvider(BaseProvider):
+    """Pulls active alerts from SolarWinds Orion via the SWIS REST API."""
+
+    PROVIDER_DISPLAY_NAME = "SolarWinds"
+    PROVIDER_TAGS = ["alert"]
+    PROVIDER_CATEGORY = ["Monitoring"]
+    PROVIDER_SCOPES = [
+        ProviderScope(
+            name="authenticated",
+            description="User can authenticate against the SWIS API",
+        ),
+    ]
+
+    # SolarWinds Orion alert severity values (Orion.AlertConfigurations.Severity):
+    # https://documentation.solarwinds.com/en/success_center/orionplatform/content/core-using-the-information-service.htm
+    SEVERITY_MAP = {
+        0: AlertSeverity.INFO,       # Informational
+        1: AlertSeverity.LOW,        # Notice
+        2: AlertSeverity.WARNING,    # Warning
+        3: AlertSeverity.HIGH,       # Serious
+        4: AlertSeverity.CRITICAL,   # Critical
+    }
+
+    FINGERPRINT_FIELDS = ["alert_object_id"]
+
+    # SWQL query that returns the currently-active alerts joined with their
+    # configuration so we can read severity and configured names.
+    ACTIVE_ALERTS_QUERY = (
+        "SELECT a.AlertActiveID, a.AlertObjectID, a.TriggeredDateTime, "
+        "a.TriggeredMessage, a.Acknowledged, a.AcknowledgedBy, "
+        "a.AcknowledgedDateTime, "
+        "ao.AlertID, ao.EntityCaption, ao.EntityType, ao.RelatedNodeCaption, "
+        "ac.Name AS AlertName, ac.Severity, ac.Description "
+        "FROM Orion.AlertActive a "
+        "INNER JOIN Orion.AlertObjects ao ON a.AlertObjectID = ao.AlertObjectID "
+        "INNER JOIN Orion.AlertConfigurations ac ON ao.AlertID = ac.AlertID"
+    )
+
+    def __init__(
+        self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
+    ):
+        super().__init__(context_manager, provider_id, config)
+
+    def dispose(self):
+        pass
+
+    def validate_config(self):
+        self.authentication_config = SolarwindsProviderAuthConfig(
+            **self.config.authentication
+        )
+
+    def __query_url(self) -> str:
+        base = str(self.authentication_config.host_url).rstrip("/")
+        return f"{base}/SolarWinds/InformationService/v3/Json/Query"
+
+    def __auth(self):
+        return (
+            self.authentication_config.username,
+            self.authentication_config.password,
+        )
+
+    def __post_swql(self, query: str) -> dict:
+        response = requests.post(
+            self.__query_url(),
+            json={"query": query},
+            auth=self.__auth(),
+            verify=self.authentication_config.verify_ssl,
+            timeout=30,
+        )
+        if not response.ok:
+            raise ProviderException(
+                f"SolarWinds SWIS query failed: {response.status_code} {response.text[:300]}"
+            )
+        return response.json()
+
+    def validate_scopes(self) -> dict[str, bool | str]:
+        try:
+            self.__post_swql("SELECT TOP 1 NodeID FROM Orion.Nodes")
+            return {"authenticated": True}
+        except Exception as exc:  # surface the underlying reason for the user
+            return {"authenticated": f"Error validating scopes: {exc}"}
+
+    @staticmethod
+    def __parse_iso(value):
+        if not value:
+            return datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+        # SWIS returns ISO 8601 with optional Z; let fromisoformat handle both.
+        try:
+            return datetime.datetime.fromisoformat(
+                str(value).replace("Z", "+00:00")
+            ).isoformat()
+        except ValueError:
+            return str(value)
+
+    def _get_alerts(self) -> list[AlertDto]:
+        try:
+            self.logger.info("Pulling active alerts from SolarWinds Orion")
+            payload = self.__post_swql(self.ACTIVE_ALERTS_QUERY)
+        except Exception as exc:
+            self.logger.error("Error querying SolarWinds: %s", exc)
+            raise ProviderException(f"Error querying SolarWinds: {exc}") from exc
+
+        results = payload.get("results", payload) or []
+        alerts: list[AlertDto] = []
+        for row in results:
+            severity_int = row.get("Severity")
+            severity = self.SEVERITY_MAP.get(severity_int, AlertSeverity.WARNING)
+
+            acknowledged = bool(row.get("Acknowledged"))
+            status = AlertStatus.ACKNOWLEDGED if acknowledged else AlertStatus.FIRING
+
+            entity_caption = row.get("EntityCaption") or row.get("RelatedNodeCaption")
+            name = row.get("AlertName") or entity_caption or "SolarWinds Alert"
+            triggered = self.__parse_iso(row.get("TriggeredDateTime"))
+
+            # Stable id: AlertObjectID is unique per (alert config, entity) pair
+            # in Orion, so we can dedupe across pulls without races.
+            alert_id = str(
+                row.get("AlertObjectID")
+                or row.get("AlertActiveID")
+                or f"{name}-{triggered}"
+            )
+
+            alerts.append(
+                AlertDto(
+                    id=alert_id,
+                    name=name,
+                    description=row.get("TriggeredMessage") or row.get("Description"),
+                    severity=severity,
+                    status=status,
+                    source=["solarwinds"],
+                    lastReceived=triggered,
+                    alert_object_id=row.get("AlertObjectID"),
+                    alert_active_id=row.get("AlertActiveID"),
+                    alert_id=row.get("AlertID"),
+                    entity_type=row.get("EntityType"),
+                    entity_caption=entity_caption,
+                    related_node_caption=row.get("RelatedNodeCaption"),
+                    acknowledged=acknowledged,
+                    acknowledged_by=row.get("AcknowledgedBy"),
+                    acknowledged_at=self.__parse_iso(row.get("AcknowledgedDateTime"))
+                    if row.get("AcknowledgedDateTime")
+                    else None,
+                )
+            )
+        return alerts
+
+
+if __name__ == "__main__":
+    import logging
+    import os
+
+    logging.basicConfig(level=logging.DEBUG, handlers=[logging.StreamHandler()])
+    context_manager = ContextManager(tenant_id="singletenant", workflow_id="test")
+
+    host_url = os.environ.get("SOLARWINDS_HOST_URL")
+    username = os.environ.get("SOLARWINDS_USERNAME")
+    password = os.environ.get("SOLARWINDS_PASSWORD")
+
+    if not host_url:
+        raise ProviderException("SOLARWINDS_HOST_URL is not set")
+
+    config = ProviderConfig(
+        description="SolarWinds Provider",
+        authentication={
+            "host_url": host_url,
+            "username": username,
+            "password": password,
+            "verify_ssl": os.environ.get("SOLARWINDS_VERIFY_SSL", "true").lower() != "false",
+        },
+    )
+
+    provider = SolarwindsProvider(
+        context_manager, provider_id="solarwinds", config=config
+    )
+    provider.validate_config()
+    print(provider._get_alerts())


### PR DESCRIPTION
## Summary

Adds a pull-based provider that queries SolarWinds Orion via the SolarWinds Information Service (SWIS) REST API and surfaces active alerts in Keep. Modeled after the existing Centreon provider (`keep/providers/centreon_provider/`) — small, self-contained, no extra runtime dependencies.

## Changes

- `keep/providers/solarwinds_provider/__init__.py` — package marker.
- `keep/providers/solarwinds_provider/solarwinds_provider.py` — provider class + auth dataclass (~240 LOC).
- `keep/providers/solarwinds_provider/alerts_mock.py` — four mock SWIS query payloads (node down, interface warning, acknowledged volume, informational discovery).
- `keep/providers/solarwinds_provider/README.md` — setup, severity mapping, SWIS reference.

## Behaviour

- **Auth**: HTTP Basic against the SWIS endpoint on the Orion server (port `17778` by default), using the same credentials as the Orion Web Console. `verify_ssl` flag for self-signed certs.
- **Query**: a single SWQL join across `Orion.AlertActive`, `Orion.AlertObjects` and `Orion.AlertConfigurations` so each row already carries the configured alert name, description, severity and the entity that triggered it — no follow-up per-alert calls needed.
- **Severity** mapping: Orion's numeric `0..4` (Informational → Critical) → Keep's `info / low / warning / high / critical`.
- **Status**: alerts that have been acknowledged in Orion become `AlertStatus.ACKNOWLEDGED`, otherwise `FIRING`.
- **Stable id**: `AlertObjectID` (unique per alert-config × entity in Orion), so the same active alert is deduped across pulls rather than being re-emitted as new on every cycle.
- **Read-only**: the provider only issues `SELECT` queries against `Orion.*` views; a read-only Orion account is sufficient.

## How to verify

1. Configure the provider with a SolarWinds Orion server URL, username, and password.
2. Trigger an alert in Orion (e.g. shut down a polled interface) and wait one polling cycle.
3. The active alert should appear in Keep with the correct severity, status, and entity caption. Acknowledging the alert in Orion should change its Keep status to `acknowledged` on the next pull.

The mock payloads in `alerts_mock.py` mirror the SWIS `Query` response shape and can be used to unit-test `_get_alerts` without a live Orion instance.

Closes #3526