### PR TITLE
docs: remove orphan microsoft-planner-provider entry from mint.json

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -207,7 +207,6 @@
             "providers/documentation/llamacpp-provider",
             "providers/documentation/mailgun-provider",
             "providers/documentation/mattermost-provider",
-            "providers/documentation/microsoft-planner-provider",
             "providers/documentation/mock-provider",
             "providers/documentation/monday-provider",
             "providers/documentation/mongodb-provider",


### PR DESCRIPTION
Fixes #5402.

The mint.json sidebar referenced `providers/documentation/microsoft-planner-provider` (line 210), which has no corresponding `.mdx` file in the docs tree. That's why the Microsoft Planner link was returning **404 Not Found**.

The actual Microsoft Planner provider page exists at `docs/providers/documentation/planner-provider.mdx` and is already correctly registered in the sidebar at line 230, and linked from both `overview.md` and `overview.mdx`. The orphan entry was a stale leftover from when the page was renamed.

### Change

One line removed from `docs/mint.json`:
```diff
-            "providers/documentation/microsoft-planner-provider",
```

### Verification

- Sidebar still contains the working entry (`providers/documentation/planner-provider`) at the same position.
- `docs/mint.json` parses as valid JSON.
- The 404 link disappears from the sidebar; the working Planner link in `overview.md` / `overview.mdx` is unaffected.
