### PR TITLE
docs: remove dead STRESS.md link from stress-testing page

### DIFF
--- a/docs/deployment/stress-testing.mdx
+++ b/docs/deployment/stress-testing.mdx
@@ -13,10 +13,6 @@ This documentation outlines the key areas of focus for testing Keep under differ
 
 Keep was initially designed to be user-friendly for setups handling less than 10,000 alerts. However, as alert volumes increase, users can leverage advanced features such as Elasticsearch for document storage and Redis + ARQ for queue-based alert ingestion. While these advanced configurations are not fully documented here, they are supported and can be discussed further in our Slack community.
 
-## How To Reproduce
-
-To reproduce the stress testing scenarios mentioned above, please refer to the [STRESS.md](https://github.com/keephq/keep/blob/main/STRESS.md) file in Keep's repository. This document provides step-by-step instructions on how to set up, run, and measure the performance of Keep under different load conditions.
-
 ## Performance Testing
 
 ### Factors Affecting Specifications


### PR DESCRIPTION
Fixes #5261.

The stress-testing page contained a 'How To Reproduce' section pointing to `STRESS.md` at the repo root, but no such file exists — the link returns 404. Searching the repo for any `STRESS*` file confirms the doc was never extracted to a separate file (only `docs/deployment/stress-testing.mdx` exists).

Reading the surrounding context, the section was redundant: the rest of `stress-testing.mdx` already contains the reproduction details ("Performance Testing", "Testing Scenarios", setup expectations per volume tier).

### Change

Removes the 4-line dead-link section:

```diff
-## How To Reproduce
-
-To reproduce the stress testing scenarios mentioned above, please refer to the [STRESS.md](https://github.com/keephq/keep/blob/main/STRESS.md) file in Keep's repository. This document provides step-by-step instructions on how to set up, run, and measure the performance of Keep under different load conditions.
-
```

### Why removal vs. relink

There's no equivalent stress-test scripts directory in the repo. If the intention is to expose the actual benchmarking harness (e.g., scripts under `tests/load/` or similar), that's a separate task — beyond what #5261 reports. This PR addresses only the broken-link symptom.
