### PR TITLE
fix(fluxcd): use GA API versions in reconcile kind_map (v2 / v1)

### DIFF
--- a/keep/providers/fluxcd_provider/fluxcd_provider.py
+++ b/keep/providers/fluxcd_provider/fluxcd_provider.py
@@ -511,13 +511,15 @@ class FluxcdProvider(BaseTopologyProvider):
         if self.k8s_client is None:
             raise Exception("Kubernetes client is not available.")
 
-        # Mapping from kind to the API group, version, and plural form
+        # Mapping from kind to the API group, version, and plural form.
+        # Versions match the GA APIs available in FluxCD >= 2.7
+        # (also what the corresponding `__list_*` methods in this provider use).
         kind_map = {
-            "HelmRelease": ("helm.toolkit.fluxcd.io", "v2beta1", "helmreleases"),
-            "Kustomization": ("kustomize.toolkit.fluxcd.io", "v1beta2", "kustomizations"),
-            "GitRepository": ("source.toolkit.fluxcd.io", "v1beta2", "gitrepositories"),
-            "OCIRepository": ("source.toolkit.fluxcd.io", "v1beta2", "ocirepositories"),
-            "HelmRepository": ("source.toolkit.fluxcd.io", "v1beta2", "helmrepositories"),
+            "HelmRelease": ("helm.toolkit.fluxcd.io", "v2", "helmreleases"),
+            "Kustomization": ("kustomize.toolkit.fluxcd.io", "v1", "kustomizations"),
+            "GitRepository": ("source.toolkit.fluxcd.io", "v1", "gitrepositories"),
+            "OCIRepository": ("source.toolkit.fluxcd.io", "v1", "ocirepositories"),
+            "HelmRepository": ("source.toolkit.fluxcd.io", "v1", "helmrepositories"),
         }
 
         kind_lower = kind.lower()


### PR DESCRIPTION
Closes #5394 (partial — see scope note below).

The FluxCD provider's `reconcile_resource` path uses a hard-coded `kind_map` that still points at pre-GA API versions:

```python
"HelmRelease":   ("helm.toolkit.fluxcd.io",   "v2beta1", "helmreleases"),
"Kustomization": ("kustomize.toolkit.fluxcd.io", "v1beta2", "kustomizations"),
"GitRepository": ("source.toolkit.fluxcd.io",   "v1beta2", "gitrepositories"),
"OCIRepository": ("source.toolkit.fluxcd.io",   "v1beta2", "ocirepositories"),
"HelmRepository":("source.toolkit.fluxcd.io",   "v1beta2", "helmrepositories"),
```

These APIs were removed in **FluxCD 2.7**, when the controllers promoted to GA: `helm.toolkit.fluxcd.io/v2`, `kustomize.toolkit.fluxcd.io/v1`, and `source.toolkit.fluxcd.io/v1`. On a 2.7+ cluster, any *Reconcile* button click from Keep currently fails with a 404 from the Kubernetes API.

The corresponding `__list_helm_releases`, `__list_kustomizations`, `__list_git_repositories`, etc. methods in the same file already query the GA versions, so this PR aligns the reconcile path with how the provider already lists these resources.

### Diff

```diff
-    "HelmRelease":   ("helm.toolkit.fluxcd.io",   "v2beta1", "helmreleases"),
-    "Kustomization": ("kustomize.toolkit.fluxcd.io", "v1beta2", "kustomizations"),
-    "GitRepository": ("source.toolkit.fluxcd.io",   "v1beta2", "gitrepositories"),
-    "OCIRepository": ("source.toolkit.fluxcd.io",   "v1beta2", "ocirepositories"),
-    "HelmRepository":("source.toolkit.fluxcd.io",   "v1beta2", "helmrepositories"),
+    "HelmRelease":   ("helm.toolkit.fluxcd.io",   "v2", "helmreleases"),
+    "Kustomization": ("kustomize.toolkit.fluxcd.io", "v1", "kustomizations"),
+    "GitRepository": ("source.toolkit.fluxcd.io",   "v1", "gitrepositories"),
+    "OCIRepository": ("source.toolkit.fluxcd.io",   "v1", "ocirepositories"),
+    "HelmRepository":("source.toolkit.fluxcd.io",   "v1", "helmrepositories"),
```

### Scope note (please read before merging)

This PR fixes one concrete consequence of the FluxCD 2.7 GA migration: the **Reconcile button → 404** failure path. It does *not* fully address #5394, which is about HelmReleases not appearing on the topology map. `__list_helm_releases` already uses `v2` so the listing should succeed; the remaining gap likely lives in the v2 schema-shape parsing inside `__build_topology` (e.g. the `spec.chart` vs `spec.chartRef` change). I don't have a 2.7 cluster handy to verify that side.

If you'd prefer to keep #5394 open for the topology-display work, please change the keyword to "Relates to #5394" (or just reopen the issue after merge) — happy either way.

### Compatibility

For users on FluxCD < 2.7 the old beta APIs were already deprecated and removed in newer cluster versions. If a backwards-compatible reconcile is desired, the same probing pattern used elsewhere in the file (try `v2`, fall back to `v2beta2`/`v2beta1`) could be added — let me know if that's preferred and I'll iterate.
