### PR TITLE
docs: remove orphan deployment/openshift entry from mint.json

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -316,7 +316,6 @@
                 "deployment/kubernetes/openshift"
               ]
             },
-            "deployment/openshift",
             "deployment/ecs"
           ]
         },


### PR DESCRIPTION
Fixes #5217.

The sidebar in `docs/mint.json` has two OpenShift deployment entries:

1. `deployment/kubernetes/openshift` — exists at `docs/deployment/kubernetes/openshift.mdx` (correct)
2. `deployment/openshift` — **no corresponding mdx file**, so Mintlify falls back to the Introduction page

That orphan is exactly the broken redirect reported in #5217: clicking OpenShift in the sidebar lands on Introduction.

### Change

One line removed from `docs/mint.json`:

```diff
                 "deployment/kubernetes/openshift"
               ]
             },
-            "deployment/openshift",
             "deployment/ecs"
```

### Verification

- The legitimate page (`deployment/kubernetes/openshift.mdx`) is still wired up under the **Kubernetes** group; clicking OpenShift now lands on the actual content instead of redirecting.
- `docs/mint.json` parses as valid JSON.
- Same pattern as #5402 (Microsoft Planner orphan), which removed an analogous orphan entry pointing at a non-existent mdx file.
