### PR TITLE
fix(elastic): surface clear error for Elasticsearch 7.x (UnsupportedProductError)

### DIFF
--- a/keep/providers/elastic_provider/elastic_provider.py
+++ b/keep/providers/elastic_provider/elastic_provider.py
@@ -8,6 +8,7 @@ import typing
 
 import pydantic
 from elasticsearch import Elasticsearch
+from elasticsearch.exceptions import UnsupportedProductError
 
 from keep.contextmanager.contextmanager import ContextManager
 from keep.exceptions.provider_connection_failed import ProviderConnectionFailed
@@ -169,6 +170,13 @@ class ElasticProvider(BaseProvider):
         # Check if the connection was successful
         try:
             es.info()
+        except UnsupportedProductError:
+            raise ProviderConnectionFailed(
+                "Failed to connect to Elasticsearch: the server did not identify itself as "
+                "Elasticsearch (UnsupportedProductError). This typically happens when connecting "
+                "to Elasticsearch 7.x with the elasticsearch-py 8.x client. "
+                "Please upgrade to Elasticsearch 8.x or use elasticsearch-py < 8.0."
+            )
         except Exception as e:
             raise ProviderConnectionFailed(
                 f"Failed to connect to Elasticsearch: {str(e)}"


### PR DESCRIPTION
## Summary

Catches `UnsupportedProductError` from elasticsearch-py 8.x separately and surfaces a clear, actionable error message.

Closes #5174

## Problem

Connecting to Elasticsearch 7.x with elasticsearch-py 8.x raises `UnsupportedProductError` because ES 7.x does not send the required `X-Elastic-Product: Elasticsearch` header. Previously this was swallowed by the generic `except Exception` block with a cryptic message.

## Fix

Import and catch `UnsupportedProductError` explicitly, raising `ProviderConnectionFailed` with an actionable message explaining the ES 7.x / elasticsearch-py 8.x incompatibility and recommended remediation steps.