### PR TITLE
fix: indentation error in AnthropicProvider._query()

### DIFF
--- a/keep/providers/anthropic_provider/anthropic_provider.py
+++ b/keep/providers/anthropic_provider/anthropic_provider.py
@@ -90,7 +90,7 @@ class AnthropicProvider(BaseProvider):
             system_prompt (str): System prompt override for this call.
             structured_output_format (dict): The structured output format to use.
         """
-      client = Anthropic(api_key=self.authentication_config.api_key)
+        client = Anthropic(api_key=self.authentication_config.api_key)
 
         messages = [{"role": "user", "content": prompt}]
 


### PR DESCRIPTION
Fix 6-space indent on `client = Anthropic(...)` line that caused an IndentationError at import time, making the provider unusable.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
