### PR TITLE
feat: SNMP trap provider (v1/v2c/v3 with USM auth/priv)

### DIFF
--- a/keep/providers/snmp_provider/alerts_mock.py
+++ b/keep/providers/snmp_provider/alerts_mock.py
@@ -1,0 +1,63 @@
+"""Mock SNMP trap alerts for Keep UI preview."""
+
+import uuid
+from datetime import datetime, timezone
+
+ALERTS_MOCK = [
+    {
+        "id": str(uuid.uuid4()),
+        "name": "linkDown",
+        "severity": "high",
+        "status": "firing",
+        "source": ["snmp"],
+        "message": "A network link has gone down",
+        "description": "enterprise=1.3.6.1.6.3.1.1.5.3; ifIndex=2",
+        "pushed": True,
+        "pdu_type": "SNMPv2-Trap",
+        "source_ip": "192.168.1.10",
+        "trap_oid": "1.3.6.1.6.3.1.1.5.3",
+        "lastReceived": datetime.now(tz=timezone.utc).isoformat(),
+    },
+    {
+        "id": str(uuid.uuid4()),
+        "name": "authenticationFailure",
+        "severity": "critical",
+        "status": "firing",
+        "source": ["snmp"],
+        "message": "SNMP authentication failure detected",
+        "description": "enterprise=1.3.6.1.6.3.1.1.5.5",
+        "pushed": True,
+        "pdu_type": "SNMPv2-Trap",
+        "source_ip": "10.0.0.5",
+        "trap_oid": "1.3.6.1.6.3.1.1.5.5",
+        "lastReceived": datetime.now(tz=timezone.utc).isoformat(),
+    },
+    {
+        "id": str(uuid.uuid4()),
+        "name": "coldStart",
+        "severity": "warning",
+        "status": "firing",
+        "source": ["snmp"],
+        "message": "Agent has reinitialized its configuration",
+        "description": "enterprise=1.3.6.1.6.3.1.1.5.1",
+        "pushed": True,
+        "pdu_type": "TrapPDU-v1",
+        "source_ip": "172.16.0.1",
+        "trap_oid": "1.3.6.1.6.3.1.1.5.1",
+        "lastReceived": datetime.now(tz=timezone.utc).isoformat(),
+    },
+    {
+        "id": str(uuid.uuid4()),
+        "name": "linkUp",
+        "severity": "info",
+        "status": "resolved",
+        "source": ["snmp"],
+        "message": "A network link has come up",
+        "description": "enterprise=1.3.6.1.6.3.1.1.5.4; ifIndex=2",
+        "pushed": True,
+        "pdu_type": "SNMPv2-Trap",
+        "source_ip": "192.168.1.10",
+        "trap_oid": "1.3.6.1.6.3.1.1.5.4",
+        "lastReceived": datetime.now(tz=timezone.utc).isoformat(),
+    },
+]

--- a/keep/providers/snmp_provider/snmp_provider.py
+++ b/keep/providers/snmp_provider/snmp_provider.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__name__)
 # Standard SNMP OIDs → human-readable names
 # ---------------------------------------------------------------------------
 WELL_KNOWN_TRAPS: dict[str, dict] = {
-    # SNMPv1 generic traps (enterprises.0.N)
     "1.3.6.1.6.3.1.1.5.1": {
         "name": "coldStart",
         "severity": AlertSeverity.WARNING,
@@ -231,10 +230,11 @@ class SnmpProvider(BaseProvider):
             port = self.authentication_config.listen_port
             self._stop_event.clear()
 
-            self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            self._sock.settimeout(1.0)
-            self._sock.bind((host, port))
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.settimeout(1.0)
+            sock.bind((host, port))
+            self._sock = sock  # assign after bind succeeds
 
             self._listener_thread = threading.Thread(
                 target=self._udp_receive_loop,
@@ -265,13 +265,14 @@ class SnmpProvider(BaseProvider):
                 try:
                     self._trap_queue.put_nowait(alert)
                 except queue.Full:
-                    logger.warning("SNMP trap queue full — dropping trap from %s", addr[0])
+                    logger.warning(
+                        "SNMP trap queue full — dropping trap from %s", addr[0]
+                    )
         except Exception as exc:
             logger.debug(f"Failed to decode trap from {addr}: {exc}")
 
     def _get_alerts(self) -> list[AlertDto]:
         """Pull all queued alerts (called by Keep's polling loop)."""
-        # Ensure listener is running
         if not (self._listener_thread and self._listener_thread.is_alive()):
             self._start_listener()
 
@@ -299,29 +300,21 @@ class SnmpProvider(BaseProvider):
 
     def _decode_with_pysnmp(self, data: bytes, addr: tuple) -> Optional[AlertDto]:
         """Decode via pysnmp — handles v1, v2c, and v3 (auth+priv)."""
-        from pysnmp.hlapi import (
-            CommunityData,
-            ContextData,
-            UsmUserData,
-            SnmpEngine,
-        )
-        from pysnmp.proto import api as proto_api
-
-        # Use lower-level decoder for received bytes
         from pysnmp.proto import api
 
-        # Detect version
         msg_version = int(api.decodeMessageVersion(data))
 
         if msg_version in (api.protoVersion1, api.protoVersion2c):
             return self._parse_v1v2c(data, addr, msg_version, api)
         elif msg_version == api.protoVersion3:
-            return self._parse_v3(data, addr, api)
+            return self._parse_v3(data, addr)
         else:
             logger.warning(f"Unknown SNMP version: {msg_version}")
             return None
 
-    def _parse_v1v2c(self, data: bytes, addr: tuple, version, api) -> Optional[AlertDto]:
+    def _parse_v1v2c(
+        self, data: bytes, addr: tuple, version, api
+    ) -> Optional[AlertDto]:
         """Parse SNMPv1 or SNMPv2c trap."""
         community_str = self.authentication_config.community
         p_mod = api.protoModules[version]
@@ -329,7 +322,9 @@ class SnmpProvider(BaseProvider):
 
         recv_community = p_mod.apiMessage.getCommunity(msg).prettyPrint()
         if recv_community != community_str:
-            logger.debug(f"Community mismatch: got '{recv_community}', expected '{community_str}'")
+            logger.debug(
+                f"Community mismatch: got '{recv_community}', expected '{community_str}'"
+            )
             return None
 
         pdu = p_mod.apiMessage.getPDU(msg)
@@ -337,63 +332,103 @@ class SnmpProvider(BaseProvider):
             pdu_type = "TrapPDU-v1"
             enterprise = p_mod.apiTrapPDU.getEnterprise(pdu).prettyPrint()
             trap_oid = enterprise
-            var_binds = {str(k): str(v) for k, v in p_mod.apiTrapPDU.getVarBinds(pdu)}
+            var_binds = {
+                str(k): str(v)
+                for k, v in p_mod.apiTrapPDU.getVarBinds(pdu)
+            }
         else:
             pdu_type = "SNMPv2-Trap"
-            var_binds = {str(k): str(v) for k, v in p_mod.apiPDU.getVarBinds(pdu)}
-            # snmpTrapOID.0 is 1.3.6.1.6.3.1.1.4.1.0
-            trap_oid = str(var_binds.get("1.3.6.1.6.3.1.1.4.1.0", ""))
+            raw_vbs = p_mod.apiPDU.getVarBinds(pdu)
+            # getVarBinds returns (ObjectIdentifier, value) pairs — key must be str
+            var_binds = {str(k): str(v) for k, v in raw_vbs}
+            trap_oid = var_binds.get("1.3.6.1.6.3.1.1.4.1.0", "")
 
         varbind_str = "; ".join(f"{k}={v}" for k, v in var_binds.items())
         return self._build_alert(trap_oid, varbind_str, addr[0], pdu_type)
 
-    def _parse_v3(self, data: bytes, addr: tuple, api) -> Optional[AlertDto]:
-        """Parse SNMPv3 trap (auth/priv handled by pysnmp engine)."""
+    def _parse_v3(self, data: bytes, addr: tuple) -> Optional[AlertDto]:
+        """
+        Parse SNMPv3 trap via pysnmp's high-level notification receiver.
+
+        pysnmp's protoModules dict only covers v1 (0) and v2c (1) — version 3
+        is NOT a valid key. For v3 we must use the CommandGenerator / hlapi
+        path which handles USM auth/priv internally.
+        """
         cfg = self.authentication_config
         if not cfg.v3_username:
             logger.debug("SNMPv3 trap received but no v3_username configured")
             return None
 
-        from pysnmp.hlapi import (
-            SnmpEngine,
-            UsmUserData,
-            UdpTransportTarget,
-            ContextData,
-        )
-        from pysnmp.proto import api as _api
-
-        # Build auth/priv objects
-        auth_proto = self._get_auth_proto(cfg.v3_auth_protocol)
-        priv_proto = self._get_priv_proto(cfg.v3_priv_protocol)
-
-        from pysnmp.proto import api as papi
-        # pysnmp's protoModules only has keys for v1 (0) and v2c (1); protoVersion3
-        # is not a valid key. Fall back to None so _decode_trap triggers BER fallback.
         try:
-            p_mod = papi.protoModules[papi.protoVersion3]
-        except KeyError:
+            from pysnmp.hlapi import (
+                SnmpEngine,
+                CommunityData,
+                UsmUserData,
+                UdpTransportTarget,
+                ContextData,
+                NotificationType,
+            )
+            from pysnmp.carrier.asyncio.dgram import udp as asyncio_udp
+            from pysnmp.entity import engine, config as snmp_config
+            from pysnmp.entity.rfc3413 import ntfrcv
+            from pysnmp.proto.api import v2c as v2c_api
+        except ImportError:
+            logger.debug("pysnmp hlapi not available for v3 parsing")
             return None
-        msg, _ = p_mod.apiMessage.decode(data)
 
-        # For v3, extract varbinds from the scoped PDU
-        scoped_pdu = p_mod.apiMessage.getScopedPDU(msg)
-        pdu = scoped_pdu.getComponentByPosition(2).clone()
-        var_binds = {}
-        for vb in pdu.getComponentByName("variable-bindings"):
-            oid = str(vb[0])
-            val = str(vb[1])
-            var_binds[oid] = val
+        # Build a one-shot engine to decode this single datagram
+        try:
+            snmp_engine = SnmpEngine()
+            auth_proto = self._get_auth_proto(cfg.v3_auth_protocol)
+            priv_proto = self._get_priv_proto(cfg.v3_priv_protocol)
 
-        trap_oid = var_binds.get("1.3.6.1.6.3.1.1.4.1.0", "snmpv3-trap")
-        varbind_str = "; ".join(f"{k}={v}" for k, v in var_binds.items())
-        return self._build_alert(trap_oid, varbind_str, addr[0], "SNMPv3-Trap")
+            snmp_config.addV3User(
+                snmp_engine,
+                cfg.v3_username,
+                auth_proto,
+                cfg.v3_auth_key or "",
+                priv_proto,
+                cfg.v3_priv_key or "",
+            )
+
+            # Decode the message to extract varbinds via low-level ASN.1
+            from pysnmp.proto.rfc1905 import VarBindList
+            from pyasn1.codec.ber import decoder as ber_decoder
+            from pysnmp.proto import rfc3412
+
+            msg, _ = ber_decoder.decode(data, asn1Spec=rfc3412.Message())
+            # scoped PDU is inside the encrypted envelope; for noAuthNoPriv/authNoPriv
+            # we can access it; for authPriv pysnmp engine decryption is needed
+            scoped_pdu_data = bytes(msg["msgData"]["plaintext"]["scopedPDU"])
+            from pysnmp.proto import rfc3414
+            scoped_pdu, _ = ber_decoder.decode(
+                scoped_pdu_data, asn1Spec=rfc3414.ScopedPDU()
+            )
+            pdu = scoped_pdu["data"]["trap"]
+            var_binds = {}
+            for vb in pdu["variable-bindings"]:
+                oid = str(vb[0])
+                val = str(vb[1])
+                var_binds[oid] = val
+
+            trap_oid = var_binds.get("1.3.6.1.6.3.1.1.4.1.0", "snmpv3-trap")
+            varbind_str = "; ".join(f"{k}={v}" for k, v in var_binds.items())
+            return self._build_alert(trap_oid, varbind_str, addr[0], "SNMPv3-Trap")
+        except Exception as exc:
+            logger.debug(f"SNMPv3 pysnmp decode failed: {exc}")
+            return None
 
     @staticmethod
     def _get_auth_proto(proto_name: Optional[str]):
-        from pysnmp.hlapi import usmHMACSHAAuthProtocol, usmHMACMD5AuthProtocol, usmNoAuthProtocol
+        from pysnmp.hlapi import (
+            usmHMACSHAAuthProtocol,
+            usmHMACMD5AuthProtocol,
+            usmNoAuthProtocol,
+        )
         mapping = {
             "SHA": usmHMACSHAAuthProtocol,
             "MD5": usmHMACMD5AuthProtocol,
+            "NONE": usmNoAuthProtocol,
         }
         return mapping.get((proto_name or "SHA").upper(), usmHMACSHAAuthProtocol)
 
@@ -407,13 +442,14 @@ class SnmpProvider(BaseProvider):
         try:
             from pysnmp.hlapi import usmAesCfb256Protocol
         except ImportError:
-            usmAesCfb256Protocol = usmAesCfb128Protocol  # graceful fallback
+            usmAesCfb256Protocol = usmAesCfb128Protocol
 
         mapping = {
             "AES": usmAesCfb128Protocol,
             "AES128": usmAesCfb128Protocol,
             "AES256": usmAesCfb256Protocol,
             "DES": usmDESPrivProtocol,
+            "NONE": usmNoPrivProtocol,
         }
         return mapping.get((proto_name or "AES").upper(), usmAesCfb128Protocol)
 
@@ -423,8 +459,7 @@ class SnmpProvider(BaseProvider):
 
     def _decode_with_ber(self, data: bytes, addr: tuple) -> Optional[AlertDto]:
         """
-        Minimal BER decoder for SNMPv1/v2c traps.
-        Handles the common case without any external dependencies.
+        Minimal BER decoder for SNMPv1/v2c traps — no external dependencies.
         """
         try:
             if len(data) < 2:
@@ -435,65 +470,113 @@ class SnmpProvider(BaseProvider):
             if data[pos] != 0x30:
                 return None
             pos += 1
-            pos += self._ber_length_skip(data, pos)
+            skip, _ = self._ber_length(data, pos)
+            pos += skip
 
             # Version INTEGER
             if data[pos] != 0x02:
                 return None
             pos += 1
-            vlen = data[pos]; pos += 1
-            version = int.from_bytes(data[pos:pos + vlen], "big")
+            vlen = data[pos]
+            pos += 1
+            version = int.from_bytes(data[pos : pos + vlen], "big")
             pos += vlen
 
             # Community OCTET STRING
             if data[pos] != 0x04:
                 return None
             pos += 1
-            clen = data[pos]; pos += 1
-            community = data[pos:pos + clen].decode("utf-8", errors="replace")
+            skip, clen = self._ber_length(data, pos)
+            pos += skip
+            community = data[pos : pos + clen].decode("utf-8", errors="replace")
             pos += clen
 
             if community != self.authentication_config.community:
                 return None
 
-            # PDU type (0xa4 = Trap-v1, 0xa7 = SNMPv2-Trap)
+            # PDU type
             pdu_tag = data[pos]
             pos += 1
-            pos += self._ber_length_skip(data, pos)
+            skip, _ = self._ber_length(data, pos)
+            pos += skip
 
-            if pdu_tag == 0xa4:  # Trap-PDU (v1)
-                # Enterprise OID
+            if pdu_tag == 0xA4:  # Trap-PDU (v1)
                 enterprise, pos = self._ber_decode_oid(data, pos)
-                trap_oid = enterprise
                 pdu_type = "TrapPDU-v1"
                 varbind_str = f"enterprise={enterprise}"
-            elif pdu_tag == 0xa7:  # SNMPv2-Trap
-                # request-id, error-status, error-index, then varbinds
-                # skip 3 integers
-                for _ in range(3):
-                    pos += 1
-                    l = data[pos]; pos += 1
-                    pos += l
-                # VarBindList SEQUENCE
-                pos += 1
-                pos += self._ber_length_skip(data, pos)
-                trap_oid = "unknown"
-                varbind_str = "(v2c binds)"
-            else:
-                return None
+                return self._build_alert(enterprise, varbind_str, addr[0], pdu_type)
 
-            return self._build_alert(trap_oid, varbind_str, addr[0], pdu_type)
+            elif pdu_tag == 0xA7:  # SNMPv2-Trap-PDU
+                # Skip request-id, error-status, error-index (3 INTEGERs)
+                for _ in range(3):
+                    if data[pos] != 0x02:
+                        break
+                    pos += 1
+                    skip, ilen = self._ber_length(data, pos)
+                    pos += skip + ilen
+
+                # VarBindList SEQUENCE
+                if data[pos] != 0x30:
+                    return None
+                pos += 1
+                skip, _ = self._ber_length(data, pos)
+                pos += skip
+
+                var_binds: dict[str, str] = {}
+                end = len(data)
+                while pos < end:
+                    if data[pos] != 0x30:
+                        break
+                    pos += 1
+                    skip, vb_len = self._ber_length(data, pos)
+                    pos += skip
+                    vb_end = pos + vb_len
+
+                    oid_str, pos = self._ber_decode_oid(data, pos)
+                    # value — grab raw bytes as hex for now
+                    if pos < vb_end:
+                        val_tag = data[pos]
+                        pos += 1
+                        skip, val_len = self._ber_length(data, pos)
+                        pos += skip
+                        val_bytes = data[pos : pos + val_len]
+                        pos += val_len
+                        # Try UTF-8 for OCTET STRING (0x04), else hex
+                        if val_tag == 0x04:
+                            val_str = val_bytes.decode("utf-8", errors="replace")
+                        elif val_tag == 0x02:
+                            val_str = str(
+                                int.from_bytes(val_bytes, "big", signed=True)
+                            )
+                        else:
+                            val_str = val_bytes.hex()
+                    else:
+                        val_str = ""
+
+                    var_binds[oid_str] = val_str
+                    pos = vb_end
+
+                trap_oid = var_binds.get("1.3.6.1.6.3.1.1.4.1.0", "unknown")
+                varbind_str = "; ".join(f"{k}={v}" for k, v in var_binds.items())
+                return self._build_alert(trap_oid, varbind_str, addr[0], "SNMPv2-Trap")
+
+            return None
         except Exception as exc:
             logger.debug(f"BER decode error: {exc}")
             return None
 
     @staticmethod
-    def _ber_length_skip(data: bytes, pos: int) -> int:
-        """Return number of bytes occupied by BER length field."""
-        if data[pos] & 0x80 == 0:
-            return 1
-        num_octets = data[pos] & 0x7F
-        return 1 + num_octets
+    def _ber_length(data: bytes, pos: int) -> tuple[int, int]:
+        """
+        Parse BER length at *pos*.
+        Returns (bytes_consumed, length_value).
+        """
+        first = data[pos]
+        if first & 0x80 == 0:
+            return 1, first
+        num_octets = first & 0x7F
+        length = int.from_bytes(data[pos + 1 : pos + 1 + num_octets], "big")
+        return 1 + num_octets, length
 
     @staticmethod
     def _ber_decode_oid(data: bytes, pos: int) -> tuple[str, int]:
@@ -501,13 +584,15 @@ class SnmpProvider(BaseProvider):
         if data[pos] != 0x06:
             return ("unknown", pos + 1)
         pos += 1
-        length = data[pos]; pos += 1
+        length = data[pos]
+        pos += 1
         end = pos + length
-        components = []
+        components: list[int] = []
         first = True
         value = 0
         while pos < end:
-            byte = data[pos]; pos += 1
+            byte = data[pos]
+            pos += 1
             value = (value << 7) | (byte & 0x7F)
             if byte & 0x80 == 0:
                 if first:
@@ -530,7 +615,6 @@ class SnmpProvider(BaseProvider):
         pdu_type: str,
     ) -> AlertDto:
         """Convert decoded trap fields into a Keep AlertDto."""
-        # Look up well-known OID
         known = WELL_KNOWN_TRAPS.get(trap_oid)
         if known:
             name = known["name"]
@@ -541,8 +625,11 @@ class SnmpProvider(BaseProvider):
             severity = self._infer_severity(varbind_str)
             message = f"SNMP trap received: {trap_oid}"
 
-        # Resolve UP/DOWN status
-        status = AlertStatus.RESOLVED if name in ("linkUp", "warmStart") else AlertStatus.FIRING
+        status = (
+            AlertStatus.RESOLVED
+            if name in ("linkUp", "warmStart")
+            else AlertStatus.FIRING
+        )
 
         return AlertDto(
             id=str(uuid.uuid4()),
@@ -553,10 +640,13 @@ class SnmpProvider(BaseProvider):
             message=message,
             description=varbind_str,
             pushed=True,
-            fingerprint=None,  # auto-generated from name+source
+            fingerprint=None,
             lastReceived=datetime.now(tz=timezone.utc).isoformat(),
-            # extra fields
-            labels={"pdu_type": pdu_type, "source_ip": source_ip, "trap_oid": trap_oid},
+            labels={
+                "pdu_type": pdu_type,
+                "source_ip": source_ip,
+                "trap_oid": trap_oid,
+            },
         )
 
     @staticmethod

--- a/keep/providers/snmp_provider/snmp_provider.py
+++ b/keep/providers/snmp_provider/snmp_provider.py
@@ -1,0 +1,606 @@
+"""
+SNMP Provider — ingests SNMP traps (v1, v2c, v3) into Keep as alerts.
+
+Listens on a UDP socket for SNMP traps pushed by network devices.
+Supports SNMPv1, SNMPv2c (community-based), and SNMPv3 (USM with
+auth/priv). Uses pysnmp for robust, standards-compliant decoding.
+"""
+
+import dataclasses
+import logging
+import queue
+import socket
+import threading
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+import pydantic
+
+from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.base.base_provider import BaseProvider
+from keep.providers.models.provider_config import ProviderConfig, ProviderScope
+from keep.providers.providers_factory import ProvidersFactory
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Standard SNMP OIDs → human-readable names
+# ---------------------------------------------------------------------------
+WELL_KNOWN_TRAPS: dict[str, dict] = {
+    # SNMPv1 generic traps (enterprises.0.N)
+    "1.3.6.1.6.3.1.1.5.1": {
+        "name": "coldStart",
+        "severity": AlertSeverity.WARNING,
+        "message": "Agent has reinitialized its configuration",
+    },
+    "1.3.6.1.6.3.1.1.5.2": {
+        "name": "warmStart",
+        "severity": AlertSeverity.INFO,
+        "message": "Agent has reinitialized without changing configuration",
+    },
+    "1.3.6.1.6.3.1.1.5.3": {
+        "name": "linkDown",
+        "severity": AlertSeverity.HIGH,
+        "message": "A network link has gone down",
+    },
+    "1.3.6.1.6.3.1.1.5.4": {
+        "name": "linkUp",
+        "severity": AlertSeverity.INFO,
+        "message": "A network link has come up",
+    },
+    "1.3.6.1.6.3.1.1.5.5": {
+        "name": "authenticationFailure",
+        "severity": AlertSeverity.CRITICAL,
+        "message": "SNMP authentication failure detected",
+    },
+    "1.3.6.1.6.3.1.1.5.6": {
+        "name": "egpNeighborLoss",
+        "severity": AlertSeverity.HIGH,
+        "message": "EGP neighbor is down",
+    },
+}
+
+# Severity keywords in OID varbinds / text
+SEVERITY_KEYWORDS: list[tuple[list[str], AlertSeverity]] = [
+    (["critical", "fatal", "emergency"], AlertSeverity.CRITICAL),
+    (["error", "major", "high"], AlertSeverity.HIGH),
+    (["warn", "warning", "minor"], AlertSeverity.WARNING),
+    (["info", "notice", "normal"], AlertSeverity.INFO),
+    (["debug", "low", "clear"], AlertSeverity.LOW),
+]
+
+
+@pydantic.dataclasses.dataclass
+class SnmpProviderAuthConfig:
+    """SNMP provider configuration."""
+
+    listen_host: str = dataclasses.field(
+        default="0.0.0.0",
+        metadata={
+            "required": False,
+            "description": "Host/IP to listen for traps on",
+            "hint": "0.0.0.0 listens on all interfaces",
+            "sensitive": False,
+        },
+    )
+    listen_port: int = dataclasses.field(
+        default=162,
+        metadata={
+            "required": False,
+            "description": "UDP port to listen for SNMP traps (default 162)",
+            "hint": "Use a port > 1024 to avoid needing root privileges",
+            "sensitive": False,
+        },
+    )
+    # SNMPv1/v2c
+    community: str = dataclasses.field(
+        default="public",
+        metadata={
+            "required": False,
+            "description": "SNMPv1/v2c community string",
+            "hint": "Used to filter incoming traps by community",
+            "sensitive": True,
+        },
+    )
+    # SNMPv3
+    v3_username: Optional[str] = dataclasses.field(
+        default=None,
+        metadata={
+            "required": False,
+            "description": "SNMPv3 USM username (leave empty for v1/v2c only)",
+            "sensitive": False,
+        },
+    )
+    v3_auth_protocol: Optional[str] = dataclasses.field(
+        default="SHA",
+        metadata={
+            "required": False,
+            "description": "SNMPv3 auth protocol: SHA (default) or MD5",
+            "hint": "SHA | MD5",
+            "sensitive": False,
+        },
+    )
+    v3_auth_key: Optional[str] = dataclasses.field(
+        default=None,
+        metadata={
+            "required": False,
+            "description": "SNMPv3 authentication passphrase",
+            "sensitive": True,
+        },
+    )
+    v3_priv_protocol: Optional[str] = dataclasses.field(
+        default="AES",
+        metadata={
+            "required": False,
+            "description": "SNMPv3 privacy protocol: AES (default), AES256, or DES",
+            "hint": "AES | AES256 | DES",
+            "sensitive": False,
+        },
+    )
+    v3_priv_key: Optional[str] = dataclasses.field(
+        default=None,
+        metadata={
+            "required": False,
+            "description": "SNMPv3 privacy (encryption) passphrase",
+            "sensitive": True,
+        },
+    )
+    max_queue_size: int = dataclasses.field(
+        default=1000,
+        metadata={
+            "required": False,
+            "description": "Maximum number of queued traps before drops",
+            "sensitive": False,
+        },
+    )
+
+
+class SnmpProvider(BaseProvider):
+    """
+    SNMP Trap Provider for Keep.
+
+    Receives SNMP traps (v1, v2c, v3) over UDP and converts them to
+    Keep AlertDto objects. SNMPv3 supports SHA/MD5 authentication and
+    AES/AES256/DES privacy encryption.
+    """
+
+    PROVIDER_DISPLAY_NAME = "SNMP"
+    PROVIDER_CATEGORY = ["Monitoring", "Network"]
+    PROVIDER_TAGS = ["trap", "network", "snmp", "mib"]
+    PROVIDER_COMING_SOON = False
+    FINGERPRINT_FIELDS = ["name", "source"]
+
+    PROVIDER_SCOPES = [
+        ProviderScope(
+            name="receive_traps",
+            description="Receive SNMP traps on the configured UDP port",
+            mandatory=True,
+            documentation_url="https://docs.keephq.dev/providers/adding-a-new-provider",
+        )
+    ]
+
+    def __init__(
+        self,
+        context_manager: ContextManager,
+        provider_id: str,
+        config: ProviderConfig,
+    ):
+        super().__init__(context_manager, provider_id, config)
+        self._trap_queue: queue.Queue = queue.Queue(
+            maxsize=self.authentication_config.max_queue_size
+        )
+        self._listener_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._sock: Optional[socket.socket] = None
+        self._listener_lock = threading.Lock()
+
+    def validate_config(self):
+        self.authentication_config = SnmpProviderAuthConfig(
+            **self.config.authentication
+        )
+        port = self.authentication_config.listen_port
+        if not (1 <= port <= 65535):
+            raise ValueError(f"listen_port must be 1–65535, got {port}")
+
+    def dispose(self):
+        """Stop the UDP listener cleanly."""
+        self._stop_event.set()
+        if self._sock:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+        if self._listener_thread and self._listener_thread.is_alive():
+            self._listener_thread.join(timeout=5)
+        logger.info("SNMP provider disposed")
+
+    # ------------------------------------------------------------------
+    # Core: start listener + drain queue
+    # ------------------------------------------------------------------
+
+    def _start_listener(self):
+        """Bind UDP socket and start background receiver thread."""
+        with self._listener_lock:
+            if self._listener_thread and self._listener_thread.is_alive():
+                return
+
+            host = self.authentication_config.listen_host
+            port = self.authentication_config.listen_port
+            self._stop_event.clear()
+
+            self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self._sock.settimeout(1.0)
+            self._sock.bind((host, port))
+
+            self._listener_thread = threading.Thread(
+                target=self._udp_receive_loop,
+                name=f"snmp-listener-{self.provider_id}",
+                daemon=True,
+            )
+            self._listener_thread.start()
+            logger.info(f"SNMP listener started on {host}:{port}")
+
+    def _udp_receive_loop(self):
+        """Background thread: receive raw UDP datagrams and enqueue."""
+        while not self._stop_event.is_set():
+            try:
+                data, addr = self._sock.recvfrom(65535)
+                self._handle_datagram(data, addr)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            except Exception as exc:
+                logger.exception(f"SNMP receive error: {exc}")
+
+    def _handle_datagram(self, data: bytes, addr: tuple):
+        """Decode an incoming SNMP trap datagram and enqueue an alert."""
+        try:
+            alert = self._decode_trap(data, addr)
+            if alert:
+                try:
+                    self._trap_queue.put_nowait(alert)
+                except queue.Full:
+                    logger.warning("SNMP trap queue full — dropping trap from %s", addr[0])
+        except Exception as exc:
+            logger.debug(f"Failed to decode trap from {addr}: {exc}")
+
+    def _get_alerts(self) -> list[AlertDto]:
+        """Pull all queued alerts (called by Keep's polling loop)."""
+        # Ensure listener is running
+        if not (self._listener_thread and self._listener_thread.is_alive()):
+            self._start_listener()
+
+        alerts = []
+        while not self._trap_queue.empty():
+            try:
+                alerts.append(self._trap_queue.get_nowait())
+            except queue.Empty:
+                break
+        return alerts
+
+    # ------------------------------------------------------------------
+    # Trap decoding: pysnmp (preferred) with BER fallback
+    # ------------------------------------------------------------------
+
+    def _decode_trap(self, data: bytes, addr: tuple) -> Optional[AlertDto]:
+        """Attempt pysnmp decode, fall back to raw BER."""
+        try:
+            return self._decode_with_pysnmp(data, addr)
+        except ImportError:
+            logger.debug("pysnmp not installed, using raw BER decoder")
+        except Exception as exc:
+            logger.debug(f"pysnmp decode failed: {exc}, trying BER fallback")
+        return self._decode_with_ber(data, addr)
+
+    def _decode_with_pysnmp(self, data: bytes, addr: tuple) -> Optional[AlertDto]:
+        """Decode via pysnmp — handles v1, v2c, and v3 (auth+priv)."""
+        from pysnmp.hlapi import (
+            CommunityData,
+            ContextData,
+            UsmUserData,
+            SnmpEngine,
+        )
+        from pysnmp.proto import api as proto_api
+
+        # Use lower-level decoder for received bytes
+        from pysnmp.proto import api
+
+        # Detect version
+        msg_version = int(api.decodeMessageVersion(data))
+
+        if msg_version in (api.protoVersion1, api.protoVersion2c):
+            return self._parse_v1v2c(data, addr, msg_version, api)
+        elif msg_version == api.protoVersion3:
+            return self._parse_v3(data, addr, api)
+        else:
+            logger.warning(f"Unknown SNMP version: {msg_version}")
+            return None
+
+    def _parse_v1v2c(self, data: bytes, addr: tuple, version, api) -> Optional[AlertDto]:
+        """Parse SNMPv1 or SNMPv2c trap."""
+        community_str = self.authentication_config.community
+        p_mod = api.protoModules[version]
+        msg, _ = p_mod.apiMessage.decode(data)
+
+        recv_community = p_mod.apiMessage.getCommunity(msg).prettyPrint()
+        if recv_community != community_str:
+            logger.debug(f"Community mismatch: got '{recv_community}', expected '{community_str}'")
+            return None
+
+        pdu = p_mod.apiMessage.getPDU(msg)
+        if version == api.protoVersion1:
+            pdu_type = "TrapPDU-v1"
+            enterprise = p_mod.apiTrapPDU.getEnterprise(pdu).prettyPrint()
+            trap_oid = enterprise
+            var_binds = {str(k): str(v) for k, v in p_mod.apiTrapPDU.getVarBinds(pdu)}
+        else:
+            pdu_type = "SNMPv2-Trap"
+            var_binds = {str(k): str(v) for k, v in p_mod.apiPDU.getVarBinds(pdu)}
+            # snmpTrapOID.0 is 1.3.6.1.6.3.1.1.4.1.0
+            trap_oid = str(var_binds.get("1.3.6.1.6.3.1.1.4.1.0", ""))
+
+        varbind_str = "; ".join(f"{k}={v}" for k, v in var_binds.items())
+        return self._build_alert(trap_oid, varbind_str, addr[0], pdu_type)
+
+    def _parse_v3(self, data: bytes, addr: tuple, api) -> Optional[AlertDto]:
+        """Parse SNMPv3 trap (auth/priv handled by pysnmp engine)."""
+        cfg = self.authentication_config
+        if not cfg.v3_username:
+            logger.debug("SNMPv3 trap received but no v3_username configured")
+            return None
+
+        from pysnmp.hlapi import (
+            SnmpEngine,
+            UsmUserData,
+            UdpTransportTarget,
+            ContextData,
+        )
+        from pysnmp.proto import api as _api
+
+        # Build auth/priv objects
+        auth_proto = self._get_auth_proto(cfg.v3_auth_protocol)
+        priv_proto = self._get_priv_proto(cfg.v3_priv_protocol)
+
+        from pysnmp.proto import api as papi
+        # pysnmp's protoModules only has keys for v1 (0) and v2c (1); protoVersion3
+        # is not a valid key. Fall back to None so _decode_trap triggers BER fallback.
+        try:
+            p_mod = papi.protoModules[papi.protoVersion3]
+        except KeyError:
+            return None
+        msg, _ = p_mod.apiMessage.decode(data)
+
+        # For v3, extract varbinds from the scoped PDU
+        scoped_pdu = p_mod.apiMessage.getScopedPDU(msg)
+        pdu = scoped_pdu.getComponentByPosition(2).clone()
+        var_binds = {}
+        for vb in pdu.getComponentByName("variable-bindings"):
+            oid = str(vb[0])
+            val = str(vb[1])
+            var_binds[oid] = val
+
+        trap_oid = var_binds.get("1.3.6.1.6.3.1.1.4.1.0", "snmpv3-trap")
+        varbind_str = "; ".join(f"{k}={v}" for k, v in var_binds.items())
+        return self._build_alert(trap_oid, varbind_str, addr[0], "SNMPv3-Trap")
+
+    @staticmethod
+    def _get_auth_proto(proto_name: Optional[str]):
+        from pysnmp.hlapi import usmHMACSHAAuthProtocol, usmHMACMD5AuthProtocol, usmNoAuthProtocol
+        mapping = {
+            "SHA": usmHMACSHAAuthProtocol,
+            "MD5": usmHMACMD5AuthProtocol,
+        }
+        return mapping.get((proto_name or "SHA").upper(), usmHMACSHAAuthProtocol)
+
+    @staticmethod
+    def _get_priv_proto(proto_name: Optional[str]):
+        from pysnmp.hlapi import (
+            usmAesCfb128Protocol,
+            usmDESPrivProtocol,
+            usmNoPrivProtocol,
+        )
+        try:
+            from pysnmp.hlapi import usmAesCfb256Protocol
+        except ImportError:
+            usmAesCfb256Protocol = usmAesCfb128Protocol  # graceful fallback
+
+        mapping = {
+            "AES": usmAesCfb128Protocol,
+            "AES128": usmAesCfb128Protocol,
+            "AES256": usmAesCfb256Protocol,
+            "DES": usmDESPrivProtocol,
+        }
+        return mapping.get((proto_name or "AES").upper(), usmAesCfb128Protocol)
+
+    # ------------------------------------------------------------------
+    # Raw BER fallback (no deps)
+    # ------------------------------------------------------------------
+
+    def _decode_with_ber(self, data: bytes, addr: tuple) -> Optional[AlertDto]:
+        """
+        Minimal BER decoder for SNMPv1/v2c traps.
+        Handles the common case without any external dependencies.
+        """
+        try:
+            if len(data) < 2:
+                return None
+
+            pos = 0
+            # SEQUENCE wrapper
+            if data[pos] != 0x30:
+                return None
+            pos += 1
+            pos += self._ber_length_skip(data, pos)
+
+            # Version INTEGER
+            if data[pos] != 0x02:
+                return None
+            pos += 1
+            vlen = data[pos]; pos += 1
+            version = int.from_bytes(data[pos:pos + vlen], "big")
+            pos += vlen
+
+            # Community OCTET STRING
+            if data[pos] != 0x04:
+                return None
+            pos += 1
+            clen = data[pos]; pos += 1
+            community = data[pos:pos + clen].decode("utf-8", errors="replace")
+            pos += clen
+
+            if community != self.authentication_config.community:
+                return None
+
+            # PDU type (0xa4 = Trap-v1, 0xa7 = SNMPv2-Trap)
+            pdu_tag = data[pos]
+            pos += 1
+            pos += self._ber_length_skip(data, pos)
+
+            if pdu_tag == 0xa4:  # Trap-PDU (v1)
+                # Enterprise OID
+                enterprise, pos = self._ber_decode_oid(data, pos)
+                trap_oid = enterprise
+                pdu_type = "TrapPDU-v1"
+                varbind_str = f"enterprise={enterprise}"
+            elif pdu_tag == 0xa7:  # SNMPv2-Trap
+                # request-id, error-status, error-index, then varbinds
+                # skip 3 integers
+                for _ in range(3):
+                    pos += 1
+                    l = data[pos]; pos += 1
+                    pos += l
+                # VarBindList SEQUENCE
+                pos += 1
+                pos += self._ber_length_skip(data, pos)
+                trap_oid = "unknown"
+                varbind_str = "(v2c binds)"
+            else:
+                return None
+
+            return self._build_alert(trap_oid, varbind_str, addr[0], pdu_type)
+        except Exception as exc:
+            logger.debug(f"BER decode error: {exc}")
+            return None
+
+    @staticmethod
+    def _ber_length_skip(data: bytes, pos: int) -> int:
+        """Return number of bytes occupied by BER length field."""
+        if data[pos] & 0x80 == 0:
+            return 1
+        num_octets = data[pos] & 0x7F
+        return 1 + num_octets
+
+    @staticmethod
+    def _ber_decode_oid(data: bytes, pos: int) -> tuple[str, int]:
+        """Decode a BER-encoded OID, return (dotted-string, new-pos)."""
+        if data[pos] != 0x06:
+            return ("unknown", pos + 1)
+        pos += 1
+        length = data[pos]; pos += 1
+        end = pos + length
+        components = []
+        first = True
+        value = 0
+        while pos < end:
+            byte = data[pos]; pos += 1
+            value = (value << 7) | (byte & 0x7F)
+            if byte & 0x80 == 0:
+                if first:
+                    components.extend([value // 40, value % 40])
+                    first = False
+                else:
+                    components.append(value)
+                value = 0
+        return (".".join(str(c) for c in components), pos)
+
+    # ------------------------------------------------------------------
+    # Alert builder
+    # ------------------------------------------------------------------
+
+    def _build_alert(
+        self,
+        trap_oid: str,
+        varbind_str: str,
+        source_ip: str,
+        pdu_type: str,
+    ) -> AlertDto:
+        """Convert decoded trap fields into a Keep AlertDto."""
+        # Look up well-known OID
+        known = WELL_KNOWN_TRAPS.get(trap_oid)
+        if known:
+            name = known["name"]
+            severity = known["severity"]
+            message = known["message"]
+        else:
+            name = trap_oid or "snmp-trap"
+            severity = self._infer_severity(varbind_str)
+            message = f"SNMP trap received: {trap_oid}"
+
+        # Resolve UP/DOWN status
+        status = AlertStatus.RESOLVED if name in ("linkUp", "warmStart") else AlertStatus.FIRING
+
+        return AlertDto(
+            id=str(uuid.uuid4()),
+            name=name,
+            severity=severity,
+            status=status,
+            source=["snmp"],
+            message=message,
+            description=varbind_str,
+            pushed=True,
+            fingerprint=None,  # auto-generated from name+source
+            lastReceived=datetime.now(tz=timezone.utc).isoformat(),
+            # extra fields
+            labels={"pdu_type": pdu_type, "source_ip": source_ip, "trap_oid": trap_oid},
+        )
+
+    @staticmethod
+    def _infer_severity(text: str) -> AlertSeverity:
+        """Guess severity from varbind text content."""
+        lower = text.lower()
+        for keywords, sev in SEVERITY_KEYWORDS:
+            if any(kw in lower for kw in keywords):
+                return sev
+        return AlertSeverity.INFO
+
+    # ------------------------------------------------------------------
+    # Webhook / inbound setup
+    # ------------------------------------------------------------------
+
+    def setup_webhook(
+        self,
+        tenant_id: str,
+        keep_api_url: str,
+        api_key: str,
+        setup_alerts: bool = True,
+    ):
+        """
+        For SNMP the 'webhook' is the UDP trap listener itself.
+        This method documents how to configure network devices to send
+        traps to Keep's listener.
+        """
+        host = self.authentication_config.listen_host
+        port = self.authentication_config.listen_port
+        logger.info(
+            f"SNMP trap listener: configure your devices to send SNMP traps to "
+            f"{host}:{port} (UDP). Community string: "
+            f"{self.authentication_config.community}"
+        )
+        self._start_listener()
+        return {
+            "message": (
+                f"SNMP trap listener active on UDP {host}:{port}. "
+                "Configure your network devices to send traps to this address."
+            ),
+            "listen_host": host,
+            "listen_port": port,
+        }
+
+
+# Register provider
+ProvidersFactory.register_provider(SnmpProvider)

--- a/tests/test_snmp_provider.py
+++ b/tests/test_snmp_provider.py
@@ -1,0 +1,302 @@
+"""
+Tests for the SNMP provider.
+
+Covers:
+- Raw BER decoder (v1 + v2c traps, no pysnmp needed)
+- Severity inference from varbind text
+- Well-known OID mapping (linkDown, authFailure, linkUp, coldStart)
+- Alert builder fields (name, severity, status, source, pushed)
+- Queue filling and draining via _get_alerts (with mock listener)
+- Community string filtering
+- SNMPv3 config validation (username present → v3 enabled)
+"""
+
+import queue
+import socket
+import struct
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from keep.api.models.alert import AlertSeverity, AlertStatus
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.models.provider_config import ProviderConfig
+from keep.providers.snmp_provider.snmp_provider import SnmpProvider, WELL_KNOWN_TRAPS
+
+
+def _make_provider(
+    community="public",
+    listen_port=16200,
+    v3_username=None,
+    v3_auth_key=None,
+    v3_priv_key=None,
+):
+    """Helper: build an SnmpProvider with a mock context manager."""
+    context_manager = MagicMock(spec=ContextManager)
+    context_manager.tenant_id = "test-tenant"
+    config = ProviderConfig(
+        authentication={
+            "listen_host": "127.0.0.1",
+            "listen_port": listen_port,
+            "community": community,
+            "v3_username": v3_username,
+            "v3_auth_key": v3_auth_key,
+            "v3_priv_key": v3_priv_key,
+            "max_queue_size": 100,
+        }
+    )
+    provider = SnmpProvider(
+        context_manager=context_manager,
+        provider_id="test-snmp",
+        config=config,
+    )
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# BER helper: encode a minimal SNMPv2c Trap PDU
+# ---------------------------------------------------------------------------
+
+def _encode_length(length: int) -> bytes:
+    if length < 0x80:
+        return bytes([length])
+    if length < 0x100:
+        return bytes([0x81, length])
+    return bytes([0x82, (length >> 8) & 0xFF, length & 0xFF])
+
+
+def _encode_integer(value: int) -> bytes:
+    return b"\x02\x01" + bytes([value & 0xFF])
+
+
+def _encode_octet_string(s: str) -> bytes:
+    enc = s.encode()
+    return b"\x04" + _encode_length(len(enc)) + enc
+
+
+def _encode_oid(dotted: str) -> bytes:
+    parts = list(map(int, dotted.split(".")))
+    first = parts[0] * 40 + parts[1]
+    body = [first] + parts[2:]
+    encoded = []
+    for v in body:
+        if v == 0:
+            encoded.append(0)
+        else:
+            septets = []
+            while v:
+                septets.append(v & 0x7F)
+                v >>= 7
+            septets.reverse()
+            for i, s in enumerate(septets):
+                encoded.append(s | (0x80 if i < len(septets) - 1 else 0))
+    return b"\x06" + _encode_length(len(encoded)) + bytes(encoded)
+
+
+def _build_v2c_trap(community: str, trap_oid: str) -> bytes:
+    """Build a minimal SNMPv2c Trap PDU."""
+    version = _encode_integer(1)  # version 2 = integer 1
+    comm = _encode_octet_string(community)
+
+    # VarBind: snmpTrapOID.0 = trap_oid
+    snmp_trap_oid_oid = _encode_oid("1.3.6.1.6.3.1.1.4.1.0")
+    trap_oid_value = _encode_oid(trap_oid)
+    varbind = b"\x30" + _encode_length(len(snmp_trap_oid_oid) + len(trap_oid_value)) + snmp_trap_oid_oid + trap_oid_value
+    varbind_list = b"\x30" + _encode_length(len(varbind)) + varbind
+
+    # PDU: request-id(0), error-status(0), error-index(0), varbinds
+    req_id = _encode_integer(0)
+    err_status = _encode_integer(0)
+    err_index = _encode_integer(0)
+    pdu_body = req_id + err_status + err_index + varbind_list
+    pdu = b"\xa7" + _encode_length(len(pdu_body)) + pdu_body
+
+    msg_body = version + comm + pdu
+    return b"\x30" + _encode_length(len(msg_body)) + msg_body
+
+
+# ---------------------------------------------------------------------------
+
+class TestSnmpProviderConfig(unittest.TestCase):
+    def test_valid_config(self):
+        p = _make_provider()
+        self.assertEqual(p.authentication_config.community, "public")
+        self.assertEqual(p.authentication_config.listen_port, 16200)
+
+    def test_invalid_port(self):
+        with self.assertRaises(Exception):
+            _make_provider(listen_port=0)
+
+    def test_v3_username_stored(self):
+        p = _make_provider(v3_username="admin", v3_auth_key="authpass", v3_priv_key="privpass")
+        self.assertEqual(p.authentication_config.v3_username, "admin")
+
+
+class TestSeverityInference(unittest.TestCase):
+    def test_critical_keyword(self):
+        p = _make_provider()
+        self.assertEqual(p._infer_severity("CRITICAL error on interface"), AlertSeverity.CRITICAL)
+
+    def test_warning_keyword(self):
+        p = _make_provider()
+        self.assertEqual(p._infer_severity("warning: memory low"), AlertSeverity.WARNING)
+
+    def test_default_info(self):
+        p = _make_provider()
+        self.assertEqual(p._infer_severity("some varbind data"), AlertSeverity.INFO)
+
+    def test_high_keyword(self):
+        p = _make_provider()
+        self.assertEqual(p._infer_severity("major interface failure"), AlertSeverity.HIGH)
+
+
+class TestWellKnownOids(unittest.TestCase):
+    def test_link_down_severity(self):
+        self.assertEqual(WELL_KNOWN_TRAPS["1.3.6.1.6.3.1.1.5.3"]["severity"], AlertSeverity.HIGH)
+
+    def test_auth_failure_critical(self):
+        self.assertEqual(WELL_KNOWN_TRAPS["1.3.6.1.6.3.1.1.5.5"]["severity"], AlertSeverity.CRITICAL)
+
+    def test_link_up_info(self):
+        self.assertEqual(WELL_KNOWN_TRAPS["1.3.6.1.6.3.1.1.5.4"]["severity"], AlertSeverity.INFO)
+
+    def test_cold_start_warning(self):
+        self.assertEqual(WELL_KNOWN_TRAPS["1.3.6.1.6.3.1.1.5.1"]["severity"], AlertSeverity.WARNING)
+
+
+class TestAlertBuilder(unittest.TestCase):
+    def setUp(self):
+        self.p = _make_provider()
+
+    def test_link_down_alert(self):
+        alert = self.p._build_alert(
+            "1.3.6.1.6.3.1.1.5.3", "ifIndex=2", "192.168.1.1", "SNMPv2-Trap"
+        )
+        self.assertEqual(alert.name, "linkDown")
+        self.assertEqual(alert.severity, AlertSeverity.HIGH)
+        self.assertEqual(alert.status, AlertStatus.FIRING)
+        self.assertEqual(alert.source, ["snmp"])
+        self.assertTrue(alert.pushed)
+
+    def test_link_up_resolved(self):
+        alert = self.p._build_alert(
+            "1.3.6.1.6.3.1.1.5.4", "ifIndex=2", "192.168.1.1", "SNMPv2-Trap"
+        )
+        self.assertEqual(alert.status, AlertStatus.RESOLVED)
+
+    def test_unknown_oid_defaults_to_info(self):
+        alert = self.p._build_alert(
+            "1.2.3.4.5.6", "some=varbind", "10.0.0.1", "SNMPv2-Trap"
+        )
+        self.assertEqual(alert.severity, AlertSeverity.INFO)
+        self.assertEqual(alert.status, AlertStatus.FIRING)
+
+    def test_alert_has_id_and_lastReceived(self):
+        alert = self.p._build_alert("1.2.3", "x=1", "1.2.3.4", "v2c")
+        self.assertIsNotNone(alert.id)
+        self.assertIsNotNone(alert.lastReceived)
+
+
+class TestBerDecoder(unittest.TestCase):
+    def setUp(self):
+        self.p = _make_provider()
+
+    def test_v2c_link_down(self):
+        data = _build_v2c_trap("public", "1.3.6.1.6.3.1.1.5.3")
+        alert = self.p._decode_with_ber(data, ("192.168.1.1", 12345))
+        self.assertIsNotNone(alert)
+
+    def test_community_mismatch_returns_none(self):
+        data = _build_v2c_trap("wrong-community", "1.3.6.1.6.3.1.1.5.3")
+        alert = self.p._decode_with_ber(data, ("192.168.1.1", 12345))
+        self.assertIsNone(alert)
+
+    def test_garbage_data_returns_none(self):
+        alert = self.p._decode_with_ber(b"\x00\x01\x02garbage", ("1.2.3.4", 0))
+        self.assertIsNone(alert)
+
+    def test_empty_data_returns_none(self):
+        alert = self.p._decode_with_ber(b"", ("1.2.3.4", 0))
+        self.assertIsNone(alert)
+
+
+class TestQueueDrain(unittest.TestCase):
+    def test_queue_filled_and_drained(self):
+        p = _make_provider(listen_port=16201)
+
+        # Manually inject alerts into the queue
+        for i in range(5):
+            alert = p._build_alert(
+                "1.3.6.1.6.3.1.1.5.3", f"ifIndex={i}", f"10.0.0.{i}", "test"
+            )
+            p._trap_queue.put_nowait(alert)
+
+        # Patch listener thread to avoid binding a socket
+        p._listener_thread = threading.Thread(target=lambda: None, daemon=True)
+        p._listener_thread.start()
+        p._listener_thread.join()
+
+        alerts = p._get_alerts()
+        self.assertEqual(len(alerts), 5)
+        # Queue should be empty now
+        self.assertTrue(p._trap_queue.empty())
+
+    def test_queue_full_drops_trap(self):
+        p = _make_provider(listen_port=16202)
+        p._trap_queue = queue.Queue(maxsize=2)
+
+        # Fill queue
+        for i in range(2):
+            p._trap_queue.put_nowait(
+                p._build_alert("1.3.6.1.6.3.1.1.5.3", "x=1", "1.2.3.4", "v2c")
+            )
+
+        # This should not raise — it should log and drop
+        data = _build_v2c_trap("public", "1.3.6.1.6.3.1.1.5.3")
+        p._handle_datagram(data, ("1.2.3.4", 0))
+        self.assertEqual(p._trap_queue.qsize(), 2)
+
+
+class TestUdpListener(unittest.TestCase):
+    """Integration: actually bind a UDP socket and send a trap."""
+
+    def test_end_to_end_v2c(self):
+        PORT = 16210
+        p = _make_provider(listen_port=PORT)
+        p._start_listener()
+        time.sleep(0.2)
+
+        # Send a linkDown trap
+        data = _build_v2c_trap("public", "1.3.6.1.6.3.1.1.5.3")
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.sendto(data, ("127.0.0.1", PORT))
+        sock.close()
+
+        time.sleep(0.3)
+        alerts = p._get_alerts()
+        p.dispose()
+
+        self.assertGreater(len(alerts), 0)
+        self.assertEqual(alerts[0].name, "linkDown")
+
+    def test_community_filter_drops_wrong(self):
+        PORT = 16211
+        p = _make_provider(listen_port=PORT)
+        p._start_listener()
+        time.sleep(0.2)
+
+        data = _build_v2c_trap("wrong-community", "1.3.6.1.6.3.1.1.5.3")
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.sendto(data, ("127.0.0.1", PORT))
+        sock.close()
+
+        time.sleep(0.3)
+        alerts = p._get_alerts()
+        p.dispose()
+
+        self.assertEqual(len(alerts), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2112\n\nBeen meaning to get SNMP trap ingestion working for a while. This adds a new provider that listens for traps over UDP and turns them into Keep alerts — covering v1, v2c, and v3 with USM auth/priv.\n\n**What's in here:**\n\n- UDP trap listener that runs as a background thread, feeds a bounded queue\n- SNMPv1 and v2c: community string filtering, enterprise OID and varbind extraction\n- SNMPv3: USM with SHA/MD5 auth and AES/AES256/DES encryption config\n- Well-known trap OIDs mapped to human names + severity (linkDown, linkUp, coldStart, authFailure, etc.)\n- Raw BER decoder as fallback if pysnmp isn't available\n- Mock alerts for UI preview\n\nTested manually with  against a local listener. The v3 path requires pysnmp; if it's not installed the BER fallback handles v1/v2c cleanly.\n\nPart of the Algora bounty on this issue.