### PR TITLE
fix: indentation error in AnthropicProvider._query()

### DIFF
--- a/keep/providers/anthropic_provider/anthropic_provider.py
+++ b/keep/providers/anthropic_provider/anthropic_provider.py
@@ -90,7 +90,7 @@ class AnthropicProvider(BaseProvider):
             system_prompt (str): System prompt override for this call.
             structured_output_format (dict): The structured output format to use.
         """
-      client = Anthropic(api_key=self.authentication_config.api_key)
+        client = Anthropic(api_key=self.authentication_config.api_key)
 
         messages = [{"role": "user", "content": prompt}]
 


### PR DESCRIPTION
Fixes #6462

The `client = Anthropic(...)` line in `_query()` had 6 spaces of indentation instead of 8, causing an `IndentationError` on module import.

Changed 6-space indent to 8-space to match the method body.