### PR TITLE
feat(prometheus): expose PromQL query as invokable provider method

### DIFF
--- a/docs/snippets/providers/prometheus-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/prometheus-snippet-autogenerated.mdx
@@ -9,7 +9,7 @@ This provider requires authentication.
 - **verify**: Verify SSL certificates (required: False, sensitive: False)
 
 Certain scopes may be required to perform specific actions or queries via the provider. Below is a summary of relevant scopes and their use cases:
-- **connectivity**: Connectivity Test (mandatory)
+- **connectivity**: Connectivity Test (mandatory) 
 
 
 
@@ -25,7 +25,7 @@ steps:
       provider: prometheus
       config: "{{ provider.my_provider_name }}"
       with:
-        query: {value}
+        query: {value}  
 ```
 
 
@@ -39,6 +39,14 @@ Check the following workflow examples:
 - [enrich_using_structured_output_from_vllm_qwen.yaml](https://github.com/keephq/keep/blob/main/examples/workflows/enrich_using_structured_output_from_vllm_qwen.yaml)
 - [http_enrich.yml](https://github.com/keephq/keep/blob/main/examples/workflows/http_enrich.yml)
 - [multi-condition-cel.yml](https://github.com/keephq/keep/blob/main/examples/workflows/multi-condition-cel.yml)
+
+
+## Provider Methods
+The provider exposes the following [Provider Methods](/providers/provider-methods#via-ai-assistant). They are available in the [AI Assistant](/overview/ai-incident-assistant).
+
+- **execute_query** Run an instant PromQL query against Prometheus and return the results (view, scopes: no additional scopes)
+
+    - `query`: A valid PromQL expression, e.g. ``up`` or ``rate(http_requests_total[5m])``
 
 ## Connecting via Webhook (omnidirectional)
 

--- a/keep/providers/prometheus_provider/prometheus_provider.py
+++ b/keep/providers/prometheus_provider/prometheus_provider.py
@@ -126,7 +126,7 @@ receivers:
             validated_scopes["connectivity"] = str(e)
         return validated_scopes
 
-    def execute_query(self, query: str):
+    def execute_query(self, query: str) -> dict:
         """
         Public wrapper around _query — exposes PromQL instant queries as an
         invokable provider method so AI agents and Keep workflows can query
@@ -138,7 +138,12 @@ receivers:
         Returns:
             dict: The raw ``data`` object from the Prometheus API response.
         """
-        return self._query(query)
+        try:
+            return self._query(query)
+        except requests.HTTPError as e:
+            raise Exception(
+                f"Prometheus query failed ({e.response.status_code}): {e.response.text[:200]}"
+            ) from e
 
     def _query(self, query):
         """

--- a/keep/providers/prometheus_provider/prometheus_provider.py
+++ b/keep/providers/prometheus_provider/prometheus_provider.py
@@ -15,6 +15,7 @@ from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
 from keep.contextmanager.contextmanager import ContextManager
 from keep.providers.base.base_provider import BaseProvider, ProviderHealthMixin
 from keep.providers.models.provider_config import ProviderConfig, ProviderScope
+from keep.providers.models.provider_method import ProviderMethod
 
 
 @pydantic.dataclasses.dataclass
@@ -95,6 +96,14 @@ receivers:
         )
     ]
     FINGERPRINT_FIELDS = ["fingerprint"]
+    PROVIDER_METHODS = [
+        ProviderMethod(
+            name="Execute PromQL Query",
+            func_name="execute_query",
+            description="Run an instant PromQL query against Prometheus and return the results",
+            type="view",
+        )
+    ]
 
     def __init__(
         self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
@@ -116,6 +125,20 @@ receivers:
         except Exception as e:
             validated_scopes["connectivity"] = str(e)
         return validated_scopes
+
+    def execute_query(self, query: str):
+        """
+        Public wrapper around _query — exposes PromQL instant queries as an
+        invokable provider method so AI agents and Keep workflows can query
+        Prometheus directly.
+
+        Args:
+            query: A valid PromQL expression, e.g. ``up`` or ``rate(http_requests_total[5m])``
+
+        Returns:
+            dict: The raw ``data`` object from the Prometheus API response.
+        """
+        return self._query(query)
 
     def _query(self, query):
         """


### PR DESCRIPTION
## Problem

Closes #6475

Users want to use Keep's AI assistant to query Prometheus directly via PromQL. Currently `PrometheusProvider` has a private `_query()` method that isn't registered as an invokable method, so it doesn't appear in the AI agent's tool list or the Keep provider UI.

## Solution

- Added `PROVIDER_METHODS` registration for a new `execute_query` method
- Added public `execute_query(query: str) -> dict` wrapper with friendly HTTP error messages
- Keep's `ProviderMethodDTO` auto-infers the `query` parameter from the function signature via reflection — no manual param spec needed

Now users can invoke PromQL queries directly from the Keep AI assistant or workflow actions.