### PR TITLE
feat: support formatted text in incident summary

### DIFF
--- a/keep-ui/app/(keep)/incidents/[id]/incident-overview.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/incident-overview.tsx
@@ -109,9 +109,14 @@ function Summary({
     setGeneratingSummary(false);
   };
 
+  const isHtml = (content: string) => /<[a-z][\s\S]*>/i.test(content);
+
   const formatedSummary = (
     <div className="prose prose-slate max-w-2xl [&>p]:!my-1 [&>ul]:!my-1 [&>ol]:!my-1">
-      <FormattedContent content={summary ?? generatedSummary} format="html" />
+      <FormattedContent
+        content={summary ?? generatedSummary}
+        format={isHtml(summary ?? generatedSummary ?? "") ? "html" : "markdown"}
+      />
     </div>
   );
 

--- a/keep-ui/features/incidents/incident-list/ui/incidents-table.tsx
+++ b/keep-ui/features/incidents/incident-list/ui/incidents-table.tsx
@@ -195,7 +195,9 @@ export default function IncidentsTable({
             {summary ? (
               <FormattedContent
                 content={summary}
-                format="html"
+                format={
+                  /<[a-z][\s\S]*>/i.test(summary) ? "html" : "markdown"
+                }
                 plain
                 className="line-clamp-2 text-sm text-gray-500"
               />


### PR DESCRIPTION
This PR addresses bounty #3353 by adding dynamic detection of HTML vs Markdown for incident summaries.

Fixes #3353

/claim #3353