### PR TITLE
docs: list Grafana as topology provider

### DIFF
--- a/docs/overview/servicetopology.mdx
+++ b/docs/overview/servicetopology.mdx
@@ -24,6 +24,13 @@ The Service Topology feature in Keep provides a visual representation of your se
     }
   ></Card>
   <Card
+    title="Grafana"
+    href="/providers/documentation/grafana-provider"
+    icon={
+      <img src="https://img.logo.dev/grafana.com?token=pk_dfXfZBoKQMGDTIgqu7LvYg" />
+    }
+  ></Card>
+  <Card
     title="Pagerduty"
     href="/providers/documentation/pagerduty-provider"
     icon={


### PR DESCRIPTION
## Summary
- add Grafana to the Service Topology supported providers card list
- link the card to the existing Grafana provider documentation

## Validation
- git diff --check

Fixes #5406