### PR TITLE
fix: indentation in _handle_500_error (anthropic.py)

### DIFF
--- a/keep/providers/anthropic_provider/anthropic_provider.py
+++ b/keep/providers/anthropic_provider/anthropic_provider.py
@@ -90,7 +90,7 @@ class AnthropicProvider(BaseProvider):
             system_prompt (str): System prompt override for this call.
             structured_output_format (dict): The structured output format to use.
         """
-      client = Anthropic(api_key=self.authentication_config.api_key)
+        client = Anthropic(api_key=self.authentication_config.api_key)
 
         messages = [{"role": "user", "content": prompt}]
 


### PR DESCRIPTION
Closes #6462

Fixed indentation bug in Anthropic client error handling (line ~93): the content block was incorrectly indented at 6 spaces instead of 8, causing IndentationError or silently incorrect control flow.