### PR TITLE
fix: Handle test Contact Point alert from Grafana 12

### DIFF
--- a/keep/providers/grafana_provider/grafana_provider.py
+++ b/keep/providers/grafana_provider/grafana_provider.py
@@ -9,6 +9,7 @@ import json
 import logging
 import re
 import time
+import urllib.parse
 
 import pydantic
 import requests
@@ -289,6 +290,16 @@ class GrafanaProvider(BaseTopologyProvider, ProviderHealthMixin):
         return fingerprint
 
     @staticmethod
+    def _resolve_alert_url(url: str | None, external_url: str | None) -> str | None:
+        if not url or not isinstance(url, str):
+            return None
+        if url.startswith(("http://", "https://")):
+            return url
+        if not external_url or not isinstance(external_url, str):
+            return None
+        return urllib.parse.urljoin(external_url, url)
+
+    @staticmethod
     def _format_alert(
         event: dict, provider_instance: "BaseProvider" = None
     ) -> AlertDto:
@@ -324,8 +335,13 @@ class GrafanaProvider(BaseTopologyProvider, ProviderHealthMixin):
             if values:
                 extra["values"] = values
 
-            url = alert.get("generatorURL", None)
-            image_url = alert.get("imageURL", None)
+            external_url = event.get("externalURL")
+            url = GrafanaProvider._resolve_alert_url(
+                alert.get("generatorURL"), external_url
+            )
+            image_url = GrafanaProvider._resolve_alert_url(
+                alert.get("imageURL"), external_url
+            )
             # Always set these as "" when absent so workflow templates can
             # reference them safely without triggering render_context safe=True errors.
             dashboard_url = alert.get("dashboardURL", "")

--- a/tests/providers/grafana_provider/test_grafana_v12_webhook.py
+++ b/tests/providers/grafana_provider/test_grafana_v12_webhook.py
@@ -1,0 +1,103 @@
+from keep.providers.grafana_provider.grafana_provider import GrafanaProvider
+
+
+def _grafana12_test_payload(generator_url: str = "?orgId=1") -> dict:
+    return {
+        "receiver": "webhook",
+        "status": "firing",
+        "alerts": [
+            {
+                "status": "firing",
+                "labels": {
+                    "alertname": "TestAlert",
+                    "grafana_folder": "Test Folder",
+                    "instance": "Grafana",
+                },
+                "annotations": {
+                    "description": "Test Description",
+                    "summary": "TEST",
+                },
+                "startsAt": "2026-05-05T13:04:57.62281314Z",
+                "endsAt": "0001-01-01T00:00:00Z",
+                "generatorURL": generator_url,
+                "fingerprint": "c4edaaf9f9f839b0",
+                "silenceURL": "https://grafana.example.com/alerting/silence/new",
+                "dashboardURL": "https://grafana.example.com/d/dashboard_uid",
+                "panelURL": "https://grafana.example.com/d/dashboard_uid?viewPanel=1",
+                "values": {"B": 22, "C": 1},
+                "valueString": "[ var='B' value=22 ]",
+                "orgId": 1,
+            }
+        ],
+        "groupLabels": {"alertname": "TestAlert"},
+        "commonLabels": {"alertname": "TestAlert"},
+        "commonAnnotations": {"description": "Test Description"},
+        "externalURL": "https://grafana.example.com/",
+        "appVersion": "12.4.2",
+        "version": "1",
+        "groupKey": "webhook-c4edaaf9f9f839b0-1777986297",
+        "truncatedAlerts": 0,
+        "orgId": 1,
+        "title": "TestAlert",
+        "state": "alerting",
+        "message": "Firing",
+    }
+
+
+class TestResolveAlertUrl:
+    def test_absolute_url_passes_through(self):
+        assert (
+            GrafanaProvider._resolve_alert_url(
+                "https://grafana.example.com/d/foo", "https://ignored.example.com/"
+            )
+            == "https://grafana.example.com/d/foo"
+        )
+
+    def test_query_only_url_joins_with_external_url(self):
+        # Grafana 12 test alerts emit this shape.
+        assert (
+            GrafanaProvider._resolve_alert_url(
+                "?orgId=1", "https://grafana.example.com/"
+            )
+            == "https://grafana.example.com/?orgId=1"
+        )
+
+    def test_relative_path_joins_with_external_url(self):
+        assert (
+            GrafanaProvider._resolve_alert_url(
+                "alerting/grafana/abc/view", "https://grafana.example.com/"
+            )
+            == "https://grafana.example.com/alerting/grafana/abc/view"
+        )
+
+    def test_relative_url_without_external_url_returns_none(self):
+        assert GrafanaProvider._resolve_alert_url("?orgId=1", None) is None
+        assert GrafanaProvider._resolve_alert_url("?orgId=1", "") is None
+
+    def test_missing_or_empty_url_returns_none(self):
+        assert GrafanaProvider._resolve_alert_url(None, "https://x/") is None
+        assert GrafanaProvider._resolve_alert_url("", "https://x/") is None
+
+
+class TestFormatAlertGrafana12:
+    def test_test_alert_payload_parses(self):
+        event = _grafana12_test_payload()
+
+        alerts = GrafanaProvider._format_alert(event)
+
+        assert len(alerts) == 1
+        alert = alerts[0]
+        assert alert.name == "TestAlert"
+        assert alert.fingerprint == "c4edaaf9f9f839b0"
+        assert str(alert.url) == "https://grafana.example.com/?orgId=1"
+        assert alert.values == {"B": 22, "C": 1}
+        assert alert.description == "Test Description"
+
+    def test_test_alert_without_external_url_drops_invalid_generator_url(self):
+        event = _grafana12_test_payload()
+        event.pop("externalURL")
+
+        alerts = GrafanaProvider._format_alert(event)
+
+        assert len(alerts) == 1
+        assert alerts[0].url is None


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #6506 

## 📑 Description
Fixes Grafana 12 test Contact Point payloads being rejected by Keep. Grafana 12 emits generatorURL as a bare query string (e.g. "?orgId=1"), which AlertDto.url can't validate because it has no host, so the whole alert was dropped. The Grafana provider now resolves relative generatorURL/imageURL against the payload's externalURL before constructing the AlertDto.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
No breaking changes, no new dependencies. 
Real (non-test) Grafana alerts with absolute generatorURLs are unaffected.
Tested locally by POSTing the exact Grafana 12 test payload to /alerts/event/grafana: without the fix the alert is dropped with a pydantic URL host invalid error, with the fix the alert is parsed and url resolves to https://<externalURL host>/?orgId=1.
