### PR TITLE
fix: Prefix "Possible" in Incident Title Based on is_candidate Value

### DIFF
--- a/keep-ui/app/(keep)/incidents/[id]/incident-header.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/incident-header.tsx
@@ -70,7 +70,7 @@ export function IncidentHeader({
             <Subtitle className="text-sm">
               <Link href="/incidents">All Incidents</Link>{" "}
               <Icon icon={ArrowRightIcon} color="gray" size="xs" />{" "}
-              {incident.is_candidate ? "" : "Possible "}
+              {incident.is_candidate ? "Possible " : ""}
               {getIncidentName(incident)}
               {pathNameCapitalized && (
                 <>


### PR DESCRIPTION
Closes #6516

## 📑 Description

This PR fixes a logical error in the Incident Header UI regarding the "Possible" prefix. 

Currently, the logic is inverted:
- Incidents with `is_candidate = false` (not requiring validation) are incorrectly prefixed with **"Possible "**.
- Incidents with `is_candidate = true` (requiring manual approval/AI-suggested) do **not** have the prefix

## The Fix:
Updated `keep-ui/app/(keep)/incidents/[id]/incident-header.tsx` to correctly apply the prefix based on the `is_candidate` flag:
- If `is_candidate` is `true` → Show **"Possible "** (indicates validation needed).
- If `is_candidate` is `false` → Show no prefix (indicates confirmed incident).

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## Additional Information
The term "Possible" implies uncertainty. In the current implementation, confirmed incidents were labeled as "Possible," while unverified (candidate) incidents lacked this warning. This caused confusion for operators managing incidents.
