### PR TITLE
fix(api): remove invalid joinedload on Incident.alerts property

### DIFF
--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -4889,7 +4889,6 @@ def confirm_predicted_incident_by_id(
                 Incident.id == incident_id,
                 Incident.is_candidate == expression.true(),
             )
-            .options(joinedload(Incident.alerts))
         ).first()
 
         if not incident:


### PR DESCRIPTION
## Summary

`confirm_predicted_incident_by_id()` used `joinedload(Incident.alerts)`, but `alerts` is a Python `@property` backed by a `_alerts` `PrivateAttr`, not an ORM relationship.

SQLModel/SQLAlchemy raised:

```
Expected ORM mapped instance attribute, got: <property object>
```

This caused `POST /v2/incidents/{id}/confirm` to return **500** when confirming predicted incidents that have associated alerts.

## Changes

- Removed the invalid `.options(joinedload(Incident.alerts))` call from `confirm_predicted_incident_by_id()` in `keep/api/core/db.py`.
- The `alerts` property already reads from `_alerts` which is populated elsewhere; eager-loading it via SQL is unnecessary and incorrect.

## Fixes

Fixes #6507

## Checklist

- [x] Bug fix (non-breaking)
- [x] No new dependencies
- [x] Minimal change — one line removed