### PR TITLE
fix(providers): replace dynamic code execution with safe bracket-access parser in _enrich

### DIFF
--- a/keep/providers/base/base_provider.py
+++ b/keep/providers/base/base_provider.py
@@ -201,6 +201,34 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
         return results if results else None
 
+
+    @staticmethod
+    def _safe_results_access(expression, results):
+        """Safely access nested indices/keys on results without dynamic code execution.
+
+        Supports expressions like: results[0]["key"]["nested"]
+        After dot-to-bracket conversion, all access should be bracket-based.
+        """
+        if not expression.startswith("results"):
+            raise ValueError("Expression must start with results")
+        remainder = expression[len("results"):]
+        obj = results
+        bracket_pattern = re.compile(r'^\[(\d+|"[^"]*"|\'[^\']*\')\]')
+        while remainder:
+            m = bracket_pattern.match(remainder)
+            if not m:
+                raise ValueError(
+                    f"Invalid access pattern in expression: {expression}"
+                )
+            key = m.group(1)
+            if key.startswith('"') or key.startswith("'"):
+                key = key[1:-1]
+            else:
+                key = int(key)
+            obj = obj[key]
+            remainder = remainder[m.end():]
+        return obj
+
     def _enrich(self, enrichments, results, audit_enabled=True):
         """
         Enrich alert with provider specific data.
@@ -289,9 +317,9 @@ class BaseProvider(metaclass=abc.ABCMeta):
                         bracket_pattern, convert_dot_to_bracket, converted_value
                     )
                     try:
-                        # this is secured since if we are here it means converted_value starts with results[
-                        value = eval(
-                            converted_value, {"__builtins__": {}}, {"results": results}
+                        # Safe index/key access without dynamic code execution
+                        value = self._safe_results_access(
+                            converted_value, results
                         )
                     except Exception:
                         self.logger.exception(


### PR DESCRIPTION
## Vulnerability Summary

**CWE-95 — Eval of Workflow Expression in `BaseProvider._enrich()`**

In `keep/providers/base/base_provider.py`, the `_enrich()` method uses `eval()` to evaluate workflow enrichment expressions that start with `results[`. While the call restricts `__builtins__` to an empty dict, Python sandbox escapes via `__subclasses__()` / `__class__.__mro__` chains are well-documented and can bypass an empty-builtins restriction to achieve arbitrary code execution.

**Affected code (before this fix):**

```python
# line ~319 in _enrich()
value = eval(
    converted_value, {"__builtins__": {}}, {"results": results}
)
```

The `converted_value` variable originates from `enrichment["value"]` in a workflow YAML definition. A user with workflow creation/edit permissions (`write:workflows` scope) can craft a malicious enrichment value that escapes the restricted `eval()` sandbox.

**Severity:** Low — exploitation requires authenticated access with `write:workflows` permission, and the restricted eval context (empty `__builtins__`) raises the bar significantly. However, Python sandbox escapes against empty builtins are a solved problem in the security research community, making this a defense-in-depth concern worth fixing.

## Fix Description

This PR replaces the `eval()` call with a new static method `_safe_results_access()` that uses a regex-based parser to walk bracket-access expressions (`results[0]["key"]["nested"]`). The parser:

1. Verifies the expression starts with `results`
2. Iterates over bracket-delimited accessors using a strict regex: `^\[(\d+|"[^"]*"|'[^']*')\]`
3. Converts numeric keys to `int` for index access, strips quotes for string keys
4. Raises `ValueError` on any unexpected syntax

This approach supports the exact same access patterns the original `eval()` was used for (numeric indices and quoted string keys), without executing arbitrary Python code.

## Testing

We verified the fix handles the expected access patterns correctly:

```python
from keep.providers.base.base_provider import BaseProvider

# Numeric index access
assert BaseProvider._safe_results_access('results[0]', ['a', 'b']) == 'a'

# Nested dict access
data = [{"message": {"source": "test"}}]
assert BaseProvider._safe_results_access('results[0]["message"]["source"]', data) == 'test'

# Mixed index and key access
assert BaseProvider._safe_results_access('results[0]["message"]', data) == {"source": "test"}

# Rejects malicious input
try:
    BaseProvider._safe_results_access('results[0].__class__', data)
    assert False, "Should have raised"
except ValueError:
    pass  # correctly rejected
```

## Proof of Concept

An authenticated user with `write:workflows` permission can create a workflow YAML containing a malicious enrichment value. The enrichment value flows through `_enrich()` → `converted_value` → previously into `eval()`.

Example malicious enrichment value in workflow YAML:

```yaml
actions:
  - name: exfil
    provider:
      type: mock
      config: "{{ providers.mock }}"
      with:
        enrich_alert:
          - key: "test"
            value: "results[0].__class__.__mro__[1].__subclasses__()"
```

After dot-to-bracket conversion, this becomes:
```
results[0]["__class__"]["__mro__"][1]["__subclasses__"]()
```

While the dot-to-bracket conversion interferes with some payloads, crafted bracket-notation expressions bypass conversion entirely:

```yaml
value: 'results[(lambda: __import__("os").system("id"))()]'
```

This would fail with empty `__builtins__` in most cases, but more sophisticated payloads leveraging `().__class__.__bases__[0].__subclasses__()` to find `os._wrap_close` or `subprocess.Popen` in the subclass list are well-documented (e.g., see "Python sandbox escape" literature). The empty-builtins restriction is not a reliable security boundary.

## Adversarial Review

Before submitting, we considered whether this finding is practically exploitable given the mitigations in place. The `eval()` call uses `{"__builtins__": {}}` which blocks direct use of `__import__`, `open`, etc. However, Python's introspection capabilities (`__class__.__mro__.__subclasses__()`) are specifically designed to bypass empty-builtins sandboxes — this is a well-known class of escape documented extensively in CTF writeups and security research (e.g., Ned Batchelder's "Eval really is dangerous"). The dot-to-bracket conversion adds friction but does not prevent exploitation via expressions already in bracket notation. The auth requirement (`write:workflows`) limits the attack surface to authenticated users, making this low severity but still worth fixing as defense-in-depth.