### PR TITLE
fix: parse site24x7 LABELS as dict for AlertDto compatibility

### DIFF
--- a/keep/providers/site24x7_provider/site24x7_provider.py
+++ b/keep/providers/site24x7_provider/site24x7_provider.py
@@ -234,11 +234,20 @@ class Site24X7Provider(BaseProvider):
         elif not isinstance(tags, list):
             tags = []
 
-        labels = event.get("LABELS", "")
-        if isinstance(labels, str) and labels:
-            labels = [lbl.strip() for lbl in labels.split(",") if lbl.strip()]
-        elif not isinstance(labels, list):
-            labels = []
+        labels_raw = event.get("LABELS", "")
+        if isinstance(labels_raw, dict):
+            labels = labels_raw
+        elif isinstance(labels_raw, str) and labels_raw:
+            labels = {}
+            for part in labels_raw.split(","):
+                part = part.strip()
+                if ":" in part:
+                    k, _, v = part.partition(":")
+                    labels[k.strip()] = v.strip()
+                elif part:
+                    labels[part] = ""
+        else:
+            labels = {}
 
         return AlertDto(
             url=event.get("MONITORURL", ""),


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #6527 

## 📑 Description

Fix `Site24X7Provider._format_alert` incorrectly parsing the `LABELS` webhook field as a `list` instead of a `dict`.

`AlertDto.labels` is typed as `dict | None`, so passing a list caused labels to be silently dropped by pydantic on alert ingestion.

- [x] Parse `LABELS` string (e.g. `"env:prod,team:sre"`) into a `dict` (`{"env": "prod", "team": "sre"}`)
- [x] Handle pre-parsed `dict` payloads passthrough
- [x] Fall back to `{}` for empty/missing values

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

**Before:** `LABELS` was split into a list of strings and passed to `AlertDto.labels`, which expects a `dict` — causing labels to never appear on alerts.

**After:** `LABELS` is parsed as `key:value` pairs into a dict. Keys without a `:` separator are stored with an empty string value.
