### PR TITLE
fix(alerts): Delete all timestamps when omitted

### DIFF
--- a/keep/api/models/alert.py
+++ b/keep/api/models/alert.py
@@ -348,7 +348,7 @@ class AlertWithIncidentLinkMetadataDto(AlertDto):
 
 class DeleteRequestBody(BaseModel):
     fingerprint: str
-    lastReceived: str
+    lastReceived: Optional[str] = None
     restore: bool = False
 
 

--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -342,22 +342,32 @@ def delete_alert(
         deleted_last_received = enrichment.enrichments.get("deletedAt", [])
         assignees_last_receievd = enrichment.enrichments.get("assignees", {})
 
-    if (
-        delete_alert.restore is True
-        and delete_alert.lastReceived in deleted_last_received
-    ):
-        # Restore deleted alert
-        deleted_last_received.remove(delete_alert.lastReceived)
-    elif (
-        delete_alert.restore is False
-        and delete_alert.lastReceived not in deleted_last_received
-    ):
-        # Delete the alert if it's not already deleted (wtf basically, shouldn't happen)
-        deleted_last_received.append(delete_alert.lastReceived)
+    last_received_values = [delete_alert.lastReceived]
+    if delete_alert.lastReceived is None:
+        alerts_history = get_alerts_by_fingerprint(
+            tenant_id=tenant_id,
+            fingerprint=delete_alert.fingerprint,
+            limit=None,
+        )
+        last_received_values = [
+            alert.event["lastReceived"]
+            for alert in alerts_history
+            if alert.event.get("lastReceived")
+        ]
 
-    if delete_alert.lastReceived not in assignees_last_receievd:
-        # auto-assign the deleting user to the alert
-        assignees_last_receievd[delete_alert.lastReceived] = user_email
+    for last_received in last_received_values:
+        if delete_alert.restore is True and last_received in deleted_last_received:
+            # Restore deleted alert
+            deleted_last_received.remove(last_received)
+        elif (
+            delete_alert.restore is False and last_received not in deleted_last_received
+        ):
+            # Delete the alert if it's not already deleted (wtf basically, shouldn't happen)
+            deleted_last_received.append(last_received)
+
+        if last_received not in assignees_last_receievd:
+            # auto-assign the deleting user to the alert
+            assignees_last_receievd[last_received] = user_email
 
     # overwrite the enrichment
     enrichment_bl = EnrichmentsBl(tenant_id)

--- a/tests/test_alert_delete.py
+++ b/tests/test_alert_delete.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+from keep.api.models.alert import DeleteRequestBody
+from keep.api.routes import alerts
+
+
+def test_delete_alert_without_last_received_deletes_all_alert_timestamps(monkeypatch):
+    captured_enrichment = {}
+    captured_fetch = {}
+
+    class FakeEnrichmentsBl:
+        def __init__(self, tenant_id):
+            assert tenant_id == "tenant-1"
+
+        def enrich_entity(self, **kwargs):
+            captured_enrichment.update(kwargs)
+
+    monkeypatch.setattr(alerts, "get_enrichment", lambda tenant_id, fingerprint: None)
+
+    def fake_get_alerts_by_fingerprint(tenant_id, fingerprint, limit=1000):
+        captured_fetch.update(
+            {
+                "tenant_id": tenant_id,
+                "fingerprint": fingerprint,
+                "limit": limit,
+            }
+        )
+        return [
+            SimpleNamespace(event={"lastReceived": "2024-01-01T00:00:00.000Z"}),
+            SimpleNamespace(event={"lastReceived": "2024-01-02T00:00:00.000Z"}),
+        ]
+
+    monkeypatch.setattr(
+        alerts, "get_alerts_by_fingerprint", fake_get_alerts_by_fingerprint
+    )
+    monkeypatch.setattr(alerts, "EnrichmentsBl", FakeEnrichmentsBl)
+
+    response = alerts.delete_alert(
+        DeleteRequestBody(fingerprint="alert-fingerprint"),
+        authenticated_entity=SimpleNamespace(
+            tenant_id="tenant-1",
+            email="user@example.com",
+        ),
+    )
+
+    assert response == {"status": "ok"}
+    assert captured_fetch == {
+        "tenant_id": "tenant-1",
+        "fingerprint": "alert-fingerprint",
+        "limit": None,
+    }
+    assert captured_enrichment["fingerprint"] == "alert-fingerprint"
+    assert captured_enrichment["enrichments"]["deletedAt"] == [
+        "2024-01-01T00:00:00.000Z",
+        "2024-01-02T00:00:00.000Z",
+    ]
+    assert captured_enrichment["enrichments"]["assignees"] == {
+        "2024-01-01T00:00:00.000Z": "user@example.com",
+        "2024-01-02T00:00:00.000Z": "user@example.com",
+    }


### PR DESCRIPTION
Allow alert delete requests to omit lastReceived and mark every timestamp for the fingerprint as deleted.

This keeps the existing single timestamp behavior when lastReceived is provided while supporting full alert deletion through one API call. When lastReceived is omitted, the route now fetches all alert history for the fingerprint without a result cap and applies the delete enrichment to each timestamp.

Fixes #2817