### PR TITLE
fix: prevent custom columns from resetting to defaults when saving preset or renaming column

### DIFF
--- a/keep-ui/entities/presets/model/usePresetActions.ts
+++ b/keep-ui/entities/presets/model/usePresetActions.ts
@@ -39,7 +39,14 @@ export function usePresetActions() {
   );
   const revalidateMultiple = useRevalidateMultiple();
   const mutatePresetsList = useCallback(
-    () => revalidateMultiple(["/preset", "/preset?"]),
+    () => {
+      // Use exact match for /preset (list without filters) and prefix match only
+      // for /preset? (filtered queries like /preset?filters=...).
+      // Do NOT use a broad /preset prefix — that would accidentally match
+      // /preset/{id}/column-config and wipe the user's column configuration.
+      revalidateMultiple(["/preset"], { isExact: true });
+      revalidateMultiple(["/preset?"]);
+    },
     [revalidateMultiple]
   );
   const mutateTags = useCallback(
@@ -88,7 +95,7 @@ export function usePresetActions() {
         return;
       }
       try {
-        const response = await api.delete(`/preset/${presetId}`);
+        await api.delete(`/preset/${presetId}`);
         showSuccessToast(`Preset ${presetName} deleted!`);
         mutatePresetsList();
         setLocalDynamicPresets((oldOrder) =>

--- a/keep-ui/entities/presets/model/usePresetColumnConfig.ts
+++ b/keep-ui/entities/presets/model/usePresetColumnConfig.ts
@@ -3,7 +3,6 @@ import { useApi } from "@/shared/lib/hooks/useApi";
 import { useCallback } from "react";
 import { showErrorToast, showSuccessToast } from "@/shared/ui";
 import { ColumnConfiguration } from "./types";
-import { useRevalidateMultiple } from "@/shared/lib/state-utils";
 
 type UsePresetColumnConfigOptions = {
   presetId?: string;
@@ -24,7 +23,6 @@ export const usePresetColumnConfig = ({
   ...options
 }: UsePresetColumnConfigOptions = {}) => {
   const api = useApi();
-  const revalidateMultiple = useRevalidateMultiple();
 
   const {
     data: columnConfig = DEFAULT_COLUMN_CONFIG,
@@ -82,16 +80,15 @@ export const usePresetColumnConfig = ({
           config
         );
         showSuccessToast("Column configuration saved!");
+        // mutate() already revalidates /preset/${presetId}/column-config
         mutate();
-        // Also revalidate preset list to update any cached data
-        revalidateMultiple(["/preset", "/preset?"]);
         return response;
       } catch (error) {
         showErrorToast(error, "Failed to save column configuration");
         throw error;
       }
     },
-    [api, presetId, mutate, revalidateMultiple]
+    [api, presetId, mutate]
   );
 
   return {

--- a/keep-ui/entities/presets/model/usePresetColumnState.ts
+++ b/keep-ui/entities/presets/model/usePresetColumnState.ts
@@ -151,24 +151,19 @@ export const usePresetColumnState = ({
       columnListFormats?: Record<string, ListFormatOption>;
     }) => {
       if (shouldUseBackend && !error) {
-        // Batch all updates into a single API call
-        const batchedUpdate: Partial<ColumnConfiguration> = {};
-
-        if (updates.columnVisibility !== undefined) {
-          batchedUpdate.column_visibility = updates.columnVisibility;
-        }
-        if (updates.columnOrder !== undefined) {
-          batchedUpdate.column_order = updates.columnOrder;
-        }
-        if (updates.columnRenameMapping !== undefined) {
-          batchedUpdate.column_rename_mapping = updates.columnRenameMapping;
-        }
-        if (updates.columnTimeFormats !== undefined) {
-          batchedUpdate.column_time_formats = updates.columnTimeFormats;
-        }
-        if (updates.columnListFormats !== undefined) {
-          batchedUpdate.column_list_formats = updates.columnListFormats;
-        }
+        // Always send the FULL current config to the backend.
+        // The backend PUT replaces the entire config object, so sending only
+        // a partial update (e.g. just column_rename_mapping) would wipe out
+        // all other fields (column_visibility, column_order, etc.) causing
+        // custom columns to disappear after a rename or format change.
+        const batchedUpdate: ColumnConfiguration = {
+          column_visibility: updates.columnVisibility ?? columnVisibility,
+          column_order: updates.columnOrder ?? columnOrder,
+          column_rename_mapping:
+            updates.columnRenameMapping ?? columnRenameMapping,
+          column_time_formats: updates.columnTimeFormats ?? columnTimeFormats,
+          column_list_formats: updates.columnListFormats ?? columnListFormats,
+        };
 
         try {
           return await updateColumnConfig(batchedUpdate);
@@ -209,6 +204,12 @@ export const usePresetColumnState = ({
       setLocalColumnTimeFormats,
       setLocalColumnListFormats,
       error,
+      // Current state values needed as baseline for full-config PUT
+      columnVisibility,
+      columnOrder,
+      columnRenameMapping,
+      columnTimeFormats,
+      columnListFormats,
     ]
   );
 


### PR DESCRIPTION
# Problem
close #5657 
Users on custom (non-static) presets would see their column layout silently reset to the default columns in two scenarios:

**Bug 1**: Renaming a column or changing its format wiped all other column config

updateMultipleColumnConfigs built a partial object containing only the fields passed in the call (e.g. just column_rename_mapping). The backend PUT /preset/{id}/column-config treats the body as a full replacement, so sending only one field erased column_visibility, column_order, and every other field. Any column the user had added that wasn't in the default set would then disappear.

Fix:
updateMultipleColumnConfigs now always sends the full current config to the backend, using the incoming updates to override only the changed fields (?? operator). This ensures a rename, format change, or visibility toggle never erases unrelated config fields.

**Bug 2**: Saving the preset itself reset the column layout

mutatePresetsList called revalidateMultiple(["/preset", "/preset?"]) using the default prefix matching (key.startsWith(k)). This accidentally matched /preset/{id}/column-config in the SWR cache, triggering a re-fetch and discarding the cached column config. Since the column config is stored and fetched separately from the preset list, it should never be invalidated by a preset save.

Fix:
usePresetActions — mutatePresetsList now uses isExact: true for the /preset key and prefix matching only for /preset? (query-string variants). This correctly invalidates the preset list without touching /preset/{id}/column-config.

usePresetColumnConfig — Removed the redundant revalidateMultiple(["/preset", "/preset?"]) call after saving column config. The hook's own mutate() already revalidates /preset/{presetId}/column-config; the extra call was unnecessary and subject to the same prefix-matching collateral damage.