### PR TITLE
fix: resolve "window is not defined" SSR crash on direct URL access to alerts page

### DIFF
--- a/keep-ui/app/(keep)/alerts/[id]/ui/__tests__/alerts-fingerprint.test.tsx
+++ b/keep-ui/app/(keep)/alerts/[id]/ui/__tests__/alerts-fingerprint.test.tsx
@@ -24,6 +24,7 @@ import Alerts from "../alerts";
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn(),
   useSearchParams: jest.fn(),
+  usePathname: jest.fn().mockReturnValue("/alerts/feed"),
 }));
 
 // ─── Mock data hooks ─────────────────────────────────────────────────────────

--- a/keep-ui/app/(keep)/alerts/[id]/ui/alerts.tsx
+++ b/keep-ui/app/(keep)/alerts/[id]/ui/alerts.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { type AlertDto, type AlertsQuery } from "@/entities/alerts/model";
 import { usePresets, type Preset } from "@/entities/presets/model";
 import { AlertHistoryModal } from "@/features/alerts/alert-history";
@@ -61,6 +61,7 @@ export default function Alerts({ presetName, initialFacets }: AlertsProps) {
     [providersData.installed_providers]
   );
 
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   // hooks for the note and ticket modals
   const [noteModalAlert, setNoteModalAlert] = useState<AlertDto | null>();
@@ -165,18 +166,16 @@ export default function Alerts({ presetName, initialFacets }: AlertsProps) {
   );
 
   const resetUrlAfterModal = useCallback(() => {
-    const currentParams = new URLSearchParams(window.location.search);
+    const currentParams = new URLSearchParams(searchParams?.toString() ?? "");
     Array.from(currentParams.keys())
       .filter((paramKey) => paramKey !== "cel")
       .forEach((paramKey) => currentParams.delete(paramKey));
-    let url = `${window.location.pathname}`;
-
-    if (currentParams.toString()) {
-      url += `?${currentParams.toString()}`;
-    }
+    const url = currentParams.toString()
+      ? `${pathname}?${currentParams.toString()}`
+      : pathname;
 
     router.replace(url);
-  }, [router]);
+  }, [router, pathname, searchParams]);
 
   // if we don't have presets data yet, just show loading
   if (!selectedPreset && isPresetsLoading) {

--- a/keep-ui/app/(keep)/alerts/fingerprint/[fp]/page.tsx
+++ b/keep-ui/app/(keep)/alerts/fingerprint/[fp]/page.tsx
@@ -1,0 +1,18 @@
+import { AlertFingerprintPage } from "./ui/alert-fingerprint-page";
+
+type PageProps = {
+  params: Promise<{ fp: string }>;
+};
+
+export default async function Page({ params }: PageProps) {
+  const { fp } = await params;
+  return <AlertFingerprintPage fingerprint={fp} />;
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { fp } = await params;
+  return {
+    title: `Keep - Alert ${fp}`,
+    description: "View alert details",
+  };
+}

--- a/keep-ui/app/(keep)/alerts/fingerprint/[fp]/ui/alert-fingerprint-page.tsx
+++ b/keep-ui/app/(keep)/alerts/fingerprint/[fp]/ui/alert-fingerprint-page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useAlerts } from "@/entities/alerts/model";
+import { ViewAlertModal } from "@/features/alerts/view-raw-alert";
+import { KeepLoader } from "@/shared/ui";
+import NotFound from "@/app/(keep)/not-found";
+
+interface AlertFingerprintPageProps {
+  fingerprint: string;
+}
+
+export function AlertFingerprintPage({ fingerprint }: AlertFingerprintPageProps) {
+  const router = useRouter();
+  const { useAlertByFingerprint } = useAlerts();
+  const { data: alert, error, isLoading, mutate } = useAlertByFingerprint(fingerprint);
+
+  if (isLoading) {
+    return <KeepLoader loadingText="Loading alert..." />;
+  }
+
+  if (error || !alert) {
+    return <NotFound />;
+  }
+
+  return (
+    <ViewAlertModal
+      alert={alert}
+      handleClose={() => router.replace("/alerts/feed")}
+      mutate={mutate}
+    />
+  );
+}

--- a/keep-ui/entities/alerts/model/useAlerts.ts
+++ b/keep-ui/entities/alerts/model/useAlerts.ts
@@ -108,6 +108,17 @@ export const useAlerts = () => {
     );
   };
 
+  const useAlertByFingerprint = (
+    fingerprint: string | null | undefined,
+    options: SWRConfiguration = { revalidateOnFocus: false }
+  ) => {
+    return useSWR<AlertDto>(
+      () => (api.isReady() && fingerprint ? `/alerts/${fingerprint}` : null),
+      (url) => api.get(url),
+      options
+    );
+  };
+
   const useErrorAlerts = (
     options: SWRConfiguration = { revalidateOnFocus: false }
   ) => {
@@ -220,6 +231,7 @@ export const useAlerts = () => {
     useAllAlerts,
     usePresetAlerts,
     useAlertAudit,
+    useAlertByFingerprint,
     useMultipleFingerprintsAlertAudit,
     useErrorAlerts,
     useLastAlerts,

--- a/keep-ui/shared/ui/MonacoCELEditor/MonacoCel.tsx
+++ b/keep-ui/shared/ui/MonacoCELEditor/MonacoCel.tsx
@@ -2,16 +2,11 @@
 
 import { Editor, EditorProps, loader } from "@monaco-editor/react";
 import { useEffect, useRef, useState } from "react";
-import * as monaco from "monaco-editor";
 
 interface MonacoCelProps extends EditorProps {
   onMonacoLoaded?: (monacoInstance: typeof import("monaco-editor")) => void;
   onMonacoLoadFailure?: (error: Error) => void;
 }
-
-// Monaco Editor - imported as an npm package instead of loading from the CDN to support air-gapped environments
-// https://github.com/suren-atoyan/monaco-react?tab=readme-ov-file#use-monaco-editor-as-an-npm-package
-loader.config({ monaco });
 
 export function MonacoCelBase(props: MonacoCelProps) {
   const [isLoaded, setIsLoaded] = useState(false);
@@ -25,8 +20,14 @@ export function MonacoCelBase(props: MonacoCelProps) {
   onMonacoLoadFailureRef.current = props.onMonacoLoadFailure;
 
   useEffect(() => {
-    loader
-      .init()
+    // Monaco Editor - imported as an npm package instead of loading from the
+    // CDN to support air-gapped environments.
+    // https://github.com/suren-atoyan/monaco-react?tab=readme-ov-file#use-monaco-editor-as-an-npm-package
+    import("monaco-editor")
+      .then((monaco) => {
+        loader.config({ monaco });
+        return loader.init();
+      })
       .then((monacoInstance) => {
         onMonacoLoadedRef.current?.(monacoInstance);
         setIsLoaded(true);

--- a/keep-ui/shared/ui/MonacoCELEditor/monaco-cel-editor.tsx
+++ b/keep-ui/shared/ui/MonacoCELEditor/monaco-cel-editor.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { ErrorComponent } from "../ErrorComponent/ErrorComponent";
 import { setupCustomCellanguage } from "./cel-support";
 import { MonacoCelBase } from "./MonacoCel";
-import { editor, Token } from "monaco-editor";
+import type { editor, Token } from "monaco-editor";
 import "./editor.scss";
 import { useCelValidation } from "./validation-hook";
 


### PR DESCRIPTION
**Problem**
Closes #6543
Directly loading any alerts URL (e.g. /alerts/feed?alertPayloadFingerprint=…) caused a server-side crash:

```
ReferenceError: window is not defined
  at .next/server/chunks/4585.js
  at .next/server/app/(keep)/rules/page.js
 ```
 
The root cause was monaco-editor being imported at module level in two files. monaco-editor is a browser-only library that accesses window during its own module initialisation. In Next.js App Router, "use client" components are still pre-rendered on the server (SSR), so any module-level import that touches window crashes the Node.js runtime before the page can render.

**Changes**
- Removed the top-level `import * as monaco from "monaco-editor"` and the module-level `loader.config({ monaco })` call.
- Moved both into a `useEffect` as a dynamic `import("monaco-editor")`, so they only ever execute in the browser.
shared/ui/MonacoCELEditor/monaco-cel-editor.tsx
- Changed `import { editor, Token } from "monaco-editor"` → `import type { editor, Token } from "monaco-editor"`.
- Replaced `window.location.search` and `window.location.pathname` inside `resetUrlAfterModal` with Next.js's `usePathname()` and `useSearchParams()` hooks.
- Adds `usePathname` to the import and wires it into the useCallback dependency array.
- Implement a full permanent link approach by adding a new route `/alerts/fingerprint/<fp>` page.