### PR TITLE
feat: provision mapping rules from a directory at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,6 +221,7 @@ workflow-yaml-json-schema.json
 
 tests/provision/*
 !tests/provision/workflows*
+!tests/provision/mapping_rules*
 grafana/*
 !grafana/provisioning/
 !grafana/dashboards/

--- a/docs/deployment/provision/mapping.mdx
+++ b/docs/deployment/provision/mapping.mdx
@@ -1,0 +1,75 @@
+---
+title: "Mapping Rule Provisioning"
+---
+
+<Tip>For any questions or issues related to mapping rule provisioning, please join our [Slack](https://slack.keephq.dev) community.</Tip>
+
+Mapping rule provisioning in Keep allows you to manage CSV-style alert enrichment rules in version control rather than the UI. This is useful when you want to track mapping changes alongside the rest of your infrastructure-as-code.
+
+### Configuring Mapping Rules
+
+To provision mapping rules, follow these steps:
+
+1. Set the `KEEP_MAPPINGS_DIRECTORY` environment variable to the path of your mapping configuration directory.
+2. Create one YAML manifest per mapping rule in that directory.
+
+Example directory structure:
+```
+/path/to/mappings/
+├── prometheus-by-namespace.yaml
+├── cloudwatch-by-team.yaml
+└── service-topology.yaml
+```
+
+### Manifest format
+
+Each YAML manifest describes one mapping rule. Fields mirror the fields accepted by the REST `POST /mapping` endpoint:
+
+```yaml
+name: example-prometheus-mapping
+description: optional description
+priority: 0
+type: csv
+matchers:
+  - [namespace]
+rows:
+  - { namespace: monitoring, team: platform }
+  - { namespace: default, team: platform }
+```
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `name` | yes | Lookup key — must be unique across the tenant |
+| `description` | no | Human-readable description |
+| `priority` | no | Integer, default `0`. Higher = evaluated first |
+| `type` | no | `csv` (default) or `topology` |
+| `matchers` | yes | List of attribute groups. Within a list: AND. Between lists: OR |
+| `rows` | yes for `csv` | List of `{key: value}` dicts; rows match against incoming alert attributes |
+| `is_multi_level` | no | Default `false` |
+| `new_property_name` | no | Required if `is_multi_level` is `true` |
+| `prefix_to_remove` | no | Optional, used with multi-level mappings |
+
+### Update Provisioned Mapping Rules
+
+On every restart, Keep reads the `KEEP_MAPPINGS_DIRECTORY` environment variable and determines which mapping rules need to be added, removed, or updated.
+
+The high-level provisioning mechanism:
+1. Keep reads the `KEEP_MAPPINGS_DIRECTORY` value.
+2. Keep lists all `.yaml`/`.yml` files under the directory (other files are skipped).
+3. For each manifest: lookup an existing rule by `name`. If found, update it and mark `is_provisioned=True`. If not, create a new provisioned rule.
+4. Provisioned rules whose source file is no longer present in the directory are deprovisioned (deleted).
+5. UI-created rules (`is_provisioned=False`) whose name does not appear in any manifest are untouched.
+
+### Adoption of existing UI rules
+
+If a mapping rule already exists in the UI with the same `name` as one of your manifests, the next provisioning run **adopts** it: `is_provisioned` flips to `True`, the rule's `provisioned_file` is recorded, and its content is overwritten from the manifest. The database id is preserved, so any external references to that rule (URLs, dashboards) continue to work.
+
+Fields not present in the manifest schema (`disabled`, `override`, `condition`) are reset to their model defaults on adoption — the manifest is the source of truth, so a rule that was disabled via the UI will be re-enabled when adopted.
+
+### Removing all provisioned mapping rules
+
+If `KEEP_MAPPINGS_DIRECTORY` is unset on a Keep instance that previously had provisioned rules, all of them are deprovisioned (deleted) on the next restart. UI-only rules are unaffected.
+
+### Per-manifest failures
+
+A malformed manifest (invalid YAML, missing required fields, validation errors) is logged and skipped. Other manifests in the directory still process normally. Each successful manifest is committed in its own transaction, so a later failure does not roll back earlier work.

--- a/docs/deployment/provision/overview.mdx
+++ b/docs/deployment/provision/overview.mdx
@@ -6,11 +6,12 @@ Keep supports various deployment and provisioning strategies to accommodate diff
 
 ### Provisioning Options
 
-Keep offers three main provisioning options:
+Keep offers four main provisioning options:
 
 1. [**Provider Provisioning**](/deployment/provision/provider) - Set up and manage data providers with their deduplication rules for Keep.
 2. [**Workflow Provisioning**](/deployment/provision/workflow) - Configure and manage workflows within Keep.
 3. [**Dashboard Provisioning**](/deployment/provision/dashboard) - Configure and manage dashboards within Keep.
+4. [**Mapping Rule Provisioning**](/deployment/provision/mapping) - Configure and manage CSV-style alert enrichment rules within Keep.
 
 
 Choosing the right provisioning strategy depends on your specific use case, deployment environment, and scalability requirements. You can read more about each provisioning option in their respective sections.
@@ -30,6 +31,7 @@ Provisioning in Keep is controlled through environment variables and configurati
 | **Workflow**           | `KEEP_WORKFLOW`                | One workflow to provision right from the env variable.                    |
 | **Workflows**          | `KEEP_WORKFLOWS_DIRECTORY`     | Directory path containing workflow configuration files                    |
 | **Dashboard**          | `KEEP_DASHBOARDS`              | JSON string containing dashboard configurations                           |
+| **Mapping Rules**      | `KEEP_MAPPINGS_DIRECTORY`      | Directory path containing mapping rule YAML manifests                     |
 
 Hint: use the script to get 1-liner from the workflow file for KEEP_WORKFLOW:
 ```

--- a/keep/api/bl/mapping_rules_provisioning.py
+++ b/keep/api/bl/mapping_rules_provisioning.py
@@ -103,21 +103,24 @@ def provision_mapping_rules_from_env(tenant_id: str):
             try:
                 _provision_one(session, tenant_id, path)
                 session.commit()
-            except Exception as exc:
-                logger.error(
-                    "Failed to provision mapping rule from %s",
-                    path,
-                    extra={"exception": exc},
-                )
+            except Exception:
+                logger.exception("Failed to provision mapping rule from %s", path)
                 session.rollback()
 
 
 def _collect_manifest_paths(mappings_dir: str) -> list[str]:
-    """Return sorted absolute paths of YAML manifests in the directory."""
+    """Return sorted absolute paths of YAML manifests in the directory.
+
+    Paths are normalized via os.path.abspath so set-membership comparison
+    against MappingRule.provisioned_file (also stored as abspath) stays stable
+    across runs even if cwd or KEEP_MAPPINGS_DIRECTORY shape (relative vs
+    absolute) changes between restarts.
+    """
+    abs_dir = os.path.abspath(mappings_dir)
     paths = []
-    for filename in sorted(os.listdir(mappings_dir)):
+    for filename in sorted(os.listdir(abs_dir)):
         if filename.endswith((".yaml", ".yml")):
-            paths.append(os.path.join(mappings_dir, filename))
+            paths.append(os.path.join(abs_dir, filename))
         else:
             logger.info("Skipping non-YAML file %s in mappings directory", filename)
     return paths

--- a/keep/api/bl/mapping_rules_provisioning.py
+++ b/keep/api/bl/mapping_rules_provisioning.py
@@ -1,0 +1,212 @@
+import datetime
+import logging
+import os
+
+from sqlmodel import Session, select
+
+import keep.api.core.db as db
+from keep.api.models.db.mapping import MappingRule, MappingRuleDtoIn
+from keep.functions import cyaml
+
+logger = logging.getLogger(__name__)
+
+KEEP_MAPPINGS_DIRECTORY_ENV_VAR = "KEEP_MAPPINGS_DIRECTORY"
+SYSTEM_ACTOR = "system"
+
+
+def provision_mapping_rules_from_env(tenant_id: str):
+    """Provision mapping rules from `KEEP_MAPPINGS_DIRECTORY` for a given tenant.
+
+    Mirrors `WorkflowStore.provision_workflows` (directory-based, per-file YAML).
+    Each YAML manifest in the directory describes one mapping rule:
+
+        name: example-prometheus-mapping
+        description: optional
+        priority: 0
+        type: csv
+        matchers:
+          - [namespace]
+        rows:
+          - { namespace: monitoring, team: platform }
+
+    Behavior on every backend startup:
+      - For each `.yaml`/`.yml` file in the directory: upsert by `name`. An
+        existing rule with the same name (whether UI-created or previously
+        provisioned) is adopted: `is_provisioned=True`, `provisioned_file=<path>`,
+        contents overwritten from the manifest (including a reset of
+        `disabled`/`override`/`condition` to their model defaults, since the
+        manifest is the source of truth).
+      - For DB rows with `is_provisioned=True` whose `provisioned_file` no
+        longer exists or is outside the directory: delete (deprovision).
+      - UI-created mapping rules (`is_provisioned=False`) whose name does not
+        appear in any manifest are untouched.
+
+    If `KEEP_MAPPINGS_DIRECTORY` is unset and any provisioned mapping rules
+    exist in DB, they are deprovisioned (deleted).
+
+    Per-manifest failures (malformed YAML, validation errors) are logged and
+    the offending manifest is skipped; other manifests in the directory still
+    process. Each manifest is committed in its own transaction.
+    """
+    mappings_dir = os.environ.get(KEEP_MAPPINGS_DIRECTORY_ENV_VAR)
+
+    with Session(db.engine) as session:
+        existing_provisioned = session.exec(
+            select(MappingRule).where(
+                MappingRule.tenant_id == tenant_id,
+                MappingRule.is_provisioned == True,  # noqa: E712
+            )
+        ).all()
+
+        if not mappings_dir:
+            if existing_provisioned:
+                logger.info(
+                    "KEEP_MAPPINGS_DIRECTORY unset; deprovisioning %d existing rule(s)",
+                    len(existing_provisioned),
+                )
+                for rule in existing_provisioned:
+                    _delete_rule(session, rule)
+                session.commit()
+            else:
+                logger.info("No mapping rules to provision and none currently provisioned")
+            return
+
+        if not os.path.isdir(mappings_dir):
+            raise FileNotFoundError(
+                f"KEEP_MAPPINGS_DIRECTORY '{mappings_dir}' does not exist or is not a directory"
+            )
+
+        manifest_paths = _collect_manifest_paths(mappings_dir)
+        logger.info(
+            "Provisioning %d mapping manifest(s) from %s", len(manifest_paths), mappings_dir
+        )
+
+        # Deprovision rules whose source file is missing or outside the directory
+        manifest_paths_set = set(manifest_paths)
+        for rule in existing_provisioned:
+            if (
+                rule.provisioned_file is None
+                or not os.path.exists(rule.provisioned_file)
+                or rule.provisioned_file not in manifest_paths_set
+            ):
+                logger.info(
+                    "Deprovisioning mapping rule '%s' (file %s no longer present)",
+                    rule.name,
+                    rule.provisioned_file,
+                )
+                _delete_rule(session, rule)
+        session.commit()
+
+        # Provision (create or update) each manifest. Commit per-manifest so a
+        # failure of manifest N does not roll back manifests 1..N-1.
+        for path in manifest_paths:
+            try:
+                _provision_one(session, tenant_id, path)
+                session.commit()
+            except Exception as exc:
+                logger.error(
+                    "Failed to provision mapping rule from %s",
+                    path,
+                    extra={"exception": exc},
+                )
+                session.rollback()
+
+
+def _collect_manifest_paths(mappings_dir: str) -> list[str]:
+    """Return sorted absolute paths of YAML manifests in the directory."""
+    paths = []
+    for filename in sorted(os.listdir(mappings_dir)):
+        if filename.endswith((".yaml", ".yml")):
+            paths.append(os.path.join(mappings_dir, filename))
+        else:
+            logger.info("Skipping non-YAML file %s in mappings directory", filename)
+    return paths
+
+
+def _provision_one(session: Session, tenant_id: str, manifest_path: str) -> None:
+    """Provision a single mapping rule from a YAML manifest file.
+
+    Looks up an existing rule by name (across all rules, regardless of
+    `is_provisioned`). If found, updates it and marks it provisioned. Otherwise
+    creates a new provisioned rule.
+    """
+    with open(manifest_path, "r", encoding="utf-8") as fh:
+        raw = cyaml.safe_load(fh.read())
+
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"Manifest {manifest_path} must be a YAML mapping (got {type(raw).__name__})"
+        )
+
+    # Validate against the same DTO used by the REST POST endpoint
+    dto = MappingRuleDtoIn(**raw)
+
+    existing = session.exec(
+        select(MappingRule).where(
+            MappingRule.tenant_id == tenant_id,
+            MappingRule.name == dto.name,
+        )
+    ).first()
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    if existing is not None:
+        logger.info(
+            "Adopting mapping rule '%s' from %s (provisioned=%s -> True)",
+            dto.name,
+            manifest_path,
+            existing.is_provisioned,
+        )
+        existing.name = dto.name
+        existing.description = dto.description
+        existing.file_name = dto.file_name
+        existing.priority = dto.priority
+        existing.matchers = dto.matchers
+        existing.type = dto.type
+        existing.is_multi_level = dto.is_multi_level
+        existing.new_property_name = dto.new_property_name
+        existing.prefix_to_remove = dto.prefix_to_remove
+        existing.rows = dto.rows
+        # Fields not present in MappingRuleDtoIn are reset to model defaults
+        # — the manifest is the source of truth, so a UI rule that was e.g.
+        # disabled via the UI should NOT remain disabled after adoption.
+        existing.disabled = False
+        existing.override = True
+        existing.condition = None
+        existing.is_provisioned = True
+        existing.provisioned_file = manifest_path
+        existing.updated_by = SYSTEM_ACTOR
+        existing.last_updated_at = now
+        # SQLAlchemy auto-tracks attribute mutations on attached instances;
+        # no explicit session.add() needed for the existing-rule branch.
+        return
+
+    logger.info("Provisioning new mapping rule '%s' from %s", dto.name, manifest_path)
+    rule = MappingRule(
+        tenant_id=tenant_id,
+        name=dto.name,
+        description=dto.description,
+        file_name=dto.file_name,
+        priority=dto.priority,
+        matchers=dto.matchers,
+        type=dto.type,
+        is_multi_level=dto.is_multi_level,
+        new_property_name=dto.new_property_name,
+        prefix_to_remove=dto.prefix_to_remove,
+        rows=dto.rows,
+        is_provisioned=True,
+        provisioned_file=manifest_path,
+        created_by=SYSTEM_ACTOR,
+        created_at=now,
+        last_updated_at=now,
+    )
+    session.add(rule)
+    # Flush so a subsequent same-name manifest in the same batch sees this
+    # row via lookup-by-name (matters when sessions disable autoflush, e.g.
+    # in some test fixtures).
+    session.flush()
+
+
+def _delete_rule(session: Session, rule: MappingRule) -> None:
+    """Delete a mapping rule from the DB. Caller is responsible for committing."""
+    session.delete(rule)

--- a/keep/api/config.py
+++ b/keep/api/config.py
@@ -6,6 +6,7 @@ from keep.api.alert_deduplicator.deduplication_rules_provisioning import (
     provision_deduplication_rules_from_env,
 )
 from keep.api.api import AUTH_TYPE
+from keep.api.bl.mapping_rules_provisioning import provision_mapping_rules_from_env
 from keep.api.core.db_on_start import migrate_db, try_create_single_tenant
 from keep.api.core.dependencies import SINGLE_TENANT_UUID
 from keep.api.core.tenant_configuration import TenantConfiguration
@@ -36,6 +37,9 @@ def provision_resources():
         logger.info("Provisioning deduplication rules")
         provision_deduplication_rules_from_env(SINGLE_TENANT_UUID)
         logger.info("Deduplication rules provisioned successfully")
+        logger.info("Provisioning mapping rules")
+        provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+        logger.info("Mapping rules provisioned successfully")
     else:
         logger.info("Provisioning resources is disabled")
 

--- a/keep/api/models/db/mapping.py
+++ b/keep/api/models/db/mapping.py
@@ -41,6 +41,11 @@ class MappingRule(SQLModel, table=True):
     is_multi_level: bool = Field(default=False)
     new_property_name: Optional[str] = Field(max_length=255)
     prefix_to_remove: Optional[str] = Field(max_length=255)
+    # Provisioning fields (set when the rule is loaded from KEEP_MAPPINGS_DIRECTORY at startup)
+    is_provisioned: bool = Field(default=False)
+    # Uncapped (no max_length) — real GitOps mount paths regularly exceed 255 chars.
+    # Mirrors Workflow.provisioned_file.
+    provisioned_file: Optional[str] = Field(default=None)
 
 
 class MappRuleDtoBase(BaseModel):

--- a/keep/api/models/db/migrations/versions/2026-05-28-16-50_67ff7efffed4.py
+++ b/keep/api/models/db/migrations/versions/2026-05-28-16-50_67ff7efffed4.py
@@ -1,0 +1,42 @@
+"""feat: add is_provisioned and provisioned_file to MappingRule
+
+Revision ID: 67ff7efffed4
+Revises: 9dd1be4539e0
+Create Date: 2026-05-28 16:50:00.000000
+
+"""
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "67ff7efffed4"
+down_revision = "9dd1be4539e0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("mappingrule", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_provisioned",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "provisioned_file",
+                sqlmodel.sql.sqltypes.AutoString(),
+                nullable=True,
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("mappingrule", schema=None) as batch_op:
+        batch_op.drop_column("provisioned_file")
+        batch_op.drop_column("is_provisioned")

--- a/keep/api/routes/mapping.py
+++ b/keep/api/routes/mapping.py
@@ -141,6 +141,12 @@ def delete_rule(
     if rule is None:
         raise HTTPException(status_code=404, detail="Rule not found")
 
+    if rule.is_provisioned:
+        raise HTTPException(
+            status_code=409,
+            detail="Provisioned mapping rule cannot be deleted",
+        )
+
     session.delete(rule)
     session.commit()
     logger.info("Deleted a mapping rule", extra={"rule_id": rule_id})
@@ -167,6 +173,11 @@ def update_rule(
     )
     if existing_rule is None:
         raise HTTPException(status_code=404, detail="Rule not found")
+    if existing_rule.is_provisioned:
+        raise HTTPException(
+            status_code=409,
+            detail="Provisioned mapping rule cannot be updated",
+        )
     existing_rule.name = rule.name
     existing_rule.description = rule.description
     existing_rule.matchers = rule.matchers

--- a/tests/provision/mapping_rules_1/prometheus-alerts.yaml
+++ b/tests/provision/mapping_rules_1/prometheus-alerts.yaml
@@ -1,0 +1,15 @@
+name: example-prometheus-mapping
+description: Example mapping that routes Prometheus alerts to a Slack provider by namespace
+priority: 0
+type: csv
+matchers:
+  - [namespace]
+rows:
+  - namespace: monitoring
+    team: platform
+    slack_warning: platform-warning
+    slack_critical: platform-critical
+  - namespace: default
+    team: platform
+    slack_warning: platform-warning
+    slack_critical: platform-critical

--- a/tests/provision/mapping_rules_2/cloudwatch-alerts.yaml
+++ b/tests/provision/mapping_rules_2/cloudwatch-alerts.yaml
@@ -1,0 +1,13 @@
+name: example-cloudwatch-mapping
+description: Example CloudWatch-by-team mapping
+priority: 10
+type: csv
+matchers:
+  - [team]
+rows:
+  - team: platform
+    slack_warning: platform-warning
+    slack_critical: platform-critical
+  - team: data
+    slack_warning: data-alerts
+    slack_critical: data-alerts

--- a/tests/provision/mapping_rules_2/prometheus-alerts.yaml
+++ b/tests/provision/mapping_rules_2/prometheus-alerts.yaml
@@ -1,0 +1,11 @@
+name: example-prometheus-mapping
+description: Example Prometheus-by-namespace mapping
+priority: 0
+type: csv
+matchers:
+  - [namespace]
+rows:
+  - namespace: monitoring
+    team: platform
+  - namespace: default
+    team: data

--- a/tests/provision/mapping_rules_invalid/good.yaml
+++ b/tests/provision/mapping_rules_invalid/good.yaml
@@ -1,0 +1,8 @@
+name: valid-mapping
+priority: 0
+type: csv
+matchers:
+  - [namespace]
+rows:
+  - namespace: monitoring
+    team: devops

--- a/tests/provision/mapping_rules_invalid/zzz-bad-missing-rows.yaml
+++ b/tests/provision/mapping_rules_invalid/zzz-bad-missing-rows.yaml
@@ -1,0 +1,6 @@
+name: bad-mapping-no-rows
+priority: 0
+type: csv
+matchers:
+  - [namespace]
+# 'rows' is missing — should be rejected by MappingRuleDtoIn validator (csv type requires rows)

--- a/tests/provision/mapping_rules_same_name/a-first.yaml
+++ b/tests/provision/mapping_rules_same_name/a-first.yaml
@@ -1,0 +1,8 @@
+name: duplicate-name-mapping
+priority: 0
+type: csv
+matchers:
+  - [namespace]
+rows:
+  - namespace: monitoring
+    team: platform

--- a/tests/provision/mapping_rules_same_name/b-second.yaml
+++ b/tests/provision/mapping_rules_same_name/b-second.yaml
@@ -1,0 +1,8 @@
+name: duplicate-name-mapping
+priority: 99
+type: csv
+matchers:
+  - [namespace]
+rows:
+  - namespace: default
+    team: data

--- a/tests/provision/mapping_rules_with_noise/example.yaml
+++ b/tests/provision/mapping_rules_with_noise/example.yaml
@@ -1,0 +1,8 @@
+name: example-prometheus-mapping
+priority: 0
+type: csv
+matchers:
+  - [namespace]
+rows:
+  - namespace: monitoring
+    team: platform

--- a/tests/provision/mapping_rules_with_noise/notes.txt
+++ b/tests/provision/mapping_rules_with_noise/notes.txt
@@ -1,0 +1,1 @@
+This is not a YAML file. The provisioner should skip it without erroring.

--- a/tests/test_mapping_rules_provisioning.py
+++ b/tests/test_mapping_rules_provisioning.py
@@ -1,0 +1,289 @@
+"""Tests for keep.api.bl.mapping_rules_provisioning.provision_mapping_rules_from_env.
+
+Mirrors the structure of tests/test_workflowstore.py — uses real in-memory SQLite
+sessions (via the `db_session` fixture from tests/conftest.py) rather than
+patching DB helpers, because the provisioning module operates on SQLModel
+sessions directly (same pattern as the existing MappingRule REST routes).
+"""
+
+import os
+
+import pytest
+from sqlmodel import Session, select
+
+import keep.api.core.db as db
+from keep.api.bl.mapping_rules_provisioning import provision_mapping_rules_from_env
+from keep.api.core.dependencies import SINGLE_TENANT_UUID
+from keep.api.models.db.mapping import MappingRule
+
+FIXTURE_DIR_ONE = "./tests/provision/mapping_rules_1"
+FIXTURE_DIR_TWO = "./tests/provision/mapping_rules_2"
+FIXTURE_DIR_INVALID = "./tests/provision/mapping_rules_invalid"
+FIXTURE_DIR_EMPTY = "./tests/provision/mapping_rules_empty"
+FIXTURE_DIR_MISSING = "./tests/provision/mapping_rules_does_not_exist"
+FIXTURE_DIR_SAME_NAME = "./tests/provision/mapping_rules_same_name"
+FIXTURE_DIR_WITH_NOISE = "./tests/provision/mapping_rules_with_noise"
+
+
+def _all_mapping_rules(tenant_id=SINGLE_TENANT_UUID) -> list[MappingRule]:
+    with Session(db.engine) as session:
+        return session.exec(
+            select(MappingRule).where(MappingRule.tenant_id == tenant_id)
+        ).all()
+
+
+def _provisioned_mapping_rules(tenant_id=SINGLE_TENANT_UUID) -> list[MappingRule]:
+    with Session(db.engine) as session:
+        return session.exec(
+            select(MappingRule).where(
+                MappingRule.tenant_id == tenant_id,
+                MappingRule.is_provisioned == True,  # noqa: E712
+            )
+        ).all()
+
+
+def test_creates_new_rule(monkeypatch, db_session):
+    """Empty DB + manifest dir → rule is created and marked provisioned."""
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_ONE)
+
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    rules = _provisioned_mapping_rules()
+    assert len(rules) == 1
+    rule = rules[0]
+    assert rule.name == "example-prometheus-mapping"
+    assert rule.is_provisioned is True
+    assert rule.provisioned_file.endswith("prometheus-alerts.yaml")
+    assert rule.type == "csv"
+    assert rule.matchers == [["namespace"]]
+    assert len(rule.rows) == 2
+    assert rule.rows[0]["namespace"] == "monitoring"
+    assert rule.created_by == "system"
+
+
+def test_provisions_multiple_rules(monkeypatch, db_session):
+    """Two manifests in dir → both rules provisioned."""
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_TWO)
+
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    rules = _provisioned_mapping_rules()
+    names = sorted(r.name for r in rules)
+    assert names == ["example-cloudwatch-mapping", "example-prometheus-mapping"]
+
+
+def test_is_idempotent(monkeypatch, db_session):
+    """Running provisioning twice does not create duplicates."""
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_TWO)
+
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+    first_ids = sorted(r.id for r in _provisioned_mapping_rules())
+    assert len(first_ids) == 2
+
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+    second_ids = sorted(r.id for r in _provisioned_mapping_rules())
+
+    assert first_ids == second_ids
+
+
+def test_adopts_existing_ui_rule_with_matching_name(monkeypatch, db_session):
+    """A UI-created rule (is_provisioned=False) with the same name as a manifest
+    gets adopted: is_provisioned flips to True, content overwritten, DB id
+    preserved, AND fields not in the manifest schema (disabled / override /
+    condition) reset to model defaults — the manifest is the source of truth.
+    """
+    with Session(db.engine) as session:
+        ui_rule = MappingRule(
+            tenant_id=SINGLE_TENANT_UUID,
+            name="example-prometheus-mapping",
+            description="created via UI",
+            priority=99,
+            matchers=[["something-different"]],
+            type="csv",
+            rows=[{"x": "y"}],
+            created_by="ui-user@example.com",
+            is_provisioned=False,
+            # Fields NOT in MappingRuleDtoIn — should be reset on adoption
+            disabled=True,
+            override=False,
+            condition="some.ui.set.condition",
+        )
+        session.add(ui_rule)
+        session.commit()
+        ui_rule_id = ui_rule.id
+
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_ONE)
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    rules = _all_mapping_rules()
+    assert len(rules) == 1  # adopted, not duplicated
+    adopted = rules[0]
+    assert adopted.id == ui_rule_id  # DB id preserved
+    assert adopted.is_provisioned is True
+    assert adopted.matchers == [["namespace"]]  # overwritten from manifest
+    assert adopted.priority == 0  # overwritten from manifest
+    assert adopted.updated_by == "system"
+    # Fields not in MappingRuleDtoIn reset to model defaults
+    assert adopted.disabled is False
+    assert adopted.override is True
+    assert adopted.condition is None
+
+
+def test_same_name_manifests_do_not_create_duplicate(monkeypatch, db_session):
+    """Two manifests in the same directory with the same `name` field result in
+    exactly one DB row (the second manifest acts as an in-batch update). Guards
+    against duplicate creation when SQLAlchemy autoflush is disabled.
+    """
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_SAME_NAME)
+
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    rules = _all_mapping_rules()
+    assert len(rules) == 1, (
+        f"expected 1 rule (duplicate names collapsed), got {len(rules)}: "
+        f"{[(r.name, r.priority) for r in rules]}"
+    )
+    # b-second.yaml sorts after a-first.yaml; final state is the second manifest's
+    assert rules[0].name == "duplicate-name-mapping"
+    assert rules[0].priority == 99
+    assert rules[0].rows[0]["namespace"] == "default"
+
+
+def test_non_yaml_files_in_directory_are_ignored(monkeypatch, db_session):
+    """Non-`.yaml`/`.yml` files (e.g. README, .gitkeep, .txt) in the directory
+    are silently skipped — they don't raise, don't block, don't get parsed.
+    """
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_WITH_NOISE)
+
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    rules = _provisioned_mapping_rules()
+    # Only the one .yaml file in the dir produces a rule; notes.txt is skipped
+    assert len(rules) == 1
+    assert rules[0].name == "example-prometheus-mapping"
+
+
+def test_updates_existing_provisioned_rule(monkeypatch, db_session):
+    """A previously-provisioned rule gets its content refreshed from the manifest."""
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_ONE)
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    first = _provisioned_mapping_rules()[0]
+    original_id = first.id
+
+    # Pretend the DB content drifted (simulating someone editing via UI directly)
+    with Session(db.engine) as session:
+        rule = session.exec(
+            select(MappingRule).where(MappingRule.id == original_id)
+        ).first()
+        rule.priority = 42
+        session.add(rule)
+        session.commit()
+
+    # Re-run provisioning — should reset priority back to manifest value (0)
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    refreshed = _provisioned_mapping_rules()
+    assert len(refreshed) == 1
+    assert refreshed[0].id == original_id
+    assert refreshed[0].priority == 0
+
+
+def test_deprovisions_when_manifest_file_disappears(monkeypatch, db_session):
+    """A rule provisioned from a file that's no longer in the directory is deleted."""
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_TWO)
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+    assert len(_provisioned_mapping_rules()) == 2
+
+    # Swap to a dir containing only one of the two manifests (by name)
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_ONE)
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    remaining = _provisioned_mapping_rules()
+    assert len(remaining) == 1
+    assert remaining[0].name == "example-prometheus-mapping"
+
+
+def test_deprovisions_all_when_env_unset(monkeypatch, db_session):
+    """Unsetting KEEP_MAPPINGS_DIRECTORY deletes all currently-provisioned rules."""
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_TWO)
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+    assert len(_provisioned_mapping_rules()) == 2
+
+    monkeypatch.delenv("KEEP_MAPPINGS_DIRECTORY")
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    assert len(_provisioned_mapping_rules()) == 0
+
+
+def test_leaves_unrelated_ui_rules_untouched(monkeypatch, db_session):
+    """A UI rule whose name does NOT match any manifest is left alone."""
+    with Session(db.engine) as session:
+        ui_rule = MappingRule(
+            tenant_id=SINGLE_TENANT_UUID,
+            name="some-ui-only-rule-not-in-manifests",
+            priority=5,
+            matchers=[["unrelated"]],
+            type="csv",
+            rows=[{"unrelated": "yes"}],
+            created_by="ui-user@example.com",
+            is_provisioned=False,
+        )
+        session.add(ui_rule)
+        session.commit()
+        ui_rule_id = ui_rule.id
+
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_ONE)
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    # UI rule still exists, still not provisioned
+    with Session(db.engine) as session:
+        rule = session.exec(
+            select(MappingRule).where(MappingRule.id == ui_rule_id)
+        ).first()
+        assert rule is not None
+        assert rule.is_provisioned is False
+        assert rule.priority == 5
+
+    all_rules = _all_mapping_rules()
+    assert len(all_rules) == 2  # the UI rule + the provisioned one
+
+
+def test_raises_when_directory_missing(monkeypatch, db_session):
+    """Pointing KEEP_MAPPINGS_DIRECTORY at a non-existent path raises FileNotFoundError."""
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_MISSING)
+    with pytest.raises(FileNotFoundError):
+        provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+
+def test_invalid_manifest_does_not_break_valid_one(monkeypatch, db_session):
+    """A malformed manifest is logged and skipped; valid manifests in the same dir still provision."""
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_INVALID)
+
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    rules = _provisioned_mapping_rules()
+    assert len(rules) == 1
+    assert rules[0].name == "valid-mapping"
+
+
+def test_noop_when_env_unset_and_no_provisioned_rules(monkeypatch, db_session):
+    """Calling with no env and no provisioned rules in DB is a clean no-op."""
+    monkeypatch.delenv("KEEP_MAPPINGS_DIRECTORY", raising=False)
+    # No rules to start with
+    assert len(_all_mapping_rules()) == 0
+
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    assert len(_all_mapping_rules()) == 0
+
+
+def test_empty_directory_deprovisions_existing(monkeypatch, db_session):
+    """An empty dir is treated like 'no manifests' — existing provisioned rules deleted."""
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_ONE)
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+    assert len(_provisioned_mapping_rules()) == 1
+
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_EMPTY)
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+    assert len(_provisioned_mapping_rules()) == 0

--- a/tests/test_mapping_rules_provisioning.py
+++ b/tests/test_mapping_rules_provisioning.py
@@ -6,15 +6,19 @@ patching DB helpers, because the provisioning module operates on SQLModel
 sessions directly (same pattern as the existing MappingRule REST routes).
 """
 
+import datetime
 import os
 
 import pytest
+from fastapi import HTTPException
 from sqlmodel import Session, select
 
 import keep.api.core.db as db
 from keep.api.bl.mapping_rules_provisioning import provision_mapping_rules_from_env
 from keep.api.core.dependencies import SINGLE_TENANT_UUID
-from keep.api.models.db.mapping import MappingRule
+from keep.api.models.db.mapping import MappingRule, MappingRuleUpdateDtoIn
+from keep.api.routes.mapping import delete_rule, update_rule
+from keep.identitymanager.authenticatedentity import AuthenticatedEntity
 
 FIXTURE_DIR_ONE = "./tests/provision/mapping_rules_1"
 FIXTURE_DIR_TWO = "./tests/provision/mapping_rules_2"
@@ -287,3 +291,76 @@ def test_empty_directory_deprovisions_existing(monkeypatch, db_session):
     monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_EMPTY)
     provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
     assert len(_provisioned_mapping_rules()) == 0
+
+
+def _seed_provisioned_rule(session: Session) -> MappingRule:
+    """Insert a provisioned MappingRule directly so REST guard tests don't depend on the directory loop."""
+    rule = MappingRule(
+        tenant_id=SINGLE_TENANT_UUID,
+        name="example-prometheus-mapping",
+        description="seeded for REST guard test",
+        priority=0,
+        matchers=[["namespace"]],
+        rows=[{"namespace": "monitoring", "team": "platform"}],
+        type="csv",
+        created_by="system",
+        created_at=datetime.datetime.now(tz=datetime.timezone.utc),
+        is_provisioned=True,
+        provisioned_file="/path/to/manifest.yaml",
+    )
+    session.add(rule)
+    session.commit()
+    session.refresh(rule)
+    return rule
+
+
+def _entity() -> AuthenticatedEntity:
+    return AuthenticatedEntity(tenant_id=SINGLE_TENANT_UUID, email="test@example.com")
+
+
+def test_delete_route_rejects_provisioned_rule(db_session):
+    """REST DELETE on a provisioned rule returns 409, mirroring the dedupe guard."""
+    rule = _seed_provisioned_rule(db_session)
+
+    with pytest.raises(HTTPException) as exc_info:
+        delete_rule(
+            rule_id=rule.id,
+            authenticated_entity=_entity(),
+            session=db_session,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "Provisioned mapping rule cannot be deleted" in exc_info.value.detail
+
+    # rule is still in DB — guard short-circuited before delete
+    assert db_session.get(MappingRule, rule.id) is not None
+
+
+def test_update_route_rejects_provisioned_rule(db_session):
+    """REST PUT on a provisioned rule returns 409, mirroring the dedupe guard."""
+    rule = _seed_provisioned_rule(db_session)
+    original_name = rule.name
+
+    update_payload = MappingRuleUpdateDtoIn(
+        name="renamed-by-ui",
+        description="ui edit attempt",
+        priority=99,
+        matchers=[["namespace"]],
+        type="csv",
+        rows=[{"namespace": "default", "team": "data"}],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        update_rule(
+            rule_id=rule.id,
+            rule=update_payload,
+            authenticated_entity=_entity(),
+            session=db_session,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "Provisioned mapping rule cannot be updated" in exc_info.value.detail
+
+    # rule is unchanged — guard short-circuited before mutation
+    db_session.refresh(rule)
+    assert rule.name == original_name

--- a/tests/test_mapping_rules_provisioning.py
+++ b/tests/test_mapping_rules_provisioning.py
@@ -293,6 +293,31 @@ def test_empty_directory_deprovisions_existing(monkeypatch, db_session):
     assert len(_provisioned_mapping_rules()) == 0
 
 
+def test_provisioned_file_is_absolute_and_stable_across_dir_form_changes(
+    monkeypatch, db_session
+):
+    """Stored provisioned_file is absolute; switching env var from relative to
+    absolute form between runs does not cause spurious deprovisioning."""
+    # First run with a RELATIVE directory
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", FIXTURE_DIR_ONE)
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    rules = _provisioned_mapping_rules()
+    assert len(rules) == 1
+    original_id = rules[0].id
+    assert os.path.isabs(rules[0].provisioned_file), (
+        f"provisioned_file should be absolute, got {rules[0].provisioned_file}"
+    )
+
+    # Second run with the SAME directory expressed as an absolute path
+    monkeypatch.setenv("KEEP_MAPPINGS_DIRECTORY", os.path.abspath(FIXTURE_DIR_ONE))
+    provision_mapping_rules_from_env(SINGLE_TENANT_UUID)
+
+    rules = _provisioned_mapping_rules()
+    assert len(rules) == 1, "rule should not have been deprovisioned"
+    assert rules[0].id == original_id, "rule id should be preserved"
+
+
 def _seed_provisioned_rule(session: Session) -> MappingRule:
     """Insert a provisioned MappingRule directly so REST guard tests don't depend on the directory loop."""
     rule = MappingRule(


### PR DESCRIPTION
Closes #4487.



## What

Adds `KEEP_MAPPINGS_DIRECTORY` support so mapping rules can be GitOps-managed (loaded from YAML files on every backend start), mirroring the existing `KEEP_WORKFLOWS_DIRECTORY` / `KEEP_PROVIDERS_DIRECTORY` / `KEEP_DEDUPLICATION_RULES` patterns. Closes the last config gap that required UI-only management.

Manifest format:

```yaml
# example: example-prometheus-mapping.yaml
name: example-prometheus-mapping
description: optional
priority: 0
type: csv
matchers:
  - [namespace]
rows:
  - { namespace: monitoring, team: platform }
```

## Behavior

Mirrors `provision_workflows` and `provision_deduplication_rules`:

- For each `.yaml`/`.yml` in `KEEP_MAPPINGS_DIRECTORY`: upsert by `name`. An existing rule with the same name (whether UI-created or previously provisioned) is adopted: `is_provisioned=True`, `provisioned_file=<path>`, contents overwritten from the manifest. **Fields not in `MappingRuleDtoIn` (`disabled`, `override`, `condition`) are reset to model defaults on adoption — the manifest is the source of truth.** DB id is preserved across re-runs.
- Each manifest is committed in its own transaction, so a malformed manifest only skips itself; earlier successful manifests stay applied.
- For DB rows with `is_provisioned=True` whose `provisioned_file` no longer exists or is outside the directory: delete (deprovision).
- UI-created mapping rules (`is_provisioned=False`) whose name does not appear in any manifest are untouched.
- If `KEEP_MAPPINGS_DIRECTORY` is unset and any provisioned rules exist in DB → all deprovisioned.
- If env var set + dir doesn't exist → `FileNotFoundError`.

## Changes

| File | What |
|---|---|
| `keep/api/models/db/mapping.py` | Adds `is_provisioned: bool` + `provisioned_file: Optional[str]` to `MappingRule` (no `max_length` on the path — real GitOps mount paths can exceed 255 chars, mirrors `Workflow.provisioned_file`) |
| `keep/api/models/db/migrations/versions/2026-05-28-16-50_67ff7efffed4.py` | Alembic migration for the two new columns (uses `batch_alter_table` for SQLite compatibility) |
| `keep/api/bl/mapping_rules_provisioning.py` | New module — `provision_mapping_rules_from_env`. Validates each manifest with the existing `MappingRuleDtoIn` DTO (no new validator). |
| `keep/api/config.py` | Wires `provision_mapping_rules_from_env(SINGLE_TENANT_UUID)` into `provision_resources()` after `provision_deduplication_rules_from_env` |
| `tests/test_mapping_rules_provisioning.py` | 14 tests using `db_session` fixture pattern from `tests/test_workflowstore.py` |
| `tests/provision/mapping_rules_{1,2,invalid,empty,same_name,with_noise}/...` | Fixture YAMLs (generic example names — `example-prometheus-mapping` etc.) |
| `docs/deployment/provision/mapping.mdx` | New docs page describing the manifest format, behavior, and adoption semantics |
| `docs/deployment/provision/overview.mdx` | Adds `KEEP_MAPPINGS_DIRECTORY` row to the env-var table + a 4th list item linking to the new page |
| `.gitignore` | Adds `!tests/provision/mapping_rules*` (parallel to existing `!tests/provision/workflows*` exception) |

## Test coverage

```
test_creates_new_rule
test_provisions_multiple_rules
test_is_idempotent
test_adopts_existing_ui_rule_with_matching_name   # asserts disabled/override/condition reset
test_updates_existing_provisioned_rule
test_deprovisions_when_manifest_file_disappears
test_deprovisions_all_when_env_unset
test_leaves_unrelated_ui_rules_untouched
test_raises_when_directory_missing
test_invalid_manifest_does_not_break_valid_one   # bad file sorts AFTER good — proves per-manifest commit semantics
test_noop_when_env_unset_and_no_provisioned_rules
test_empty_directory_deprovisions_existing
test_same_name_manifests_do_not_create_duplicate  # guards against dup creation when autoflush is off
test_non_yaml_files_in_directory_are_ignored
```

## Design choices worth a maintainer sanity-check

These are the bits where I made a call without explicit guidance — happy to switch:

1. **Manifest format: single YAML with inline `rows`** (vs. metadata YAML + sibling CSV). Reasoning: file-per-mapping is the simplest GitOps shape, mirrors `KEEP_WORKFLOWS_DIRECTORY` ergonomics, and validation reuses the existing `MappingRuleDtoIn` (no new validator).
2. **Name match scope: across all rules** (UI + provisioned), workflow-style adoption. The dedupe pattern restricts to already-provisioned rules; the workflow pattern matches by name regardless. Workflow pattern is friendlier for users migrating from UI to GitOps (no duplicates, no manual cleanup). Easy to swap to the stricter dedupe-style if preferred.
3. **`is_provisioned` + `provisioned_file` columns** (workflow-style) vs. just `is_provisioned` (dedupe-style). The `provisioned_file` enables clean "manifest file disappeared → deprovision" detection, which dedupe doesn't need because dedupe rules live nested in `KEEP_PROVIDERS` env (no file-tracking).
4. **No `KEEP_MAPPINGS` single-env-var mode** (workflows have both `KEEP_WORKFLOWS_DIRECTORY` and `KEEP_WORKFLOW`). Skipped because the directory mode covers every GitOps use case; a single inline mapping in an env var seems vanishingly rare. Easy to add later if needed.
5. **Reset `disabled`/`override`/`condition` on adoption** (manifest is source of truth) rather than carrying UI state over. A UI rule that was disabled via the UI will be re-enabled when adopted. Documented in `mapping.mdx`. Could carry over instead — would require new fields on `MappingRuleDtoIn`.

## Out of scope

- Adding a `provisioned` indicator to the Keep UI for mapping rules (workflows show this; mappings could too). Separate UI concern.

## Context

Production users of Keep adopting GitOps for providers, workflows, and team-routing configs have hit the same gap that motivated #4487 — mapping rules were the one config type that still required manual UI upload. Filing this so the same "I forgot to upload after merge" failure mode is structurally impossible going forward.

