### PR TITLE
fix: deserialize JSON string body in HTTP provider before sending request

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -300,7 +300,8 @@
             "deployment/provision/overview",
             "deployment/provision/provider",
             "deployment/provision/workflow",
-            "deployment/provision/dashboard"
+            "deployment/provision/dashboard",
+            "deployment/provision/mapping"
           ]
         },
         "deployment/secret-store",

--- a/docs/snippets/providers/anthropic-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/anthropic-snippet-autogenerated.mdx
@@ -1,9 +1,11 @@
-{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py 
+{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py
 Do not edit it manually, as it will be overwritten */}
 
 ## Authentication
 This provider requires authentication.
 - **api_key**: Anthropic API Key (required: True, sensitive: True)
+- **model**: Claude model to use (required: False, sensitive: False)
+- **system_prompt**: System prompt that sets Claude's role for all requests in this provider. (required: False, sensitive: False)
 
 
 ## In workflows
@@ -19,8 +21,9 @@ steps:
       config: "{{ provider.my_provider_name }}"
       with:
         prompt: {value}  # The prompt to query the model with.
-        model: {value}  # The model to query.
+        model: {value}  # The model to query (overrides provider config).
         max_tokens: {value}  # The maximum number of tokens to generate.
+        system_prompt: {value}  # System prompt override for this call.
         structured_output_format: {value}  # The structured output format to use.
 ```
 

--- a/keep/providers/http_provider/http_provider.py
+++ b/keep/providers/http_provider/http_provider.py
@@ -96,6 +96,11 @@ class HttpProvider(BaseProvider):
             headers = json.loads(headers)
         if body is None:
             body = {}
+        if isinstance(body, str):
+            try:
+                body = json.loads(body)
+            except (json.JSONDecodeError, ValueError):
+                pass  # not JSON — leave as-is, requests will send it as a plain string
         if params is None:
             params = {}
 

--- a/tests/providers/http_provider/test_http_provider.py
+++ b/tests/providers/http_provider/test_http_provider.py
@@ -1,0 +1,55 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from keep.providers.http_provider.http_provider import HttpProvider
+
+
+@pytest.fixture
+def provider():
+    p = HttpProvider.__new__(HttpProvider)
+    p.logger = MagicMock()
+    p.context_manager = MagicMock()
+    return p
+
+
+def _mock_response(status_code=200, body=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = json.dumps(body or {})
+    resp.json.return_value = body or {}
+    return resp
+
+
+def test_body_json_string_is_deserialised_to_dict(provider):
+    """When a workflow template renders body as a JSON string it must arrive as a dict, not a double-encoded string."""
+    alert_payload = {"id": "123", "name": "test-alert"}
+    body_string = json.dumps(alert_payload)
+
+    with patch("requests.post", return_value=_mock_response()) as mock_post:
+        provider._query(url="http://example.com/webhook", method="POST", body=body_string)
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["json"] == alert_payload
+    assert isinstance(kwargs["json"], dict)
+
+
+def test_body_none_becomes_empty_dict(provider):
+    """None body must be normalised to an empty dict."""
+
+    with patch("requests.post", return_value=_mock_response()) as mock_post:
+        provider._query(url="http://example.com/webhook", method="POST", body=None)
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["json"] == {}
+
+
+def test_body_non_json_string_passes_through(provider):
+    """A plain string body that is not valid JSON must not raise and must be forwarded as-is."""
+
+    with patch("requests.post", return_value=_mock_response()) as mock_post:
+        provider._query(url="http://example.com/webhook", method="POST", body="plain text")
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["json"] == "plain text"


### PR DESCRIPTION
Close #6547 

When a workflow renders body: "{{ alert }}", the template produces a JSON string instead of a dict. Passing that string to requests.post(json=body) double-encodes it, sending a JSON string to the target instead of a JSON object.

The fix mirrors the existing handling already in place for headers: if body arrives as a string and is valid JSON, it is deserialized back to a dict before being handed to requests. Non-JSON strings are left unchanged for backwards compatibility.

Adds unit tests for the HTTP provider.