### PR TITLE
fix(api): prevent background task garbage collection in lifespan startup

### DIFF
--- a/keep/api/api.py
+++ b/keep/api/api.py
@@ -117,7 +117,7 @@ async def check_pending_tasks(background_tasks: set):
         await asyncio.sleep(1)
 
 
-async def startup():
+async def startup(background_tasks: set | None = None):
     """
     This runs for every worker on startup.
     Read more about lifespan here: https://fastapi.tiangolo.com/advanced/events/#lifespan
@@ -180,7 +180,10 @@ async def startup():
             except Exception:
                 logger.exception("Failed to start the maintenance windows")
         else:
-            asyncio.create_task(process_watcher_task.async_process_watcher())
+            task = asyncio.create_task(process_watcher_task.async_process_watcher())
+            if background_tasks is not None:
+                background_tasks.add(task)
+                task.add_done_callback(background_tasks.discard)
             logger.info(
                 "Added task",
                 extra={
@@ -227,14 +230,16 @@ async def lifespan(app: FastAPI):
     """
     app.state.limiter = limiter
     # create a set of background tasks
-    background_tasks = set()
+    background_tasks: set[asyncio.Task] = set()
     # if debug tasks are enabled, create a task to check for pending tasks
     if KEEP_DEBUG_TASKS:
         logger.info("Starting background task to check for pending tasks")
-        asyncio.create_task(check_pending_tasks(background_tasks))
+        debug_task = asyncio.create_task(check_pending_tasks(background_tasks))
+        background_tasks.add(debug_task)
+        debug_task.add_done_callback(background_tasks.discard)
 
     # Startup
-    await startup()
+    await startup(background_tasks=background_tasks)
 
     # yield the background tasks, this is available for the app to use in request context
     yield {"background_tasks": background_tasks}


### PR DESCRIPTION
Closes #6552

**Problem**

Two `asyncio.create_task(...)` calls in `keep/api/api.py` create background tasks without holding a strong reference to the returned `Task` object. The Python asyncio docs warn that the event loop only keeps a *weak* reference to a task, so a fire-and-forget task can be garbage-collected mid-execution and silently cancelled — no traceback, just missing work.

> Important: Save a reference to the result of [`create_task()`], to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn't referenced elsewhere may be garbage collected at any time, even before it's done.
> — https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task

**Affected sites**

1. `startup()` line 183 — the maintenance-window watcher:
    ```python
    asyncio.create_task(process_watcher_task.async_process_watcher())
    ```
    Zero strong references. The Task can be collected before it ever runs `async_process_watcher`, and when it does the watcher just disappears.

2. `lifespan()` line 234 — the debug pending-task logger:
    ```python
    asyncio.create_task(check_pending_tasks(background_tasks))
    ```
    `check_pending_tasks` is passed the `background_tasks` set as an argument, but the Task wrapping the coroutine is never added to that set. So this task also lacks a strong reference and is GC-eligible.

**Root cause**

CPython garbage-collects coroutine Tasks the same way it collects any other object. The asyncio event loop only keeps weak references to running tasks (`asyncio.all_tasks()` is implemented via a `WeakSet`). If no other code holds a strong reference, the GC is free to reclaim the Task at any GC pass, which cancels it.

**Changes**

`keep/api/api.py` — one file, +10 / -5 lines:

- `startup()` now accepts an optional `background_tasks: set | None = None` parameter; when present the watcher task is added to it and registers a done-callback to discard itself on completion (`task.add_done_callback(background_tasks.discard)`).
- `lifespan()` passes its existing `background_tasks` set into `startup()`, and now also adds the debug `check_pending_tasks` task to that same set with the same done-callback. The set was already being created here for request-context use; this just makes the lifespan tasks share it.
- The `set` type annotation is tightened to `set[asyncio.Task]` for clarity.

Backward compatible: any other caller of `startup()` continues to work because the new parameter defaults to `None`.

**Testing**

Manual reasoning + asyncio docs reference; the GC-cancellation behaviour is established Python asyncio semantics and the fix matches the [pattern recommended in the stdlib docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task) (hold strong reference in a set, discard via done-callback).

I considered adding a unit test but a test that reliably triggers `gc.collect()` mid-task in pytest would be fragile and the bug class is well-documented. Happy to add a regression test that simply asserts the watcher Task ends up in `app.state` if maintainers prefer.