### PR TITLE
fix(MonacoCel): move dynamic import to module level to prevent render-cycle interference

### DIFF
--- a/keep-ui/shared/ui/MonacoCELEditor/MonacoCel.tsx
+++ b/keep-ui/shared/ui/MonacoCELEditor/MonacoCel.tsx
@@ -8,6 +8,20 @@ interface MonacoCelProps extends EditorProps {
   onMonacoLoadFailure?: (error: Error) => void;
 }
 
+// Monaco Editor - imported as an npm package instead of loading from the
+// CDN to support air-gapped environments.
+// https://github.com/suren-atoyan/monaco-react?tab=readme-ov-file#use-monaco-editor-as-an-npm-package
+//
+// The dynamic import is started at module evaluation (not inside useEffect) so
+// that it does not interfere with React's render cycle.  A typeof-window guard
+// makes it SSR-safe without causing "window is not defined" crashes.
+const monacoConfigPromise: Promise<void> | null =
+  typeof window !== "undefined"
+    ? import("monaco-editor").then((monaco) => {
+        loader.config({ monaco });
+      })
+    : null;
+
 export function MonacoCelBase(props: MonacoCelProps) {
   const [isLoaded, setIsLoaded] = useState(false);
   const onMonacoLoadedRef = useRef<MonacoCelProps["onMonacoLoaded"] | null>(
@@ -20,14 +34,8 @@ export function MonacoCelBase(props: MonacoCelProps) {
   onMonacoLoadFailureRef.current = props.onMonacoLoadFailure;
 
   useEffect(() => {
-    // Monaco Editor - imported as an npm package instead of loading from the
-    // CDN to support air-gapped environments.
-    // https://github.com/suren-atoyan/monaco-react?tab=readme-ov-file#use-monaco-editor-as-an-npm-package
-    import("monaco-editor")
-      .then((monaco) => {
-        loader.config({ monaco });
-        return loader.init();
-      })
+    (monacoConfigPromise ?? Promise.resolve())
+      .then(() => loader.init())
       .then((monacoInstance) => {
         onMonacoLoadedRef.current?.(monacoInstance);
         setIsLoaded(true);


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #6555 — regression introduced by #6540.

## 📑 Description
#6540 moved `import("monaco-editor")` from module-level into a `useEffect` to fix an SSR crash ("window is not defined"). While the SSR fix is correct, placing the async chunk load **inside** `useEffect` causes it to interact with React's render cycle: the unresolved Promise keeps `MonacoCelBase` in its `null` loading state across multiple render passes. Combined with `useWebsocket`'s `channelName` transitioning during OAUTH2PROXY session load, this cascades into ~30,000 re-renders that freeze the UI.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## Why this is correct

- **SSR-safe**: `typeof window !== "undefined"` prevents the import from running during server-side rendering — same guarantee as the original fix in #6540.
- **No render-cycle interference**: the dynamic import is started once, outside React, so it never blocks or re-triggers the render pipeline.
- **Performance**: Monaco starts loading as early as possible (module evaluation) rather than waiting for the component to mount.
- **Singleton**: the Promise is module-level, so even if multiple `MonacoCelBase` instances mount, Monaco is only configured once.

## Testing

1. Build from a commit `main`
2. Deploy with `AUTH_TYPE=OAUTH2PROXY`
3. Navigate to the alerts Feed page — previously caused ~30,000 re-renders and a frozen UI; now loads normally