### PR TITLE
chore: Bump version from 0.52.1 to 0.53.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keep"
-version = "0.52.1"
+version = "0.53.0"
 description = "Alerting. for developers, by developers."
 authors = ["Keep Alerting LTD"]
 packages = [{include = "keep"}]


### PR DESCRIPTION
Closes #6557

## Summary
- Bumps Keep version from 0.52.1 to 0.53.0

## Checks
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed

Made with [Cursor](https://cursor.com)