### PR TITLE
feat: issue #5674- improve wf parsing

### DIFF
--- a/keep/workflowmanager/workflowstore.py
+++ b/keep/workflowmanager/workflowstore.py
@@ -2,7 +2,9 @@ import io
 import logging
 import os
 import random
+import threading
 import uuid
+from dataclasses import dataclass
 from typing import Tuple
 
 import celpy
@@ -32,11 +34,22 @@ from keep.workflowmanager.workflow import Workflow
 from sqlalchemy.exc import NoResultFound
 
 
+@dataclass
+class _CachedWorkflow:
+    """Holds a parsed Workflow object and the revision it was parsed from."""
+
+    workflow: "Workflow"
+    revision: int
+
+
 class WorkflowStore:
     def __init__(self):
         self.parser = Parser()
         self.logger = logging.getLogger(__name__)
         self.celpy_env = celpy.Environment()
+        # Parse cache: avoids re-parsing unchanged workflow YAML on every execution
+        self._parse_cache: dict[str, _CachedWorkflow] = {}
+        self._cache_lock = threading.Lock()
 
     def get_workflow_execution(
         self,
@@ -114,6 +127,7 @@ class WorkflowStore:
             raise HTTPException(403, detail="Cannot delete a provisioned workflow")
         try:
             delete_workflow(tenant_id, workflow_id)
+            self.invalidate_workflow_cache(tenant_id, workflow_id)
         except Exception as e:
             self.logger.exception(f"Error deleting workflow {workflow_id}: {str(e)}")
             raise HTTPException(
@@ -150,31 +164,68 @@ class WorkflowStore:
         return self.format_workflow_yaml(workflow.workflow_raw)
 
     def get_workflow(self, tenant_id: str, workflow_id: str) -> Workflow:
-        workflow = get_workflow_by_id(tenant_id, workflow_id)
-        if not workflow:
+        workflow_model = get_workflow_by_id(tenant_id, workflow_id)
+        if not workflow_model:
             raise HTTPException(
                 status_code=404,
                 detail=f"Workflow {workflow_id} not found",
             )
-        workflow_yaml = cyaml.safe_load(workflow.workflow_raw)
-        workflow = self.parser.parse(
+
+        cache_key = f"{tenant_id}:{workflow_id}"
+
+        # Check cache — revision bumps on every update, making it a reliable cache key
+        with self._cache_lock:
+            cached = self._parse_cache.get(cache_key)
+            if cached and cached.revision == workflow_model.revision:
+                self.logger.debug(
+                    "Workflow parse cache hit",
+                    extra={"workflow_id": workflow_id, "tenant_id": tenant_id},
+                )
+                return cached.workflow
+
+        # Cache miss — parse as normal
+        self.logger.debug(
+            "Workflow parse cache miss, parsing",
+            extra={"workflow_id": workflow_id, "tenant_id": tenant_id},
+        )
+        workflow_yaml = cyaml.safe_load(workflow_model.workflow_raw)
+        parsed = self.parser.parse(
             tenant_id,
             workflow_yaml,
-            workflow_db_id=workflow.id,
-            workflow_revision=workflow.revision,
-            is_test=workflow.is_test,
+            workflow_db_id=workflow_model.id,
+            workflow_revision=workflow_model.revision,
+            is_test=workflow_model.is_test,
         )
-        if len(workflow) > 1:
+        if len(parsed) > 1:
             raise HTTPException(
                 status_code=500,
                 detail=f"More than one workflow with id {workflow_id} found",
             )
-        elif workflow:
-            return workflow[0]
-        else:
+        elif not parsed:
             raise HTTPException(
                 status_code=404,
                 detail=f"Workflow {workflow_id} not found",
+            )
+
+        result = parsed[0]
+
+        # Store result in cache
+        with self._cache_lock:
+            self._parse_cache[cache_key] = _CachedWorkflow(
+                workflow=result,
+                revision=workflow_model.revision,
+            )
+
+        return result
+
+    def invalidate_workflow_cache(self, tenant_id: str, workflow_id: str) -> None:
+        """Evict a workflow from the parse cache. Call on update or delete."""
+        cache_key = f"{tenant_id}:{workflow_id}"
+        with self._cache_lock:
+            self._parse_cache.pop(cache_key, None)
+            self.logger.debug(
+                "Workflow parse cache invalidated",
+                extra={"workflow_id": workflow_id, "tenant_id": tenant_id},
             )
 
     def get_workflow_from_dict(self, tenant_id: str, workflow_dict: dict) -> Workflow:


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5674 

## 📑 Description
Added an in-process parse cache to `WorkflowStore` keyed on 
`(tenant_id, workflow_id)`, using the workflow's existing `revision` 
field as the cache validity key.

- Cache hit: returns the previously parsed `Workflow` object directly, 
  skipping `cyaml.safe_load()` and `Parser.parse()` entirely
- Cache miss: parses as normal and stores the result
- Cache invalidation: `invalidate_workflow_cache()` is called from 
  `delete_workflow()` to evict stale entries on deletion
- Thread safety: a `threading.Lock` protects the cache dict 
  (safe for the `ThreadPoolExecutor` used in `WorkflowScheduler`)

## Changes

- `keep/workflowmanager/workflowstore.py`
  - Added `_CachedWorkflow` dataclass to hold parsed workflow + revision
  - Added `_parse_cache` dict and `_cache_lock` to `__init__`
  - Updated `get_workflow()` to check cache before parsing
  - Added `invalidate_workflow_cache()` method
  - Called `invalidate_workflow_cache()` from `delete_workflow()`

## Notes

- No schema migration required
- No behaviour change on the hot path — cache is purely additive
- Fully backwards compatible
- `revision` is already incremented by `add_or_update_workflow()` on 
  every update, making it a reliable and zero-cost cache key


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
