### PR TITLE
fix: prevent AUTH0 test timeout caused by OIDC discovery HTTP call

### DIFF
--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -1,12 +1,28 @@
 import hashlib
 import importlib
 import sys
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from keep.api.core.dependencies import SINGLE_TENANT_UUID
 from keep.api.models.db.tenant import TenantApiKey
+
+
+def _mock_oidc_discovery():
+    """Return a context manager that stubs OIDC discovery HTTP calls.
+
+    Prevents real network requests to Auth0 during app startup when
+    AUTH_TYPE=AUTH0 is set in tests.
+    """
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "jwks_uri": "https://test-domain.auth0.com/.well-known/jwks.json"
+    }
+    mock_resp.raise_for_status = MagicMock()
+    return patch("requests.get", return_value=mock_resp)
 
 
 @pytest.fixture
@@ -21,11 +37,13 @@ def test_app(monkeypatch, request, db_session):
 
     try:
         monkeypatch.setenv("KEEP_USE_LIMITER", "false")
+        is_auth0 = False
         # Check if request.param is a dict or a string
         if isinstance(request.param, dict):
             # Set environment variables based on the provided dictionary
             for key, value in request.param.items():
                 monkeypatch.setenv(key, str(value))
+            is_auth0 = request.param.get("AUTH_TYPE") == "AUTH0"
         else:
             # Old behavior for string parameters
             auth_type = request.param
@@ -35,27 +53,33 @@ def test_app(monkeypatch, request, db_session):
             if auth_type == "MULTI_TENANT":
                 monkeypatch.setenv("AUTH0_DOMAIN", "https://auth0domain.com")
 
-        # Clear and reload modules to ensure environment changes are reflected
-        for module in list(sys.modules):
-            if module.startswith("keep.api.routes"):
-                del sys.modules[module]
+        # When AUTH_TYPE=AUTH0, the authverifier module makes a real HTTP call
+        # at import time to fetch the OIDC discovery document. The mock must
+        # wrap the module reload as well, because deleted route modules get
+        # re-imported during reload and cascade into re-importing the verifier.
+        ctx = _mock_oidc_discovery() if is_auth0 else nullcontext()
+        with ctx:
+            # Clear and reload modules to ensure environment changes are reflected
+            for module in list(sys.modules):
+                if module.startswith("keep.api.routes"):
+                    del sys.modules[module]
 
-            # Bug in db patching
-            elif module.startswith("keep.providers.providers_service"):
-                importlib.reload(sys.modules[module])
+                # Bug in db patching
+                elif module.startswith("keep.providers.providers_service"):
+                    importlib.reload(sys.modules[module])
 
-        if "keep.api.api" in sys.modules:
-            importlib.reload(sys.modules["keep.api.api"])
+            if "keep.api.api" in sys.modules:
+                importlib.reload(sys.modules["keep.api.api"])
 
-        if "keep.api.config" in sys.modules:
-            importlib.reload(sys.modules["keep.api.config"])
+            if "keep.api.config" in sys.modules:
+                importlib.reload(sys.modules["keep.api.config"])
 
-        # Import and return the app instance
-        from keep.api.api import get_app
-        from keep.api.config import provision_resources
+            # Import and return the app instance
+            from keep.api.api import get_app
+            from keep.api.config import provision_resources
 
-        provision_resources()
-        app = get_app()
+            provision_resources()
+            app = get_app()
         return app
     finally:
         # Restore the original setup_logging function


### PR DESCRIPTION
## Summary

Closes #6565

`auth0_authverifier.py` makes a real HTTP request at module import time when `AUTH0_DOMAIN` is set. The `test_app` fixture's module reload cascade re-imports the verifier outside any mock, causing a 10s network hang that exceeds the 20s per-test timeout.

**Fix:** move the module reload block and `get_app()` call inside a `patch("requests.get")` context when `AUTH_TYPE=AUTH0`, so the OIDC discovery call returns immediately without hitting the network.

## Files changed

- `tests/fixtures/client.py` — mock OIDC discovery during app startup for AUTH0 test fixtures
