### PR TITLE
fix(ui): exclude public static assets from auth middleware to fix image loading

### DIFF
--- a/docker/Dockerfile.ui
+++ b/docker/Dockerfile.ui
@@ -55,6 +55,12 @@ COPY --from=builder /app/public ./public
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+# sharp is required for Next.js image optimization in standalone mode.
+# The standalone output does not include native modules automatically.
+# sharp v0.33+ uses @img/* packages for its native bindings.
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/sharp ./node_modules/sharp
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/@img ./node_modules/@img
 COPY entrypoint.sh /app/entrypoint.sh
 
 # as per Openshift guidelines, https://docs.openshift.com/container-platform/4.11/openshift_images/create-images.html#use-uid_create-images

--- a/docker/Dockerfile.ui
+++ b/docker/Dockerfile.ui
@@ -56,11 +56,6 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-# sharp is required for Next.js image optimization in standalone mode.
-# The standalone output does not include native modules automatically.
-# sharp v0.33+ uses @img/* packages for its native bindings.
-COPY --from=deps --chown=nextjs:nodejs /app/node_modules/sharp ./node_modules/sharp
-COPY --from=deps --chown=nextjs:nodejs /app/node_modules/@img ./node_modules/@img
 COPY entrypoint.sh /app/entrypoint.sh
 
 # as per Openshift guidelines, https://docs.openshift.com/container-platform/4.11/openshift_images/create-images.html#use-uid_create-images

--- a/keep-ui/middleware.ts
+++ b/keep-ui/middleware.ts
@@ -99,6 +99,7 @@ export const config = {
      * - api (API routes)
      * - keep_big.svg (logo)
      * - keep.svg (logo)
+     * - keep.png (logo)
      * - gnip.webp (logo)
      * - api/aws-marketplace (aws marketplace)
      * - api/auth (auth)
@@ -108,7 +109,8 @@ export const config = {
      * - favicon.ico (favicon file)
      * - icons (providers' logos)
      * - api/provider-images (provider icons)
+     * - public static assets (png, jpg, jpeg, gif, webp, svg, ico)
      */
-    "/((?!keep_big\\.svg$|gnip\\.webp|api/aws-marketplace$|api/auth|monitoring|_next/static|_next/image|favicon\\.ico|icons|keep\\.svg|api/provider-images).*)",
+    "/((?!keep_big\\.svg$|keep\\.png$|gnip\\.webp|api/aws-marketplace$|api/auth|monitoring|_next/static|_next/image|favicon\\.ico|icons|keep\\.svg|api/provider-images|.*\\.(?:png|jpg|jpeg|gif|webp|ico)$).*)",
   ],
 };


### PR DESCRIPTION
## Summary

Local images served via `/_next/image` were failing with "The requested resource isn't a valid image" in self-hosted deployments.

## Root cause

When Next.js image optimization (`/_next/image`) fetches a local image internally via `fetchInternalImage`, the request goes through the full middleware pipeline. Public assets like `/keep.png` were not excluded from the middleware matcher, so the middleware redirected them to `/signin` — returning HTML instead of image data, which Next.js cannot process as an image.

`keep.svg` was already in the exclusion list but `keep.png` was not.

## Fix

Add common static image extensions (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.ico`) to the middleware matcher negative lookahead so public assets bypass authentication entirely.

## Test

Before: `/_next/image?url=%2Fkeep.png&w=64&q=75` → "The requested resource isn't a valid image."
After: image loads correctly.

Fixes #6575