### PR TITLE
fix: change monaco-editor imports to type-only imports

### DIFF
--- a/keep-ui/shared/ui/MonacoCELEditor/handle-completions.ts
+++ b/keep-ui/shared/ui/MonacoCELEditor/handle-completions.ts
@@ -1,4 +1,4 @@
-import { editor, languages, Position, CancellationToken } from "monaco-editor";
+import type { editor, languages, Position, CancellationToken } from "monaco-editor";
 
 // NOTE: The enums below are workarounds due to inability to import from monaco-editor (turbopack related)
 enum CompletionItemKind {

--- a/keep-ui/shared/ui/MonacoCELEditor/validation-hook.ts
+++ b/keep-ui/shared/ui/MonacoCELEditor/validation-hook.ts
@@ -1,6 +1,6 @@
 import { useApi } from "@/shared/lib/hooks/useApi";
 import { useDebouncedValue } from "@/utils/hooks/useDebouncedValue";
-import { editor } from "monaco-editor";
+import type { editor } from "monaco-editor";
 import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 


### PR DESCRIPTION
Fixes #6545.

Change monaco-editor imports to type-only imports in MonacoCELEditor validation and completions files to prevent SSR crash. The error 'window is not defined' occurs because monaco-editor module accesses window during initialization. Two files in the MonacoCELEditor directory import from monaco-editor at module level but only use types. Changing these to type-only imports prevents the module from being loaded on the server side, fixing the SSR issue.

I ran the available lightweight check for the frontend change.