### PR TITLE
fix: parse PUSHER_USE_SSL and PUSHER_DISABLED env booleans correctly

### DIFF
--- a/keep/api/core/dependencies.py
+++ b/keep/api/core/dependencies.py
@@ -23,6 +23,14 @@ if PUSHER_ROOT_CA:
     pusher_requests.CERT_PATH = PUSHER_ROOT_CA
 
 
+def parse_env_bool(value: str | bool | None, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 async def extract_generic_body(request: Request) -> dict | bytes | FormData:
     """
     Extracts the body of the request based on the content type.
@@ -51,7 +59,7 @@ async def extract_generic_body(request: Request) -> dict | bytes | FormData:
 
 def get_pusher_client() -> Pusher | None:
     logger.debug("Getting pusher client")
-    pusher_disabled = os.environ.get("PUSHER_DISABLED", "false") == "true"
+    pusher_disabled = parse_env_bool(os.environ.get("PUSHER_DISABLED"), default=False)
     pusher_host = os.environ.get("PUSHER_HOST")
     pusher_app_id = os.environ.get("PUSHER_APP_ID")
     pusher_app_key = os.environ.get("PUSHER_APP_KEY")
@@ -77,7 +85,7 @@ def get_pusher_client() -> Pusher | None:
             app_id=pusher_app_id,
             key=pusher_app_key,
             secret=pusher_app_secret,
-            ssl=False if os.environ.get("PUSHER_USE_SSL", False) is False else True,
+            ssl=parse_env_bool(os.environ.get("PUSHER_USE_SSL"), default=False),
             cluster=os.environ.get("PUSHER_CLUSTER"),
         )
     except ValueError:

--- a/keep/api/core/dependencies.py
+++ b/keep/api/core/dependencies.py
@@ -23,14 +23,6 @@ if PUSHER_ROOT_CA:
     pusher_requests.CERT_PATH = PUSHER_ROOT_CA
 
 
-def parse_env_bool(value: str | bool | None, default: bool = False) -> bool:
-    if value is None:
-        return default
-    if isinstance(value, bool):
-        return value
-    return value.strip().lower() in {"1", "true", "yes", "on"}
-
-
 async def extract_generic_body(request: Request) -> dict | bytes | FormData:
     """
     Extracts the body of the request based on the content type.
@@ -59,7 +51,7 @@ async def extract_generic_body(request: Request) -> dict | bytes | FormData:
 
 def get_pusher_client() -> Pusher | None:
     logger.debug("Getting pusher client")
-    pusher_disabled = parse_env_bool(os.environ.get("PUSHER_DISABLED"), default=False)
+    pusher_disabled = config("PUSHER_DISABLED", cast=bool, default=False)
     pusher_host = os.environ.get("PUSHER_HOST")
     pusher_app_id = os.environ.get("PUSHER_APP_ID")
     pusher_app_key = os.environ.get("PUSHER_APP_KEY")
@@ -85,7 +77,7 @@ def get_pusher_client() -> Pusher | None:
             app_id=pusher_app_id,
             key=pusher_app_key,
             secret=pusher_app_secret,
-            ssl=parse_env_bool(os.environ.get("PUSHER_USE_SSL"), default=False),
+            ssl=config("PUSHER_USE_SSL", cast=bool, default=False),
             cluster=os.environ.get("PUSHER_CLUSTER"),
         )
     except ValueError:

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,21 @@
+from keep.api.core.dependencies import parse_env_bool
+
+
+def test_parse_env_bool_treats_false_strings_as_false():
+    assert parse_env_bool("false") is False
+    assert parse_env_bool("False") is False
+    assert parse_env_bool("0") is False
+    assert parse_env_bool("off") is False
+    assert parse_env_bool("no") is False
+
+
+def test_parse_env_bool_treats_truthy_strings_as_true():
+    assert parse_env_bool("true") is True
+    assert parse_env_bool("1") is True
+    assert parse_env_bool("yes") is True
+    assert parse_env_bool("on") is True
+
+
+def test_parse_env_bool_uses_default_for_missing_values():
+    assert parse_env_bool(None, default=False) is False
+    assert parse_env_bool(None, default=True) is True

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,21 +1,40 @@
-from keep.api.core.dependencies import parse_env_bool
+from unittest.mock import patch
+
+from keep.api.core.dependencies import get_pusher_client
 
 
-def test_parse_env_bool_treats_false_strings_as_false():
-    assert parse_env_bool("false") is False
-    assert parse_env_bool("False") is False
-    assert parse_env_bool("0") is False
-    assert parse_env_bool("off") is False
-    assert parse_env_bool("no") is False
+def test_get_pusher_client_uses_false_for_string_false(monkeypatch):
+    monkeypatch.setenv("PUSHER_APP_ID", "123")
+    monkeypatch.setenv("PUSHER_APP_KEY", "key")
+    monkeypatch.setenv("PUSHER_APP_SECRET", "secret")
+    monkeypatch.setenv("PUSHER_USE_SSL", "false")
+
+    with patch("keep.api.core.dependencies.Pusher") as mock_pusher:
+        get_pusher_client()
+
+    assert mock_pusher.call_args.kwargs["ssl"] is False
 
 
-def test_parse_env_bool_treats_truthy_strings_as_true():
-    assert parse_env_bool("true") is True
-    assert parse_env_bool("1") is True
-    assert parse_env_bool("yes") is True
-    assert parse_env_bool("on") is True
+def test_get_pusher_client_uses_true_for_string_true(monkeypatch):
+    monkeypatch.setenv("PUSHER_APP_ID", "123")
+    monkeypatch.setenv("PUSHER_APP_KEY", "key")
+    monkeypatch.setenv("PUSHER_APP_SECRET", "secret")
+    monkeypatch.setenv("PUSHER_USE_SSL", "true")
+
+    with patch("keep.api.core.dependencies.Pusher") as mock_pusher:
+        get_pusher_client()
+
+    assert mock_pusher.call_args.kwargs["ssl"] is True
 
 
-def test_parse_env_bool_uses_default_for_missing_values():
-    assert parse_env_bool(None, default=False) is False
-    assert parse_env_bool(None, default=True) is True
+def test_get_pusher_client_respects_pusher_disabled(monkeypatch):
+    monkeypatch.setenv("PUSHER_DISABLED", "true")
+    monkeypatch.setenv("PUSHER_APP_ID", "123")
+    monkeypatch.setenv("PUSHER_APP_KEY", "key")
+    monkeypatch.setenv("PUSHER_APP_SECRET", "secret")
+
+    with patch("keep.api.core.dependencies.Pusher") as mock_pusher:
+        client = get_pusher_client()
+
+    assert client is None
+    mock_pusher.assert_not_called()


### PR DESCRIPTION
## Summary
- parse PUSHER_USE_SSL and PUSHER_DISABLED using explicit boolean coercion instead of Python truthiness
- preserve existing behavior for already-boolean values
- add focused regression coverage for string env inputs

Closes #6582

## Testing
- .venv313\\Scripts\\python.exe -m pytest tests/test_dependencies.py -q