### PR TITLE
fix: parse PUSHER_USE_SSL as a boolean env flag

### DIFF
--- a/keep/api/core/dependencies.py
+++ b/keep/api/core/dependencies.py
@@ -23,6 +23,15 @@ if PUSHER_ROOT_CA:
     pusher_requests.CERT_PATH = PUSHER_ROOT_CA
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
 async def extract_generic_body(request: Request) -> dict | bytes | FormData:
     """
     Extracts the body of the request based on the content type.
@@ -51,7 +60,7 @@ async def extract_generic_body(request: Request) -> dict | bytes | FormData:
 
 def get_pusher_client() -> Pusher | None:
     logger.debug("Getting pusher client")
-    pusher_disabled = os.environ.get("PUSHER_DISABLED", "false") == "true"
+    pusher_disabled = _env_flag("PUSHER_DISABLED")
     pusher_host = os.environ.get("PUSHER_HOST")
     pusher_app_id = os.environ.get("PUSHER_APP_ID")
     pusher_app_key = os.environ.get("PUSHER_APP_KEY")
@@ -77,7 +86,7 @@ def get_pusher_client() -> Pusher | None:
             app_id=pusher_app_id,
             key=pusher_app_key,
             secret=pusher_app_secret,
-            ssl=False if os.environ.get("PUSHER_USE_SSL", False) is False else True,
+            ssl=_env_flag("PUSHER_USE_SSL"),
             cluster=os.environ.get("PUSHER_CLUSTER"),
         )
     except ValueError:

--- a/tests/test_pusher_dependencies.py
+++ b/tests/test_pusher_dependencies.py
@@ -1,0 +1,19 @@
+from keep.api.core.dependencies import _env_flag
+
+
+def test_env_flag_defaults_to_false_when_missing(monkeypatch):
+    monkeypatch.delenv("PUSHER_USE_SSL", raising=False)
+
+    assert _env_flag("PUSHER_USE_SSL") is False
+
+
+def test_env_flag_parses_truthy_strings(monkeypatch):
+    for value in ("1", "true", "TRUE", "yes", "on"):
+        monkeypatch.setenv("PUSHER_USE_SSL", value)
+        assert _env_flag("PUSHER_USE_SSL") is True
+
+
+def test_env_flag_parses_falsey_strings(monkeypatch):
+    for value in ("0", "false", "FALSE", "no", "off", ""):
+        monkeypatch.setenv("PUSHER_USE_SSL", value)
+        assert _env_flag("PUSHER_USE_SSL") is False


### PR DESCRIPTION
## Summary

Closes #6582

- fixes `PUSHER_USE_SSL` parsing in `keep/api/core/dependencies.py`
- treats string env values like `false`, `0`, `no`, and `off` as `False`
- reuses the same parsing helper for `PUSHER_DISABLED` to avoid the same class of bug
- adds narrow regression coverage for env flag parsing

## Why

`PUSHER_USE_SSL` currently uses:

```python
ssl=False if os.environ.get(PUSHER_USE_SSL, False) is False else True
```

When the app is configured through Docker Compose, `PUSHER_USE_SSL: false` is passed as the string `false`, which is not the boolean `False`. That makes the current expression evaluate to `True`, so SSL is enabled unexpectedly.

## Change

- add `_env_flag(name, default=False)` for simple env-based boolean parsing
- switch `PUSHER_USE_SSL` to `ssl=_env_flag(PUSHER_USE_SSL)`
- switch `PUSHER_DISABLED` to `_env_flag(PUSHER_DISABLED)`

## Validation

Local lightweight verification with Python 3.13 and minimal runtime deps:

- `PUSHER_USE_SSL=false -> _ssl=False`
- `PUSHER_USE_SSL=true -> _ssl=True`
- `_env_flag` also correctly handles `0/1` and `false/true`

I also added a narrow regression test file:

- `tests/test_pusher_dependencies.py`

## Notes

- I kept the scope limited to the Pusher env parsing path instead of broadening this into a repo-wide boolean parsing refactor.
