### PR TITLE
fix: remove invalid bullet format from ReactQuill configs

### DIFF
--- a/keep-ui/features/alerts/alert-note/ui/alert-note-modal.tsx
+++ b/keep-ui/features/alerts/alert-note/ui/alert-note-modal.tsx
@@ -40,7 +40,6 @@ export const AlertNoteModal = ({
     "italic",
     "underline",
     "list",
-    "bullet",
     "link",
     "align",
     "blockquote",

--- a/keep-ui/features/incidents/create-or-update-incident/ui/create-or-update-incident-form.tsx
+++ b/keep-ui/features/incidents/create-or-update-incident/ui/create-or-update-incident-form.tsx
@@ -124,7 +124,6 @@ export function CreateOrUpdateIncidentForm({
     "italic",
     "underline",
     "list",
-    "bullet",
     "link",
     "align",
     "blockquote",


### PR DESCRIPTION
## Summary

Closes #6581

- removes the invalid `bullet` entry from the Quill `formats` arrays
- keeps `list` in place, which already covers ordered and bullet lists
- updates both affected components to avoid the browser console error consistently

## Why

Quill expects `list` in the `formats` array, while `bullet` is only used as a toolbar value such as `{ list: "bullet" }`.

Having `bullet` inside `formats` causes the console error:

`Cannot register bullet specified in formats config`

## Change

- update `keep-ui/features/alerts/alert-note/ui/alert-note-modal.tsx`
- update `keep-ui/features/incidents/create-or-update-incident/ui/create-or-update-incident-form.tsx`

## Validation

- verified both affected files contain the invalid `bullet` entry in `formats`
- removed only `bullet` and left the existing toolbar config unchanged
- scope kept intentionally minimal because the issue is a direct config mismatch

## Notes

- I did not broaden this into a richer editor refactor or toolbar behavior change.
