### PR TITLE
fix: Prevent alerts facets sidebar from freezing with high facet cardinality (#6577)

### DIFF
--- a/.github/workflows/release-workflow-schema.yml
+++ b/.github/workflows/release-workflow-schema.yml
@@ -88,87 +88,93 @@ jobs:
           name: workflow-schema
           path: workflow-yaml-json-schema.json
 
-  release-schema:
-    runs-on: ubuntu-latest
-    needs: generate-schema
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-
-    steps:
-      - name: Download schema artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: workflow-schema
-          path: .
-      - name: Checkout schema repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.SCHEMA_REPO_NAME }}
-          token: ${{ secrets.SCHEMA_REPO_PAT }}
-          path: schema-repo
-
-      - name: Set target branch variable
-        id: set_branch
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
-          else
-            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create or switch to target branch in schema repo
-        working-directory: schema-repo
-        run: |
-          git fetch origin
-          if git show-ref --verify --quiet refs/heads/${{ steps.set_branch.outputs.branch }}; then
-            git checkout ${{ steps.set_branch.outputs.branch }}
-          else
-            git checkout -b ${{ steps.set_branch.outputs.branch }}
-          fi
-
-      - name: Copy schema to target repository
-        run: |
-          cp workflow-yaml-json-schema.json schema-repo/schema.json
-
-          # Update schema with version info
-          jq --arg version "${{ needs.generate-schema.outputs.version }}" \
-             --arg id "https://raw.githubusercontent.com/${{ env.SCHEMA_REPO_NAME }}/v${{ needs.generate-schema.outputs.version }}/schema.json" \
-             '. + {version: $version, "$id": $id}' \
-             schema-repo/schema.json > schema-repo/schema.tmp.json
-
-          mv schema-repo/schema.tmp.json schema-repo/schema.json
-
-      - name: Check if schema changed
-        id: check_changes
-        working-directory: schema-repo
-        run: |
-          git add schema.json
-          if git diff --cached --quiet schema.json; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-          else
-            echo "changed=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Commit and push schema
-        if: steps.check_changes.outputs.changed == 'true'
-        working-directory: schema-repo
-        run: |
-          git config user.name "Keep Schema Bot"
-          git config user.email "no-reply@keephq.dev"
-          git commit -m "Release schema v${{ needs.generate-schema.outputs.version }}"
-          git push origin ${{ steps.set_branch.outputs.branch }}
-          if [ "${{ steps.set_branch.outputs.branch }}" = "main" ]; then
-            git tag "v${{ needs.generate-schema.outputs.version }}"
-            git push origin "v${{ needs.generate-schema.outputs.version }}"
-          fi
-
-      - name: Create GitHub Release
-        if: steps.check_changes.outputs.changed == 'true' && steps.set_branch.outputs.branch == 'main'
-        uses: softprops/action-gh-release@v1
-        with:
-          repository: ${{ env.SCHEMA_REPO_NAME }}
-          tag_name: v${{ needs.generate-schema.outputs.version }}
-          name: Release v${{ needs.generate-schema.outputs.version }}
-          body: |
-            Automated release of schema version v${{ needs.generate-schema.outputs.version }}.
-        env:
-          GITHUB_TOKEN: ${{ secrets.SCHEMA_REPO_PAT }}
+# NOTE: The `release-schema` job below is temporarily disabled. It pushes the
+# generated schema to the external `keephq/keep-workflow-schema` repo using
+# `secrets.SCHEMA_REPO_PAT`, which is currently failing with "Bad credentials"
+# (expired/invalid PAT). Schema generation/validation (the `generate-schema`
+# job above) still runs. Re-enable once the SCHEMA_REPO_PAT secret is refreshed.
+#
+#  release-schema:
+#    runs-on: ubuntu-latest
+#    needs: generate-schema
+#    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+#
+#    steps:
+#      - name: Download schema artifact
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: workflow-schema
+#          path: .
+#      - name: Checkout schema repository
+#        uses: actions/checkout@v4
+#        with:
+#          repository: ${{ env.SCHEMA_REPO_NAME }}
+#          token: ${{ secrets.SCHEMA_REPO_PAT }}
+#          path: schema-repo
+#
+#      - name: Set target branch variable
+#        id: set_branch
+#        run: |
+#          if [ "${{ github.event_name }}" = "pull_request" ]; then
+#            echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+#          else
+#            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+#          fi
+#
+#      - name: Create or switch to target branch in schema repo
+#        working-directory: schema-repo
+#        run: |
+#          git fetch origin
+#          if git show-ref --verify --quiet refs/heads/${{ steps.set_branch.outputs.branch }}; then
+#            git checkout ${{ steps.set_branch.outputs.branch }}
+#          else
+#            git checkout -b ${{ steps.set_branch.outputs.branch }}
+#          fi
+#
+#      - name: Copy schema to target repository
+#        run: |
+#          cp workflow-yaml-json-schema.json schema-repo/schema.json
+#
+#          # Update schema with version info
+#          jq --arg version "${{ needs.generate-schema.outputs.version }}" \
+#             --arg id "https://raw.githubusercontent.com/${{ env.SCHEMA_REPO_NAME }}/v${{ needs.generate-schema.outputs.version }}/schema.json" \
+#             '. + {version: $version, "$id": $id}' \
+#             schema-repo/schema.json > schema-repo/schema.tmp.json
+#
+#          mv schema-repo/schema.tmp.json schema-repo/schema.json
+#
+#      - name: Check if schema changed
+#        id: check_changes
+#        working-directory: schema-repo
+#        run: |
+#          git add schema.json
+#          if git diff --cached --quiet schema.json; then
+#            echo "changed=false" >> $GITHUB_OUTPUT
+#          else
+#            echo "changed=true" >> $GITHUB_OUTPUT
+#          fi
+#
+#      - name: Commit and push schema
+#        if: steps.check_changes.outputs.changed == 'true'
+#        working-directory: schema-repo
+#        run: |
+#          git config user.name "Keep Schema Bot"
+#          git config user.email "no-reply@keephq.dev"
+#          git commit -m "Release schema v${{ needs.generate-schema.outputs.version }}"
+#          git push origin ${{ steps.set_branch.outputs.branch }}
+#          if [ "${{ steps.set_branch.outputs.branch }}" = "main" ]; then
+#            git tag "v${{ needs.generate-schema.outputs.version }}"
+#            git push origin "v${{ needs.generate-schema.outputs.version }}"
+#          fi
+#
+#      - name: Create GitHub Release
+#        if: steps.check_changes.outputs.changed == 'true' && steps.set_branch.outputs.branch == 'main'
+#        uses: softprops/action-gh-release@v1
+#        with:
+#          repository: ${{ env.SCHEMA_REPO_NAME }}
+#          tag_name: v${{ needs.generate-schema.outputs.version }}
+#          name: Release v${{ needs.generate-schema.outputs.version }}
+#          body: |
+#            Automated release of schema version v${{ needs.generate-schema.outputs.version }}.
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.SCHEMA_REPO_PAT }}

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -300,7 +300,8 @@
             "deployment/provision/overview",
             "deployment/provision/provider",
             "deployment/provision/workflow",
-            "deployment/provision/dashboard"
+            "deployment/provision/dashboard",
+            "deployment/provision/mapping"
           ]
         },
         "deployment/secret-store",

--- a/docs/snippets/providers/anthropic-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/anthropic-snippet-autogenerated.mdx
@@ -1,9 +1,11 @@
-{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py 
+{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py
 Do not edit it manually, as it will be overwritten */}
 
 ## Authentication
 This provider requires authentication.
 - **api_key**: Anthropic API Key (required: True, sensitive: True)
+- **model**: Claude model to use (required: False, sensitive: False)
+- **system_prompt**: System prompt that sets Claude's role for all requests in this provider. (required: False, sensitive: False)
 
 
 ## In workflows
@@ -19,8 +21,9 @@ steps:
       config: "{{ provider.my_provider_name }}"
       with:
         prompt: {value}  # The prompt to query the model with.
-        model: {value}  # The model to query.
+        model: {value}  # The model to query (overrides provider config).
         max_tokens: {value}  # The maximum number of tokens to generate.
+        system_prompt: {value}  # System prompt override for this call.
         structured_output_format: {value}  # The structured output format to use.
 ```
 

--- a/keep-ui/features/filter/facet.tsx
+++ b/keep-ui/features/filter/facet.tsx
@@ -74,18 +74,23 @@ export const Facet: React.FC<FacetProps> = ({
     (state) => state.facetsConfig?.[facet.id]
   );
 
+  const isFacetActive = useExistingFacetsPanelStore(
+    (state) => !!state.activeFacetIds?.[facet.id]
+  );
+
   const facetStateRef = useRef(facetState);
   facetStateRef.current = facetState;
 
-  // Auto-open a lazy facet once it receives a selection (e.g. restored from URL
-  // query params after mount) so the user can see the active filter.
+  // Auto-open a lazy facet once it becomes active — either it received a
+  // selection (e.g. restored from URL query params after mount) or it was just
+  // added by the user via "Add Facet" — so the user can see its values.
   const didAutoOpenRef = useRef(false);
   useEffect(() => {
-    if (isLazy && !didAutoOpenRef.current && facetState) {
+    if (isLazy && !didAutoOpenRef.current && (facetState || isFacetActive)) {
       didAutoOpenRef.current = true;
       setIsOpen(true);
     }
-  }, [isLazy, facetState]);
+  }, [isLazy, facetState, isFacetActive]);
 
   function getSelectedValues(): string[] {
     return Object.keys(facetStateRef.current || {});

--- a/keep-ui/features/filter/facet.tsx
+++ b/keep-ui/features/filter/facet.tsx
@@ -30,8 +30,12 @@ export const Facet: React.FC<FacetProps> = ({
   // Get preset name from URL
   const presetName = pathname?.split("/").pop() || "default";
 
-  // Store open/close state in localStorage with a unique key per preset and facet
-  const [isOpen, setIsOpen] = useState<boolean>(true);
+  // Lazy facets (e.g. high-cardinality user-defined facets) start collapsed and
+  // only fetch their options when the user expands them. Eagerly mounting and
+  // loading options for every lazy facet is what froze the alerts page when many
+  // (200+) facets existed (see issue #6577).
+  const isLazy = !!facet.is_lazy;
+  const [isOpen, setIsOpen] = useState<boolean>(!isLazy);
   const [isLoaded, setIsLoaded] = useState<boolean>(!!options?.length);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -40,8 +44,14 @@ export const Facet: React.FC<FacetProps> = ({
   const facetRef = useRef(facet);
   facetRef.current = facet;
 
-  const facetOptionsLoadingState = useExistingFacetsPanelStore(
-    (state) => state.facetOptionsLoadingState
+  // Subscribe only to this facet's slice of the loading/selection state.
+  // Previously every Facet subscribed to the whole `facetOptionsLoadingState`
+  // and `facetsState` objects, so toggling one option re-rendered all facets.
+  const facetLoadingState = useExistingFacetsPanelStore(
+    (state) => state.facetOptionsLoadingState[facet.id]
+  );
+  const hasLoadingState = useExistingFacetsPanelStore(
+    (state) => Object.keys(state.facetOptionsLoadingState).length > 0
   );
   const toggleFacetOption = useExistingFacetsPanelStore(
     (state) => state.toggleFacetOption
@@ -52,19 +62,29 @@ export const Facet: React.FC<FacetProps> = ({
   const selectAllFacetOptions = useExistingFacetsPanelStore(
     (state) => state.selectAllFacetOptions
   );
-  const facetsState = useExistingFacetsPanelStore((state) => state.facetsState);
-  const facetState: Record<string, boolean> = useMemo(
-    () => facetsState?.[facet.id],
-    [facet.id, facetsState]
+  const setFacetActive = useExistingFacetsPanelStore(
+    (state) => state.setFacetActive
+  );
+  const facetState: Record<string, boolean> = useExistingFacetsPanelStore(
+    (state) => state.facetsState?.[facet.id]
   );
 
-  const facetsConfig = useExistingFacetsPanelStore(
-    (state) => state.facetsConfig
+  const facetConfig = useExistingFacetsPanelStore(
+    (state) => state.facetsConfig?.[facet.id]
   );
-  const facetConfig = facetsConfig?.[facet.id];
 
   const facetStateRef = useRef(facetState);
   facetStateRef.current = facetState;
+
+  // Auto-open a lazy facet once it receives a selection (e.g. restored from URL
+  // query params after mount) so the user can see the active filter.
+  const didAutoOpenRef = useRef(false);
+  useEffect(() => {
+    if (isLazy && !didAutoOpenRef.current && facetState) {
+      didAutoOpenRef.current = true;
+      setIsOpen(true);
+    }
+  }, [isLazy, facetState]);
 
   function getSelectedValues(): string[] {
     return Object.keys(facetStateRef.current || {});
@@ -140,7 +160,14 @@ export const Facet: React.FC<FacetProps> = ({
   };
 
   const handleExpandCollapse = (isOpen: boolean) => {
-    setIsOpen(!isOpen);
+    const willOpen = !isOpen;
+    setIsOpen(willOpen);
+
+    // Mark the facet active when expanding so its options get loaded. Lazy
+    // facets are inactive until expanded (#6577).
+    if (willOpen) {
+      setFacetActive(facet.id);
+    }
 
     if (!isLoaded && !isLoading) {
       onLoadOptions && onLoadOptions();
@@ -205,10 +232,7 @@ export const Facet: React.FC<FacetProps> = ({
   }
 
   function renderBody() {
-    if (
-      facetOptionsLoadingState[facet.id] === "loading" ||
-      !Object.keys(facetOptionsLoadingState).length
-    ) {
+    if (facetLoadingState === "loading" || !hasLoadingState) {
       return Array.from({ length: 3 }).map((_, index) =>
         renderSkeleton(`skeleton-${index}`)
       );
@@ -283,7 +307,7 @@ export const Facet: React.FC<FacetProps> = ({
             </div>
           )}
           <div
-            className={`max-h-60 overflow-y-auto${facetOptionsLoadingState[facet.id] === "reloading" ? " pointer-events-none opacity-70" : ""}`}
+            className={`max-h-60 overflow-y-auto${facetLoadingState === "reloading" ? " pointer-events-none opacity-70" : ""}`}
           >
             {renderBody()}
           </div>

--- a/keep-ui/features/filter/facet.tsx
+++ b/keep-ui/features/filter/facet.tsx
@@ -8,7 +8,7 @@ import { FacetValue } from "./facet-value";
 import { FacetDto, FacetOptionDto } from "./models";
 import { TrashIcon } from "@heroicons/react/24/outline";
 import { useExistingFacetsPanelStore } from "./store";
-import { stringToValue, valueToString } from "./store/utils";
+import { isLazyFacet, stringToValue, valueToString } from "./store/utils";
 
 export interface FacetProps {
   facet: FacetDto;
@@ -30,11 +30,12 @@ export const Facet: React.FC<FacetProps> = ({
   // Get preset name from URL
   const presetName = pathname?.split("/").pop() || "default";
 
-  // Lazy facets (e.g. high-cardinality user-defined facets) start collapsed and
-  // only fetch their options when the user expands them. Eagerly mounting and
-  // loading options for every lazy facet is what froze the alerts page when many
-  // (200+) facets existed (see issue #6577).
-  const isLazy = !!facet.is_lazy;
+  // Lazy facets (high-cardinality user-defined facets) start collapsed and only
+  // fetch their options when the user expands them. Static facets (severity,
+  // status, source, ...) always render eagerly. Eagerly mounting and loading
+  // options for every lazy facet is what froze the alerts page when many (200+)
+  // facets existed (see issue #6577).
+  const isLazy = isLazyFacet(facet);
   const [isOpen, setIsOpen] = useState<boolean>(!isLazy);
   const [isLoaded, setIsLoaded] = useState<boolean>(!!options?.length);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/keep-ui/features/filter/hooks.tsx
+++ b/keep-ui/features/filter/hooks.tsx
@@ -100,15 +100,22 @@ export const useFacetOptions = (
     }
 
     const fetchedData: FacetOptionsDict = swrValue.data.response;
-    const newFacetOptions: FacetOptionsDict = JSON.parse(
-      JSON.stringify(mergedFacetOptions || {})
-    );
+    // Shallow copy of the per-facet map only; we never mutate the existing
+    // option arrays/objects, so a full JSON deep-clone (which duplicated the
+    // entire options tree on every poll and spiked memory with high facet
+    // cardinality, see #6577) is unnecessary.
+    const newFacetOptions: FacetOptionsDict = { ...(mergedFacetOptions || {}) };
     Object.entries(fetchedData).forEach(([facetId, newOptions]) => {
-      if (newFacetOptions[facetId]) {
-        const currentFacetOptionsMap = newFacetOptions[facetId].reduce(
+      const existingOptions = newFacetOptions[facetId];
+      if (existingOptions) {
+        // Preserve previously known option values with a 0 match count so they
+        // remain visible/selectable, then overlay the freshly fetched counts.
+        const currentFacetOptionsMap = existingOptions.reduce(
           (accumulator, oldOption) => {
-            accumulator[oldOption.display_name] = oldOption;
-            oldOption.matches_count = 0;
+            accumulator[oldOption.display_name] = {
+              ...oldOption,
+              matches_count: 0,
+            };
             return accumulator;
           },
           {} as Record<string, FacetOptionDto>

--- a/keep-ui/features/filter/store/__tests__/facets-store.test.ts
+++ b/keep-ui/features/filter/store/__tests__/facets-store.test.ts
@@ -145,6 +145,56 @@ describe("useInitialStateHandler", () => {
     });
   });
 
+  it("should activate a newly added lazy facet on subsequent setFacets", () => {
+    const freshStore = createFacetsPanelStore();
+    // Initial load: one static + one lazy facet.
+    freshStore.getState().setFacets([
+      {
+        id: "severityFacet",
+        name: "Severity",
+        is_static: true,
+        is_lazy: true,
+      } as FacetDto,
+      {
+        id: "existingLazy",
+        name: "Existing",
+        is_static: false,
+        is_lazy: true,
+      } as FacetDto,
+    ]);
+    expect(freshStore.getState().activeFacetIds).toEqual({
+      severityFacet: true,
+    });
+
+    // User adds a new custom facet -> it should be active immediately, while the
+    // pre-existing lazy facet stays inactive.
+    freshStore.getState().setFacets([
+      {
+        id: "severityFacet",
+        name: "Severity",
+        is_static: true,
+        is_lazy: true,
+      } as FacetDto,
+      {
+        id: "existingLazy",
+        name: "Existing",
+        is_static: false,
+        is_lazy: true,
+      } as FacetDto,
+      {
+        id: "newCustomFacet",
+        name: "Custom Env",
+        is_static: false,
+        is_lazy: true,
+      } as FacetDto,
+    ]);
+
+    expect(freshStore.getState().activeFacetIds).toEqual({
+      severityFacet: true,
+      newCustomFacet: true,
+    });
+  });
+
   it("should mark a lazy facet active via setFacetActive", () => {
     const freshStore = createFacetsPanelStore();
     freshStore.getState().setFacets([

--- a/keep-ui/features/filter/store/__tests__/facets-store.test.ts
+++ b/keep-ui/features/filter/store/__tests__/facets-store.test.ts
@@ -109,6 +109,48 @@ describe("useInitialStateHandler", () => {
     });
   });
 
+  it("should activate only non-lazy facets when facets are set", () => {
+    const freshStore = createFacetsPanelStore();
+    freshStore.getState().setFacets([
+      { id: "staticFacet", name: "Static", is_lazy: false } as FacetDto,
+      { id: "lazyFacet", name: "Lazy", is_lazy: true } as FacetDto,
+    ]);
+
+    expect(freshStore.getState().activeFacetIds).toEqual({
+      staticFacet: true,
+    });
+  });
+
+  it("should mark a lazy facet active via setFacetActive", () => {
+    const freshStore = createFacetsPanelStore();
+    freshStore.getState().setFacets([
+      { id: "lazyFacet", name: "Lazy", is_lazy: true } as FacetDto,
+    ]);
+
+    expect(freshStore.getState().activeFacetIds).toEqual({});
+
+    freshStore.getState().setFacetActive("lazyFacet");
+    expect(freshStore.getState().activeFacetIds).toEqual({ lazyFacet: true });
+  });
+
+  it("should keep only non-lazy facets active after clearFilters", () => {
+    const freshStore = createFacetsPanelStore();
+    freshStore.getState().setFacets([
+      { id: "staticFacet", name: "Static", is_lazy: false } as FacetDto,
+      { id: "lazyFacet", name: "Lazy", is_lazy: true } as FacetDto,
+    ]);
+    freshStore.getState().setFacetActive("lazyFacet");
+    expect(freshStore.getState().activeFacetIds).toEqual({
+      staticFacet: true,
+      lazyFacet: true,
+    });
+
+    freshStore.getState().clearFilters();
+    expect(freshStore.getState().activeFacetIds).toEqual({
+      staticFacet: true,
+    });
+  });
+
   it("should select all facet options correctly", () => {
     const selectAllFacetOptions = store.getState().selectAllFacetOptions;
 

--- a/keep-ui/features/filter/store/__tests__/facets-store.test.ts
+++ b/keep-ui/features/filter/store/__tests__/facets-store.test.ts
@@ -121,6 +121,30 @@ describe("useInitialStateHandler", () => {
     });
   });
 
+  it("should keep static facets active even when is_lazy is true", () => {
+    // The backend marks every facet is_lazy: true by default, so static facets
+    // (severity/status/source) must still be active/eager (#6577 regression).
+    const freshStore = createFacetsPanelStore();
+    freshStore.getState().setFacets([
+      {
+        id: "severityFacet",
+        name: "Severity",
+        is_static: true,
+        is_lazy: true,
+      } as FacetDto,
+      {
+        id: "userFacet",
+        name: "Custom Env",
+        is_static: false,
+        is_lazy: true,
+      } as FacetDto,
+    ]);
+
+    expect(freshStore.getState().activeFacetIds).toEqual({
+      severityFacet: true,
+    });
+  });
+
   it("should mark a lazy facet active via setFacetActive", () => {
     const freshStore = createFacetsPanelStore();
     freshStore.getState().setFacets([

--- a/keep-ui/features/filter/store/__tests__/use-queries-handler.test.ts
+++ b/keep-ui/features/filter/store/__tests__/use-queries-handler.test.ts
@@ -75,6 +75,11 @@ describe("useQueriesHandler", () => {
         ],
       },
       facetsState: {},
+      activeFacetIds: {
+        severityFacet: true,
+        incidentNameFacet: true,
+        statusFacet: true,
+      },
       isFacetsStateInitializedFromQueryParams: false,
       isInitialStateHandled: true,
     });
@@ -172,6 +177,82 @@ describe("useQueriesHandler", () => {
       facetOptionQueries: null,
       filterCel: null,
     });
+  });
+
+  it("should not build option queries for inactive (lazy, not expanded) facets", () => {
+    // Only severity and status are active; incidentNameFacet is lazy/collapsed.
+    store.setState({
+      activeFacetIds: {
+        severityFacet: true,
+        statusFacet: true,
+      },
+    });
+
+    renderHook(() => useQueriesHandler(store));
+
+    act(() => {
+      store.setState({
+        facetsState: {
+          severityFacet: { critical: true, high: true },
+        },
+        facetsStateRefreshToken: "some-token",
+        isFacetsStateInitializedFromQueryParams: true,
+      });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    const { facetOptionQueries } = store.getState().queriesState;
+    expect(facetOptionQueries).not.toBeNull();
+    expect(Object.keys(facetOptionQueries as object).sort()).toEqual([
+      "severityFacet",
+      "statusFacet",
+    ]);
+    expect(facetOptionQueries).not.toHaveProperty("incidentNameFacet");
+  });
+
+  it("should build option queries once an inactive facet becomes active", () => {
+    store.setState({
+      activeFacetIds: {
+        severityFacet: true,
+        statusFacet: true,
+      },
+    });
+
+    renderHook(() => useQueriesHandler(store));
+
+    act(() => {
+      store.setState({
+        facetsState: {
+          severityFacet: { critical: true },
+        },
+        facetsStateRefreshToken: "some-token",
+        isFacetsStateInitializedFromQueryParams: true,
+      });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(store.getState().queriesState.facetOptionQueries).not.toHaveProperty(
+      "incidentNameFacet"
+    );
+
+    // Simulate the user expanding the lazy facet.
+    act(() => {
+      store.getState().setFacetActive("incidentNameFacet");
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(store.getState().queriesState.facetOptionQueries).toHaveProperty(
+      "incidentNameFacet"
+    );
   });
 
   it("should handle complex facet paths correctly", () => {

--- a/keep-ui/features/filter/store/create-facets-store.ts
+++ b/keep-ui/features/filter/store/create-facets-store.ts
@@ -1,7 +1,7 @@
 import { createStore } from "zustand";
 import { v4 as uuidV4 } from "uuid";
 import { FacetDto, FacetOptionDto, FacetsConfig, FacetState } from "../models";
-import { toFacetState, valueToString } from "./utils";
+import { isLazyFacet, toFacetState, valueToString } from "./utils";
 
 export type FacetsPanelState = {
   facetsConfig: FacetsConfig | null;
@@ -73,9 +73,12 @@ export const createFacetsPanelStore = () =>
     setFacets: (facets: FacetDto[]) => {
       const previousActive = state().activeFacetIds || {};
       const activeFacetIds: Record<string, boolean> = { ...previousActive };
-      // Non-lazy facets are always active and load options eagerly.
+      // Eager facets load options immediately. A facet is eager unless it is
+      // explicitly lazy AND not static; static facets (severity/status/source)
+      // must always render their values on load. Only non-static lazy facets
+      // (high-cardinality user-defined facets) are deferred (#6577).
       facets.forEach((facet) => {
-        if (!facet.is_lazy) {
+        if (!isLazyFacet(facet)) {
           activeFacetIds[facet.id] = true;
         }
       });
@@ -218,11 +221,11 @@ export const createFacetsPanelStore = () =>
       set({ isInitialStateHandled }),
 
     clearFilters: () => {
-      // Keep only non-lazy facets active so we don't re-load every lazy facet
+      // Keep only eager facets active so we don't re-load every lazy facet
       // after a reset (#6577).
       const activeFacetIds: Record<string, boolean> = {};
       (state().facets || []).forEach((facet) => {
-        if (!facet.is_lazy) {
+        if (!isLazyFacet(facet)) {
           activeFacetIds[facet.id] = true;
         }
       });

--- a/keep-ui/features/filter/store/create-facets-store.ts
+++ b/keep-ui/features/filter/store/create-facets-store.ts
@@ -71,14 +71,24 @@ export const createFacetsPanelStore = () =>
 
     facets: null,
     setFacets: (facets: FacetDto[]) => {
+      const previousFacets = state().facets;
       const previousActive = state().activeFacetIds || {};
       const activeFacetIds: Record<string, boolean> = { ...previousActive };
+      const previousFacetIds = new Set(
+        (previousFacets || []).map((facet) => facet.id)
+      );
+      // Whether this is the very first time facets are loaded. On subsequent
+      // updates, any facet not seen before is treated as newly added by the
+      // user (via "Add Facet") and should be active/expanded immediately.
+      const isInitialLoad = previousFacets === null;
+
       // Eager facets load options immediately. A facet is eager unless it is
       // explicitly lazy AND not static; static facets (severity/status/source)
       // must always render their values on load. Only non-static lazy facets
       // (high-cardinality user-defined facets) are deferred (#6577).
       facets.forEach((facet) => {
-        if (!isLazyFacet(facet)) {
+        const isNewlyAdded = !isInitialLoad && !previousFacetIds.has(facet.id);
+        if (!isLazyFacet(facet) || isNewlyAdded) {
           activeFacetIds[facet.id] = true;
         }
       });

--- a/keep-ui/features/filter/store/create-facets-store.ts
+++ b/keep-ui/features/filter/store/create-facets-store.ts
@@ -10,6 +10,15 @@ export type FacetsPanelState = {
   facets: FacetDto[] | null;
   setFacets: (facets: FacetDto[]) => void;
 
+  /**
+   * IDs of facets whose options should be loaded. Non-lazy facets are active
+   * immediately; lazy facets become active only once the user expands them or
+   * they have selected options. This prevents loading options for every lazy
+   * facet on mount, which froze the page with high facet cardinality (#6577).
+   */
+  activeFacetIds: Record<string, boolean>;
+  setFacetActive: (facetId: string) => void;
+
   facetOptions: Record<string, FacetOptionDto[]> | null;
   setFacetOptions: (facetOptions: Record<string, FacetOptionDto[]>) => void;
 
@@ -61,7 +70,27 @@ export const createFacetsPanelStore = () =>
     setFacetsConfig: (facetsConfig: FacetsConfig) => set({ facetsConfig }),
 
     facets: null,
-    setFacets: (facets: FacetDto[]) => set({ facets }),
+    setFacets: (facets: FacetDto[]) => {
+      const previousActive = state().activeFacetIds || {};
+      const activeFacetIds: Record<string, boolean> = { ...previousActive };
+      // Non-lazy facets are always active and load options eagerly.
+      facets.forEach((facet) => {
+        if (!facet.is_lazy) {
+          activeFacetIds[facet.id] = true;
+        }
+      });
+      set({ facets, activeFacetIds });
+    },
+
+    activeFacetIds: {},
+    setFacetActive: (facetId: string) => {
+      if (state().activeFacetIds?.[facetId]) {
+        return;
+      }
+      set({
+        activeFacetIds: { ...(state().activeFacetIds || {}), [facetId]: true },
+      });
+    },
 
     facetOptions: null,
     setFacetOptions: (facetOptions: Record<string, FacetOptionDto[]>) =>
@@ -87,9 +116,16 @@ export const createFacetsPanelStore = () =>
 
     facetsState: {},
     patchFacetsState: (facetsStatePatch) => {
+      // Facets that have a (pre)selected state must load their options so the
+      // selection can be reflected, even if they are lazy and collapsed.
+      const activeFacetIds = { ...(state().activeFacetIds || {}) };
+      Object.keys(facetsStatePatch).forEach((facetId) => {
+        activeFacetIds[facetId] = true;
+      });
       set({
         // So that it only triggers refresh when facetsState is patched once
         facetsStateRefreshToken: state().facetsStateRefreshToken || uuidV4(),
+        activeFacetIds,
         facetsState: {
           ...(state().facetsState || {}),
           ...facetsStatePatch,
@@ -125,6 +161,7 @@ export const createFacetsPanelStore = () =>
         // So that it only triggers refresh when facetsState is changed once (option is selected\deselected by user)
         facetsStateRefreshToken: uuidV4(),
         changedFacetId: facetId,
+        activeFacetIds: { ...(state().activeFacetIds || {}), [facetId]: true },
         dirtyFacetIds: Array.from(new Set(state().dirtyFacetIds).add(facetId)),
         facetsState: {
           ...facetsState,
@@ -140,6 +177,7 @@ export const createFacetsPanelStore = () =>
         // So that it only triggers refresh when facetsState is changed once (option is selected\deselected by user)
         facetsStateRefreshToken: uuidV4(),
         changedFacetId: facetId,
+        activeFacetIds: { ...(state().activeFacetIds || {}), [facetId]: true },
         dirtyFacetIds: Array.from(new Set(state().dirtyFacetIds).add(facetId)),
         facetsState: {
           ...facetsState,
@@ -155,6 +193,7 @@ export const createFacetsPanelStore = () =>
         // So that it only triggers refresh when facetsState is changed once (option is selected\deselected by user)
         facetsStateRefreshToken: uuidV4(),
         changedFacetId: facetId,
+        activeFacetIds: { ...(state().activeFacetIds || {}), [facetId]: true },
         dirtyFacetIds: Array.from(new Set(state().dirtyFacetIds).add(facetId)),
         facetsState: {
           ...facetsState,
@@ -179,10 +218,19 @@ export const createFacetsPanelStore = () =>
       set({ isInitialStateHandled }),
 
     clearFilters: () => {
+      // Keep only non-lazy facets active so we don't re-load every lazy facet
+      // after a reset (#6577).
+      const activeFacetIds: Record<string, boolean> = {};
+      (state().facets || []).forEach((facet) => {
+        if (!facet.is_lazy) {
+          activeFacetIds[facet.id] = true;
+        }
+      });
       return set({
         isInitialStateHandled: false,
         facetsState: {},
         facetsStateRefreshToken: uuidV4(),
+        activeFacetIds,
         dirtyFacetIds: [],
       });
     },

--- a/keep-ui/features/filter/store/use-queries-handler.ts
+++ b/keep-ui/features/filter/store/use-queries-handler.ts
@@ -56,6 +56,9 @@ export function useQueriesHandler(store: StoreApi<FacetsPanelState>) {
   const facets = useStore(store, (state) => state.facets);
   const facetsRef = useRef(facets);
   facetsRef.current = facets;
+  const activeFacetIds = useStore(store, (state) => state.activeFacetIds);
+  const activeFacetIdsRef = useRef(activeFacetIds);
+  activeFacetIdsRef.current = activeFacetIds;
   const allFacetOptions = useStore(store, (state) => state.facetOptions);
   const allFacetOptionsRef = useRef(allFacetOptions);
   allFacetOptionsRef.current = allFacetOptions;
@@ -93,7 +96,14 @@ export function useQueriesHandler(store: StoreApi<FacetsPanelState>) {
       return;
     }
 
-    facets.forEach((facet) => {
+    const activeFacets = facets.filter(
+      (facet) => activeFacetIdsRef.current?.[facet.id]
+    );
+
+    // Only build option queries for active facets. Lazy facets that haven't
+    // been expanded (and have no selection) are skipped so we don't fetch
+    // options for hundreds of facets at once (#6577).
+    activeFacets.forEach((facet) => {
       const otherFacetCels = facets
         .filter((f) => f.id !== facet.id)
         .map((f) => facetsCelState?.[f.id])
@@ -110,5 +120,10 @@ export function useQueriesHandler(store: StoreApi<FacetsPanelState>) {
       .join(" && ");
 
     setQueriesState(filterCel, facetOptionQueries);
-  }, [facetsCelState, facets, isFacetsStateInitializedFromQueryParams]);
+  }, [
+    facetsCelState,
+    facets,
+    activeFacetIds,
+    isFacetsStateInitializedFromQueryParams,
+  ]);
 }

--- a/keep-ui/features/filter/store/utils.ts
+++ b/keep-ui/features/filter/store/utils.ts
@@ -1,3 +1,16 @@
+import { FacetDto } from "../models";
+
+/**
+ * Whether a facet should be deferred (collapsed, options loaded only on
+ * expand). Only non-static lazy facets qualify — static facets such as
+ * Severity/Status/Source must always render eagerly. The backend marks every
+ * facet as `is_lazy: true` by default, so `is_static` is the real
+ * discriminator here (#6577).
+ */
+export function isLazyFacet(facet: FacetDto): boolean {
+  return !!facet.is_lazy && !facet.is_static;
+}
+
 export function valueToString(value: any): string {
   if (typeof value === "string") {
     /* Escape single-quote because single-quote is used for string literal mark*/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keep"
-version = "0.52.1"
+version = "0.53.0"
 description = "Alerting. for developers, by developers."
 authors = ["Keep Alerting LTD"]
 packages = [{include = "keep"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keep"
-version = "0.53.0"
+version = "0.54.0"
 description = "Alerting. for developers, by developers."
 authors = ["Keep Alerting LTD"]
 packages = [{include = "keep"}]


### PR DESCRIPTION
## Summary

Fixes #6577 — the Alerts page hangs and spikes browser memory past 1GB when there is high facet cardinality (200+ unique facet fields). The reporter's profiler shows React component-creation allocations concentrated per unique label key, growing an object graph that is never GC'd, blocking the main thread.

### On the "regression from 0.52.0"

I traced the real release boundaries (0.52.0 = #6510, 0.53.0 = #6558). The `features/filter` facets **source code is byte-identical between 0.52.0 and 0.53.0**, and there were no `package.json`/lockfile/Next.js dependency changes in that range. So this is **not** a specific source-line regression — it is a **latent scalability flaw in the facets panel** that the 0.53.0 build exposed (the reporter confirms swapping only `keep-ui` 0.53→0.52 fixes it with the same backend; the profiler points at a minified webpack chunk, consistent with a production-build/bundle difference rather than a source change). Regardless of which build crossed the freeze threshold, the allocation source the profiler identified is the always-present behavior fixed here.

### Root cause (the allocations the profiler points at)

The server-side facets panel does several things that scale poorly with facet count:

- **Every facet renders expanded eagerly and loads options on mount.** One `Facet` component + memoized selectors + render closures are instantiated per facet, all open. The backend already marks user-defined facets as `is_lazy`, but the frontend ignored the flag.
- **Option queries built for all facets at once** via an O(n²) cross-filter loop.
- **Whole-object Zustand subscriptions**: each `Facet` subscribed to the entire `facetsState`/`facetOptionsLoadingState`, so any toggle re-rendered all 200+ facets.
- **`JSON.parse(JSON.stringify(...))` deep clone** of the entire options tree on every ~5s poll — the growing, never-GC'd object graph.

### Changes

- **Respect `is_lazy`**: lazy facets start **collapsed** and only fetch options when expanded (or when they have a restored selection from URL params). A new `activeFacetIds` store concept tracks which facets should load options, preventing the initial bulk-load of 200+ facets.
- **Scope option queries to active facets** in `useQueriesHandler`.
- **Per-facet store subscriptions**: each `Facet` subscribes only to its own slice, eliminating the 200× re-render cascade.
- **Remove the deep clone** in `useFacetOptions` — shallow per-facet merge instead.
- Bumps version `0.53.0` → `0.54.0`.

Note: `ALERT_SIDEBAR_FIELDS` (the workaround attempted in the issue) only controls the alert *detail* sidebar, not the facets filter panel, which is why it had no effect.

## Test plan

- [x] `cd keep-ui && npx jest features/filter` — 48 passed (incl. new tests for lazy activation, expand-to-activate, clear-filters, and excluding inactive facets from option queries)
- [x] `tsc --noEmit` clean for `features/filter` (remaining repo errors are pre-existing/unrelated)
- [ ] Manual: load Alerts page with 200+ facets → page responsive, lazy facets collapsed, options load on expand, memory stays flat
- [ ] Manual: facet selections restored from a shared URL still auto-expand and show the active filter