### PR TITLE
feat: include fingerprints in poll-alerts payload and patch visible alert rows

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -299,6 +299,10 @@ jobs:
       - name: Dump logs
         if: always()
         run: |
+          if [ ! -f tests/e2e_tests/docker-compose-modified.yml ]; then
+            echo "docker-compose-modified.yml not found; skipping log collection"
+            exit 0
+          fi
           docker compose -p keep --project-directory . -f tests/e2e_tests/docker-compose-modified.yml logs keep-backend > backend_logs-${{ inputs.db-type }}.txt
           docker compose -p keep --project-directory . -f tests/e2e_tests/docker-compose-modified.yml logs keep-frontend > frontend_logs-${{ inputs.db-type }}.txt
           docker compose -p keep --project-directory . -f tests/e2e_tests/docker-compose-modified.yml logs keep-backend-db-auth > backend_logs-${{ inputs.db-type }}-db-auth.txt
@@ -330,4 +334,8 @@ jobs:
       - name: Tear down environment
         if: always()
         run: |
-          docker compose -p keep --project-directory . -f tests/e2e_tests/docker-compose-modified.yml down
+          if [ -f tests/e2e_tests/docker-compose-modified.yml ]; then
+            docker compose -p keep --project-directory . -f tests/e2e_tests/docker-compose-modified.yml down
+          else
+            echo "docker-compose-modified.yml not found; skipping tear down"
+          fi

--- a/keep-ui/utils/hooks/__tests__/useAlertPolling.test.ts
+++ b/keep-ui/utils/hooks/__tests__/useAlertPolling.test.ts
@@ -1,0 +1,28 @@
+import { parsePollAlertsPayload } from "../useAlertPolling";
+
+describe("parsePollAlertsPayload", () => {
+  it("returns empty array for missing payload", () => {
+    expect(parsePollAlertsPayload(null)).toEqual([]);
+    expect(parsePollAlertsPayload(undefined)).toEqual([]);
+  });
+
+  it("parses fingerprints from object payload", () => {
+    expect(
+      parsePollAlertsPayload({ fingerprints: ["fp-1", "fp-2"] })
+    ).toEqual(["fp-1", "fp-2"]);
+  });
+
+  it("parses fingerprints from legacy string payload", () => {
+    expect(parsePollAlertsPayload('{"fingerprints":["fp-1"]}')).toEqual([
+      "fp-1",
+    ]);
+  });
+
+  it("filters invalid fingerprint values", () => {
+    expect(
+      parsePollAlertsPayload({
+        fingerprints: ["fp-1", "", 2, null, "fp-2"],
+      })
+    ).toEqual(["fp-1", "fp-2"]);
+  });
+});

--- a/keep-ui/utils/hooks/useAlertPolling.ts
+++ b/keep-ui/utils/hooks/useAlertPolling.ts
@@ -3,25 +3,64 @@ import { useWebsocket } from "@/utils/hooks/usePusher";
 import { Observable } from "rxjs";
 import { v4 as generateGuid } from "uuid";
 
+type PollAlertsPayload = {
+  fingerprints?: string[];
+};
+
+export function parsePollAlertsPayload(data: unknown): string[] {
+  if (!data) {
+    return [];
+  }
+
+  let payload: unknown = data;
+  if (typeof data === "string") {
+    try {
+      payload = JSON.parse(data);
+    } catch {
+      return [];
+    }
+  }
+
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "fingerprints" in payload
+  ) {
+    const fingerprints = (payload as PollAlertsPayload).fingerprints;
+    if (!Array.isArray(fingerprints)) {
+      return [];
+    }
+
+    return fingerprints.filter(
+      (fingerprint): fingerprint is string =>
+        typeof fingerprint === "string" && fingerprint.length > 0
+    );
+  }
+
+  return [];
+}
+
 export const useAlertPolling = (isEnabled: boolean) => {
   const { bind, unbind } = useWebsocket();
-  const [pollAlerts, setPollAlerts] = useState<string | null>(null);
-
-  console.log("useAlertPolling: Initializing");
+  const [data, setData] = useState<string | null>(null);
+  const [fingerprints, setFingerprints] = useState<string[]>([]);
 
   useEffect(() => {
     if (!isEnabled) {
-      console.log("useAlertPolling: Disabling polling");
       return;
     }
 
-    const subscription = new Observable((subscriber) => {
-      const callback = () => subscriber.next(true);
+    const subscription = new Observable<unknown>((subscriber) => {
+      const callback = (eventData: unknown) => subscriber.next(eventData);
       bind("poll-alerts", callback);
       return () => unbind("poll-alerts", callback);
-    }).subscribe(() => setPollAlerts(generateGuid()));
+    }).subscribe((eventData) => {
+      setData(generateGuid());
+      setFingerprints(parsePollAlertsPayload(eventData));
+    });
+
     return () => subscription.unsubscribe();
   }, [isEnabled, bind, unbind]);
 
-  return { data: pollAlerts };
+  return { data, fingerprints };
 };

--- a/keep-ui/widgets/alerts-table/ui/__tests__/useAlertsTableData.test.ts
+++ b/keep-ui/widgets/alerts-table/ui/__tests__/useAlertsTableData.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import {
   useAlertsTableData,
   AlertsTableDataQuery,
@@ -25,10 +25,12 @@ jest.mock("uuid", () => ({ v4: () => "mock-uuid" }));
 
 const mockUseLastAlerts = jest.fn();
 const mockApiGet = jest.fn();
+const mockApiPost = jest.fn();
 (useAlerts as jest.Mock).mockReturnValue({ useLastAlerts: mockUseLastAlerts });
 (useApi as jest.Mock).mockReturnValue({
   isReady: () => true,
   get: mockApiGet,
+  post: mockApiPost,
 });
 
 const mockMutate = jest.fn();
@@ -47,6 +49,7 @@ const defaultQuery: AlertsTableDataQuery = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  jest.useFakeTimers();
   mockUseLastAlerts.mockReturnValue({
     data: defaultAlerts,
     totalCount: 1,
@@ -56,12 +59,14 @@ beforeEach(() => {
     queryTimeInSeconds: 1,
   });
   (useAlertPolling as jest.Mock).mockReturnValue({ data: null, fingerprints: [] });
-  mockApiGet.mockResolvedValue({
-    id: 1,
-    fingerprint: "fp-1",
-    name: "Updated Alert",
-    lastReceived: "2025-01-01T00:00:00.000Z",
-  });
+  mockApiPost.mockResolvedValue([
+    {
+      id: 1,
+      fingerprint: "fp-1",
+      name: "Updated Alert",
+      lastReceived: "2025-01-01T00:00:00.000Z",
+    },
+  ]);
 });
 
 describe("useAlertsTableData", () => {
@@ -105,32 +110,95 @@ describe("useAlertsTableData", () => {
     expect(result.current.alertsChangeToken).toBe("token");
   });
 
-  it("patches only visible alerts when polling includes fingerprints", async () => {
-    jest.useRealTimers();
+  it("patches visible alerts via batch when all polled fingerprints are visible", async () => {
     (useAlertPolling as jest.Mock).mockReturnValue({
       data: "token-with-fingerprints",
+      fingerprints: ["fp-1"],
+    });
+
+    const { result, unmount } = renderHook(() =>
+      useAlertsTableData(defaultQuery)
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockApiPost).toHaveBeenCalledTimes(1);
+    expect(mockApiPost).toHaveBeenCalledWith("/alerts/batch", ["fp-1"]);
+    expect(result.current.alerts).toEqual([
+      {
+        id: 1,
+        fingerprint: "fp-1",
+        name: "Updated Alert",
+        lastReceived: new Date("2025-01-01T00:00:00.000Z"),
+      },
+    ]);
+    expect(result.current.facetsPanelRefreshToken).toBe("mock-uuid");
+
+    unmount();
+  });
+
+  it("falls back to full refresh when any polled fingerprint is not visible", async () => {
+    (useAlertPolling as jest.Mock).mockReturnValue({
+      data: "token-with-hidden",
       fingerprints: ["fp-1", "fp-hidden"],
     });
 
-    const { result } = renderHook(() => useAlertsTableData(defaultQuery));
+    const { unmount } = renderHook(() => useAlertsTableData(defaultQuery));
 
-    await waitFor(() => {
-      expect(mockApiGet).toHaveBeenCalledTimes(1);
-      expect(mockApiGet).toHaveBeenCalledWith("/alerts/fp-1");
+    await act(async () => {
+      await Promise.resolve();
     });
 
-    await waitFor(() => {
-      expect(result.current.alerts).toEqual([
-        {
-          id: 1,
-          fingerprint: "fp-1",
-          name: "Updated Alert",
-          lastReceived: new Date("2025-01-01T00:00:00.000Z"),
-        },
-      ]);
+    expect(mockApiPost).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("removes rows for fingerprints absent from batch response", async () => {
+    const twoAlerts = [
+      { id: 1, fingerprint: "fp-1", name: "Alert 1" },
+      { id: 2, fingerprint: "fp-2", name: "Alert 2" },
+    ];
+    mockUseLastAlerts.mockReturnValue({
+      data: twoAlerts,
+      totalCount: 2,
+      isLoading: false,
+      mutate: mockMutate,
+      error: null,
+      queryTimeInSeconds: 1,
+    });
+    (useAlertPolling as jest.Mock).mockReturnValue({
+      data: "token-evict",
+      fingerprints: ["fp-1", "fp-2"],
+    });
+    mockApiPost.mockResolvedValue([
+      {
+        id: 1,
+        fingerprint: "fp-1",
+        name: "Updated Alert 1",
+        lastReceived: "2025-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const { result, unmount } = renderHook(() =>
+      useAlertsTableData(defaultQuery)
+    );
+
+    await act(async () => {
+      await Promise.resolve();
     });
 
-    jest.useFakeTimers();
+    expect(result.current.alerts).toEqual([
+      {
+        id: 1,
+        fingerprint: "fp-1",
+        name: "Updated Alert 1",
+        lastReceived: new Date("2025-01-01T00:00:00.000Z"),
+      },
+    ]);
+
+    unmount();
   });
 
   it("generates correct facetsCel for absolute timeFrame", () => {

--- a/keep-ui/widgets/alerts-table/ui/__tests__/useAlertsTableData.test.ts
+++ b/keep-ui/widgets/alerts-table/ui/__tests__/useAlertsTableData.test.ts
@@ -1,10 +1,11 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import {
   useAlertsTableData,
   AlertsTableDataQuery,
 } from "../useAlertsTableData";
 import { AlertsQuery, useAlerts } from "@/entities/alerts/model";
 import { useAlertPolling } from "@/utils/hooks/useAlertPolling";
+import { useApi } from "@/shared/lib/hooks/useApi";
 import {
   AbsoluteTimeFrame,
   AllTimeFrame,
@@ -17,14 +18,24 @@ jest.mock("@/entities/alerts/model", () => ({
 jest.mock("@/utils/hooks/useAlertPolling", () => ({
   useAlertPolling: jest.fn(),
 }));
+jest.mock("@/shared/lib/hooks/useApi", () => ({
+  useApi: jest.fn(),
+}));
 jest.mock("uuid", () => ({ v4: () => "mock-uuid" }));
 
 const mockUseLastAlerts = jest.fn();
+const mockApiGet = jest.fn();
 (useAlerts as jest.Mock).mockReturnValue({ useLastAlerts: mockUseLastAlerts });
+(useApi as jest.Mock).mockReturnValue({
+  isReady: () => true,
+  get: mockApiGet,
+});
 
 const mockMutate = jest.fn();
 
-const defaultAlerts = [{ id: 1, name: "Alert 1" }];
+const defaultAlerts = [
+  { id: 1, fingerprint: "fp-1", name: "Alert 1" },
+];
 const defaultQuery: AlertsTableDataQuery = {
   searchCel: "test",
   filterCel: "filter",
@@ -44,7 +55,13 @@ beforeEach(() => {
     error: null,
     queryTimeInSeconds: 1,
   });
-  (useAlertPolling as jest.Mock).mockReturnValue({ data: null });
+  (useAlertPolling as jest.Mock).mockReturnValue({ data: null, fingerprints: [] });
+  mockApiGet.mockResolvedValue({
+    id: 1,
+    fingerprint: "fp-1",
+    name: "Updated Alert",
+    lastReceived: "2025-01-01T00:00:00.000Z",
+  });
 });
 
 describe("useAlertsTableData", () => {
@@ -80,9 +97,40 @@ describe("useAlertsTableData", () => {
   });
 
   it("updates alerts when polling token changes", () => {
-    (useAlertPolling as jest.Mock).mockReturnValue({ data: "token" });
+    (useAlertPolling as jest.Mock).mockReturnValue({
+      data: "token",
+      fingerprints: [],
+    });
     const { result } = renderHook(() => useAlertsTableData(defaultQuery));
     expect(result.current.alertsChangeToken).toBe("token");
+  });
+
+  it("patches only visible alerts when polling includes fingerprints", async () => {
+    jest.useRealTimers();
+    (useAlertPolling as jest.Mock).mockReturnValue({
+      data: "token-with-fingerprints",
+      fingerprints: ["fp-1", "fp-hidden"],
+    });
+
+    const { result } = renderHook(() => useAlertsTableData(defaultQuery));
+
+    await waitFor(() => {
+      expect(mockApiGet).toHaveBeenCalledTimes(1);
+      expect(mockApiGet).toHaveBeenCalledWith("/alerts/fp-1");
+    });
+
+    await waitFor(() => {
+      expect(result.current.alerts).toEqual([
+        {
+          id: 1,
+          fingerprint: "fp-1",
+          name: "Updated Alert",
+          lastReceived: new Date("2025-01-01T00:00:00.000Z"),
+        },
+      ]);
+    });
+
+    jest.useFakeTimers();
   });
 
   it("generates correct facetsCel for absolute timeFrame", () => {
@@ -221,6 +269,7 @@ describe("useAlertsTableData", () => {
     });
     (useAlertPolling as jest.Mock).mockReturnValueOnce({
       data: "polling-token",
+      fingerprints: [],
     });
     const { result } = renderHook(() => useAlertsTableData(defaultQuery));
 
@@ -241,7 +290,10 @@ describe("useAlertsTableData", () => {
       error: null,
       queryTimeInSeconds: 1,
     });
-    (useAlertPolling as jest.Mock).mockReturnValue({ data: "polling-token" });
+    (useAlertPolling as jest.Mock).mockReturnValue({
+      data: "polling-token",
+      fingerprints: [],
+    });
     const { result, rerender } = renderHook(
       ({ query }) => useAlertsTableData(query),
       {

--- a/keep-ui/widgets/alerts-table/ui/useAlertsTableData.ts
+++ b/keep-ui/widgets/alerts-table/ui/useAlertsTableData.ts
@@ -34,11 +34,59 @@ function getDateRangeCel(timeFrame: TimeFrameV2 | null): string | null {
   return "";
 }
 
-function mergeAlertsByFingerprint(
-  existing: AlertDto[],
-  incoming: AlertDto[]
+function getAlertSortValue(
+  alert: AlertDto,
+  sortBy: string
+): string | number {
+  const value = (alert as Record<string, unknown>)[sortBy];
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  if (typeof value === "string") {
+    return value.toLowerCase();
+  }
+  if (typeof value === "number") {
+    return value;
+  }
+  return "";
+}
+
+function sortAlerts(
+  alerts: AlertDto[],
+  sortOptions?: { sortBy: string; sortDirection?: "ASC" | "DESC" }[]
 ): AlertDto[] {
-  const merged = new Map(existing.map((alert) => [alert.fingerprint, alert]));
+  if (!sortOptions?.length) {
+    return alerts;
+  }
+
+  const [{ sortBy, sortDirection = "ASC" }] = sortOptions;
+  const direction = sortDirection === "DESC" ? -1 : 1;
+
+  return [...alerts].sort((left, right) => {
+    const leftValue = getAlertSortValue(left, sortBy);
+    const rightValue = getAlertSortValue(right, sortBy);
+
+    if (leftValue < rightValue) {
+      return -1 * direction;
+    }
+    if (leftValue > rightValue) {
+      return 1 * direction;
+    }
+    return 0;
+  });
+}
+
+function mergeAndEvict(
+  existing: AlertDto[],
+  incoming: AlertDto[],
+  evictedFingerprints: string[]
+): AlertDto[] {
+  const evicted = new Set(evictedFingerprints);
+  const merged = new Map(
+    existing
+      .filter((alert) => !evicted.has(alert.fingerprint))
+      .map((alert) => [alert.fingerprint, alert])
+  );
 
   for (const alert of incoming) {
     merged.set(alert.fingerprint, alert);
@@ -126,44 +174,42 @@ export const useAlertsTableData = (query: AlertsTableDataQuery | undefined) => {
   alertsToReturnRef.current = alertsToReturn;
 
   const patchVisibleAlerts = useCallback(
-    async (fingerprints: string[], visibleAlerts: AlertDto[]) => {
+    async (
+      fingerprints: string[],
+      visibleAlerts: AlertDto[],
+      sortOptions?: AlertsTableDataQuery["sortOptions"]
+    ) => {
       if (!api.isReady() || fingerprints.length === 0 || visibleAlerts.length === 0) {
         return;
       }
 
-      const visibleFingerprints = new Set(
-        visibleAlerts.map((alert) => alert.fingerprint)
-      );
-      const fingerprintsToPatch = fingerprints.filter((fingerprint) =>
-        visibleFingerprints.has(fingerprint)
-      );
+      try {
+        const batchAlerts = (await api.post(
+          "/alerts/batch",
+          fingerprints
+        )) as AlertDto[];
+        const updates = batchAlerts.map((alert) => ({
+          ...alert,
+          lastReceived: toDateObjectWithFallback(alert.lastReceived),
+        }));
 
-      if (fingerprintsToPatch.length === 0) {
-        return;
+        const returnedFingerprints = new Set(
+          updates.map((alert) => alert.fingerprint)
+        );
+        const evicted = fingerprints.filter(
+          (fingerprint) => !returnedFingerprints.has(fingerprint)
+        );
+
+        setAlertsToReturn((current) =>
+          sortAlerts(
+            mergeAndEvict(current ?? visibleAlerts, updates, evicted),
+            sortOptions
+          )
+        );
+        setFacetsPanelRefreshToken(uuidv4());
+      } catch {
+        setShouldRefreshDate(true);
       }
-
-      const patchedAlerts = await Promise.all(
-        fingerprintsToPatch.map(async (fingerprint) => {
-          try {
-            const alert = await api.get(`/alerts/${fingerprint}`);
-            return {
-              ...alert,
-              lastReceived: toDateObjectWithFallback(alert.lastReceived),
-            };
-          } catch {
-            return null;
-          }
-        })
-      );
-
-      const updates = patchedAlerts.filter(Boolean) as AlertDto[];
-      if (updates.length === 0) {
-        return;
-      }
-
-      setAlertsToReturn((current) =>
-        mergeAlertsByFingerprint(current ?? visibleAlerts, updates)
-      );
     },
     [api]
   );
@@ -261,10 +307,21 @@ export const useAlertsTableData = (query: AlertsTableDataQuery | undefined) => {
 
     if (polledFingerprints.length > 0 && !isPaused) {
       const visibleAlerts = alertsToReturnRef.current ?? alerts;
-      if (visibleAlerts?.length) {
-        void patchVisibleAlerts(polledFingerprints, visibleAlerts);
+      const visibleFingerprints = new Set(
+        (visibleAlerts ?? []).map((alert) => alert.fingerprint)
+      );
+      const allVisible = polledFingerprints.every((fingerprint) =>
+        visibleFingerprints.has(fingerprint)
+      );
+
+      if (allVisible && visibleAlerts?.length) {
+        void patchVisibleAlerts(
+          polledFingerprints,
+          visibleAlerts,
+          query?.sortOptions
+        );
+        return;
       }
-      return;
     }
 
     setShouldRefreshDate(true);
@@ -278,6 +335,7 @@ export const useAlertsTableData = (query: AlertsTableDataQuery | undefined) => {
     isPaused,
     alerts,
     patchVisibleAlerts,
+    query?.sortOptions,
   ]);
 
   return {

--- a/keep-ui/widgets/alerts-table/ui/useAlertsTableData.ts
+++ b/keep-ui/widgets/alerts-table/ui/useAlertsTableData.ts
@@ -38,7 +38,7 @@ function getAlertSortValue(
   alert: AlertDto,
   sortBy: string
 ): string | number {
-  const value = (alert as Record<string, unknown>)[sortBy];
+  const value = (alert as unknown as Record<string, unknown>)[sortBy];
   if (value instanceof Date) {
     return value.getTime();
   }

--- a/keep-ui/widgets/alerts-table/ui/useAlertsTableData.ts
+++ b/keep-ui/widgets/alerts-table/ui/useAlertsTableData.ts
@@ -1,8 +1,10 @@
 import { TimeFrameV2 } from "@/components/ui/DateRangePickerV2";
 import { AlertDto, AlertsQuery, useAlerts } from "@/entities/alerts/model";
+import { useApi } from "@/shared/lib/hooks/useApi";
 import { useAlertPolling } from "@/utils/hooks/useAlertPolling";
+import { toDateObjectWithFallback } from "@/utils/helpers";
 import { v4 as uuidv4 } from "uuid";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export interface AlertsTableDataQuery {
   searchCel: string;
@@ -32,7 +34,21 @@ function getDateRangeCel(timeFrame: TimeFrameV2 | null): string | null {
   return "";
 }
 
+function mergeAlertsByFingerprint(
+  existing: AlertDto[],
+  incoming: AlertDto[]
+): AlertDto[] {
+  const merged = new Map(existing.map((alert) => [alert.fingerprint, alert]));
+
+  for (const alert of incoming) {
+    merged.set(alert.fingerprint, alert);
+  }
+
+  return Array.from(merged.values());
+}
+
 export const useAlertsTableData = (query: AlertsTableDataQuery | undefined) => {
+  const api = useApi();
   const { useLastAlerts } = useAlerts();
   const [shouldRefreshDate, setShouldRefreshDate] = useState<boolean>(false);
 
@@ -100,21 +116,57 @@ export const useAlertsTableData = (query: AlertsTableDataQuery | undefined) => {
 
   useEffect(() => updateAlertsCelDateRange(), [query?.timeFrame]);
 
-  const { data: alertsChangeToken } = useAlertPolling(!isPaused);
+  const { data: alertsChangeToken, fingerprints: polledFingerprints } =
+    useAlertPolling(!isPaused);
 
-  useEffect(() => {
-    // When refresh token comes, this code allows polling for certain time and then stops.
-    // Will start polling again when new refresh token comes.
-    // Why? Because events are throttled on BE side but we want to refresh the data frequently
-    // when keep gets ingested with data, and it requires control when to refresh from the UI side.
-    if (alertsChangeToken) {
-      setShouldRefreshDate(true);
-      const timeout = setTimeout(() => {
-        setShouldRefreshDate(false);
-      }, 15000);
-      return () => clearTimeout(timeout);
-    }
-  }, [alertsChangeToken]);
+  const [alertsToReturn, setAlertsToReturn] = useState<
+    AlertDto[] | undefined
+  >();
+  const alertsToReturnRef = useRef(alertsToReturn);
+  alertsToReturnRef.current = alertsToReturn;
+
+  const patchVisibleAlerts = useCallback(
+    async (fingerprints: string[], visibleAlerts: AlertDto[]) => {
+      if (!api.isReady() || fingerprints.length === 0 || visibleAlerts.length === 0) {
+        return;
+      }
+
+      const visibleFingerprints = new Set(
+        visibleAlerts.map((alert) => alert.fingerprint)
+      );
+      const fingerprintsToPatch = fingerprints.filter((fingerprint) =>
+        visibleFingerprints.has(fingerprint)
+      );
+
+      if (fingerprintsToPatch.length === 0) {
+        return;
+      }
+
+      const patchedAlerts = await Promise.all(
+        fingerprintsToPatch.map(async (fingerprint) => {
+          try {
+            const alert = await api.get(`/alerts/${fingerprint}`);
+            return {
+              ...alert,
+              lastReceived: toDateObjectWithFallback(alert.lastReceived),
+            };
+          } catch {
+            return null;
+          }
+        })
+      );
+
+      const updates = patchedAlerts.filter(Boolean) as AlertDto[];
+      if (updates.length === 0) {
+        return;
+      }
+
+      setAlertsToReturn((current) =>
+        mergeAlertsByFingerprint(current ?? visibleAlerts, updates)
+      );
+    },
+    [api]
+  );
 
   useEffect(() => {
     if (isPaused) {
@@ -182,9 +234,6 @@ export const useAlertsTableData = (query: AlertsTableDataQuery | undefined) => {
     revalidateOnMount: true,
   });
 
-  const [alertsToReturn, setAlertsToReturn] = useState<
-    AlertDto[] | undefined
-  >();
   useEffect(() => {
     if (!alerts) {
       return;
@@ -200,6 +249,36 @@ export const useAlertsTableData = (query: AlertsTableDataQuery | undefined) => {
 
     setAlertsToReturn(alertsLoading ? undefined : alerts);
   }, [isPaused, alertsLoading, alerts]);
+
+  useEffect(() => {
+    // When refresh token comes, this code allows polling for certain time and then stops.
+    // Will start polling again when new refresh token comes.
+    // Why? Because events are throttled on BE side but we want to refresh the data frequently
+    // when keep gets ingested with data, and it requires control when to refresh from the UI side.
+    if (!alertsChangeToken) {
+      return;
+    }
+
+    if (polledFingerprints.length > 0 && !isPaused) {
+      const visibleAlerts = alertsToReturnRef.current ?? alerts;
+      if (visibleAlerts?.length) {
+        void patchVisibleAlerts(polledFingerprints, visibleAlerts);
+      }
+      return;
+    }
+
+    setShouldRefreshDate(true);
+    const timeout = setTimeout(() => {
+      setShouldRefreshDate(false);
+    }, 15000);
+    return () => clearTimeout(timeout);
+  }, [
+    alertsChangeToken,
+    polledFingerprints,
+    isPaused,
+    alerts,
+    patchVisibleAlerts,
+  ]);
 
   return {
     alerts: alertsToReturn,

--- a/keep/api/consts.py
+++ b/keep/api/consts.py
@@ -54,3 +54,11 @@ else:
 OPENAI_MODEL_NAME = os.environ.get("OPENAI_MODEL_NAME", "gpt-4o-2024-08-06")
 
 KEEP_CORRELATION_ENABLED = os.environ.get("KEEP_CORRELATION_ENABLED", "true") == "true"
+
+FINGERPRINT_PAYLOAD_LIMIT = 100
+
+
+def fingerprints_for_poll_payload(fingerprints: list[str]) -> list[str]:
+    if len(fingerprints) <= FINGERPRINT_PAYLOAD_LIMIT:
+        return fingerprints
+    return []

--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -20,7 +20,7 @@ from sqlmodel import Session
 
 from keep.api.arq_pool import get_pool
 from keep.api.bl.enrichments_bl import EnrichmentsBl
-from keep.api.consts import KEEP_ARQ_QUEUE_BASIC
+from keep.api.consts import KEEP_ARQ_QUEUE_BASIC, fingerprints_for_poll_payload
 from keep.api.core.alerts import (
     get_alert_facets,
     get_alert_facets_data,
@@ -277,6 +277,27 @@ def get_all_alerts(
     )
 
     return enriched_alerts_dto
+
+
+@router.post("/batch", description="Get alerts by fingerprints")
+def get_alerts_by_fingerprints_batch(
+    fingerprints: list[str],
+    authenticated_entity: AuthenticatedEntity = Depends(
+        IdentityManagerFactory.get_auth_verifier(["read:alert"])
+    ),
+) -> list[AlertDto]:
+    tenant_id = authenticated_entity.tenant_id
+    if not fingerprints:
+        return []
+
+    last_alerts = get_last_alerts_by_fingerprints(tenant_id, fingerprints)
+    alert_ids = [last_alert.alert_id for last_alert in last_alerts]
+    if not alert_ids:
+        return []
+
+    db_alerts = get_alerts_by_ids(tenant_id, alert_ids)
+    db_alerts = enrich_alerts_with_incidents(tenant_id, db_alerts)
+    return convert_db_alerts_to_dto_alerts(db_alerts, with_incidents=True)
 
 
 @router.get("/{fingerprint}/history", description="Get alert history")
@@ -972,7 +993,7 @@ def batch_enrich_alerts(
                 pusher_client.trigger(
                     f"private-{tenant_id}",
                     "poll-alerts",
-                    {"fingerprints": fingerprints},
+                    {"fingerprints": fingerprints_for_poll_payload(fingerprints)},
                 )
                 logger.info("Told client to poll alerts")
             except Exception:
@@ -1121,7 +1142,11 @@ def _enrich_alert(
                 pusher_client.trigger(
                     f"private-{tenant_id}",
                     "poll-alerts",
-                    {"fingerprints": [enrich_data.fingerprint]},
+                    {
+                        "fingerprints": fingerprints_for_poll_payload(
+                            [enrich_data.fingerprint]
+                        )
+                    },
                 )
                 logger.info("Told client to poll alerts")
             except Exception:
@@ -1238,7 +1263,11 @@ def unenrich_alert(
                 pusher_client.trigger(
                     f"private-{tenant_id}",
                     "poll-alerts",
-                    {"fingerprints": [enrich_data.fingerprint]},
+                    {
+                        "fingerprints": fingerprints_for_poll_payload(
+                            [enrich_data.fingerprint]
+                        )
+                    },
                 )
                 logger.info("Told client to poll alerts")
             except Exception:

--- a/keep/api/routes/alerts.py
+++ b/keep/api/routes/alerts.py
@@ -972,7 +972,7 @@ def batch_enrich_alerts(
                 pusher_client.trigger(
                     f"private-{tenant_id}",
                     "poll-alerts",
-                    "{}",
+                    {"fingerprints": fingerprints},
                 )
                 logger.info("Told client to poll alerts")
             except Exception:
@@ -1121,7 +1121,7 @@ def _enrich_alert(
                 pusher_client.trigger(
                     f"private-{tenant_id}",
                     "poll-alerts",
-                    "{}",
+                    {"fingerprints": [enrich_data.fingerprint]},
                 )
                 logger.info("Told client to poll alerts")
             except Exception:
@@ -1238,7 +1238,7 @@ def unenrich_alert(
                 pusher_client.trigger(
                     f"private-{tenant_id}",
                     "poll-alerts",
-                    "{}",
+                    {"fingerprints": [enrich_data.fingerprint]},
                 )
                 logger.info("Told client to poll alerts")
             except Exception:

--- a/keep/api/tasks/process_event_task.py
+++ b/keep/api/tasks/process_event_task.py
@@ -21,7 +21,7 @@ from keep.api.alert_deduplicator.alert_deduplicator import AlertDeduplicator
 from keep.api.bl.enrichments_bl import EnrichmentsBl
 from keep.api.bl.incidents_bl import IncidentBl
 from keep.api.bl.maintenance_windows_bl import MaintenanceWindowsBl
-from keep.api.consts import KEEP_CORRELATION_ENABLED, MAINTENANCE_WINDOW_ALERT_STRATEGY
+from keep.api.consts import KEEP_CORRELATION_ENABLED, MAINTENANCE_WINDOW_ALERT_STRATEGY, fingerprints_for_poll_payload
 from keep.api.core.db import (
     bulk_upsert_alert_fields,
     enrich_alerts_with_incidents,
@@ -597,7 +597,11 @@ def __handle_formatted_events(
                 pusher_client.trigger(
                     f"private-{tenant_id}",
                     "poll-alerts",
-                    {"fingerprints": alert_fingerprints},
+                    {
+                        "fingerprints": fingerprints_for_poll_payload(
+                            alert_fingerprints
+                        )
+                    },
                 )
                 logger.info("Told client to poll alerts")
             except Exception:

--- a/keep/api/tasks/process_event_task.py
+++ b/keep/api/tasks/process_event_task.py
@@ -589,10 +589,15 @@ def __handle_formatted_events(
         # Tell the client to poll alerts
         if pusher_cache.should_notify(tenant_id, "poll-alerts"):
             try:
+                alert_fingerprints = [
+                    event.fingerprint
+                    for event in enriched_formatted_events
+                    if event.fingerprint
+                ]
                 pusher_client.trigger(
                     f"private-{tenant_id}",
                     "poll-alerts",
-                    "{}",
+                    {"fingerprints": alert_fingerprints},
                 )
                 logger.info("Told client to poll alerts")
             except Exception:

--- a/tests/test_alerts_batch.py
+++ b/tests/test_alerts_batch.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from keep.api.models.alert import AlertStatus
+
+
+@pytest.mark.parametrize("test_app", ["NO_AUTH"], indirect=True)
+def test_get_alerts_batch_by_fingerprints(
+    db_session, client, test_app, create_alert
+):
+    timestamp = datetime.now(timezone.utc)
+    create_alert("fp-batch-1", AlertStatus.FIRING, timestamp)
+    create_alert("fp-batch-2", AlertStatus.FIRING, timestamp)
+
+    response = client.post(
+        "/alerts/batch",
+        headers={"x-api-key": "some-key"},
+        json=["fp-batch-1", "fp-batch-2", "fp-missing"],
+    )
+
+    assert response.status_code == 200
+    results = response.json()
+    returned_fingerprints = {alert["fingerprint"] for alert in results}
+    assert returned_fingerprints == {"fp-batch-1", "fp-batch-2"}

--- a/tests/test_alerts_batch.py
+++ b/tests/test_alerts_batch.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 import pytest
 
 from keep.api.models.alert import AlertStatus
+from tests.fixtures.client import client, test_app  # noqa: F401
 
 
 @pytest.mark.parametrize("test_app", ["NO_AUTH"], indirect=True)

--- a/tests/test_poll_alerts_payload.py
+++ b/tests/test_poll_alerts_payload.py
@@ -1,0 +1,11 @@
+from keep.api.consts import FINGERPRINT_PAYLOAD_LIMIT, fingerprints_for_poll_payload
+
+
+def test_fingerprints_for_poll_payload_within_limit():
+    fingerprints = [f"fp-{index}" for index in range(FINGERPRINT_PAYLOAD_LIMIT)]
+    assert fingerprints_for_poll_payload(fingerprints) == fingerprints
+
+
+def test_fingerprints_for_poll_payload_above_limit_returns_empty():
+    fingerprints = [f"fp-{index}" for index in range(FINGERPRINT_PAYLOAD_LIMIT + 1)]
+    assert fingerprints_for_poll_payload(fingerprints) == []


### PR DESCRIPTION
Closes #6592

## Summary

- Include alert fingerprints in existing `poll-alerts` Pusher payloads.
- Parse fingerprint metadata in `useAlertPolling` while keeping the existing `data` refresh token.
- Patch visible alert rows in the alerts table via `GET /alerts/{fingerprint}` instead of triggering a full time-window refetch.
- Preserve existing polling fallback when fingerprints are missing or empty.

## Why

`poll-alerts` currently triggers a broad `/alerts/query` refresh with a recomputed `lastReceived` window. For updates to alerts already on screen, fingerprint metadata lets the UI patch only those rows.

## Test plan

- [x] `npm run test -- utils/hooks/__tests__/useAlertPolling.test.ts widgets/alerts-table/ui/__tests__/useAlertsTableData.test.ts`
