### PR TITLE
fix(conditions): compare percentage thresholds numerically

### DIFF
--- a/keep/conditions/threshold_condition.py
+++ b/keep/conditions/threshold_condition.py
@@ -87,6 +87,8 @@ class ThresholdCondition(BaseCondition):
                     compare_to, compare_value
                 )
             )
+        if self._is_percentage(compare_to) and self._is_percentage(compare_value):
+            return float(compare_to.strip("%")), float(compare_value.strip("%"))
         return compare_to, compare_value
 
     def apply(self, compare_to, compare_value) -> bool:

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -114,6 +114,20 @@ def test_threshold_condition_one_value_is_precentage():
         threshold_condition.apply("90", "80%")
 
 
+def test_threshold_condition_percentage_values_compared_numerically():
+    context_manager = ContextManager(tenant_id="mock", workflow_id=None)
+    threshold_condition = ThresholdCondition(
+        context_manager=context_manager,
+        condition_type="threshold",
+        condition_name="mock",
+        condition_config={"compare_type": "gt"},
+    )
+    # Percentages must be compared numerically, not lexicographically:
+    # as strings "100%" < "90%" and "9%" > "50%".
+    assert threshold_condition.apply("90%", "100%") is True
+    assert threshold_condition.apply("50%", "9%") is False
+
+
 def test_threshold_condition_multithreshold():
     context_manager = ContextManager(tenant_id="mock", workflow_id=None)
     threshold_condition = ThresholdCondition(


### PR DESCRIPTION
## Linked Issue

Fixes #6604

## Description

`ThresholdCondition._validate` returns percentage values (e.g. `"90%"`, `"100%"`) unchanged as strings, so `_apply_threshold` then compares them **lexicographically** instead of numerically:

- `"100%" > "90%"` → `False` (because `'1' < '9'`)
- `"9%" > "50%"` → `True` (because `'9' > '5'`)

So a workflow threshold like `compare_to: 90%` (see `examples/workflows/db_disk_space_monitor.yml`) **fails to fire when the actual value is 100%** — a silently missed alert in a monitoring tool.

`_validate` already deliberately accepts two percentage strings (via `_is_percentage`), so the fix is: when **both** values are percentages, strip the `%` and convert to `float` before returning, so the `gt`/`lt` comparison is numeric. Numeric-vs-numeric and mixed numeric/percentage inputs are unaffected (the latter still raise as before).

## Test

Added `test_threshold_condition_percentage_values_compared_numerically` to `tests/test_conditions.py`:

- `apply("90%", "100%")` is `True` (was `False`)
- `apply("50%", "9%")` is `False` (was `True`)

Both assertions fail before this change and pass after. `ruff check` and `ruff format` pass locally.
