### PR TITLE
feat(ai): add option to disable temperature in AI requests

### DIFF
--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -204,6 +204,7 @@ The authenticated entity will have:
 |    **OPENAI_MODEL_NAME**    |       Model name to use for OpenAI requests        |    No    | "gpt-4o-2024-08-06" | Valid OpenAI model name (e.g., "gpt-4o", "gpt-4o-mini", ...) |       Both       |
 | **OPEN_AI_ORGANIZATION_ID** |        Organization ID for OpenAI services         |    No    |        None         |                 Valid OpenAI organization ID                 |       Both       |
 |     **OPENAI_BASE_URL**     | Base URL for OpenAI API (useful for LiteLLM proxy) |    No    |        None         |          Valid URL (e.g., "http://localhost:4000")           |       Both       |
+| **KEEP_AI_DISABLE_TEMPERATURE** | Omit the `temperature` parameter from AI requests (some models, e.g. reasoning models, only accept the default and reject explicit values) |    No    |        false        |                       true / false                       |     Backend      |
 
 <Tip>
   For various different LLM based features, we also require to set these

--- a/keep/api/bl/ai_suggestion_bl.py
+++ b/keep/api/bl/ai_suggestion_bl.py
@@ -21,6 +21,7 @@ from keep.api.models.incident import (
     IncidentDto,
     IncidentsClusteringSuggestion,
 )
+from keep.api.utils.ai_utils import get_ai_temperature_kwargs
 
 
 class AISuggestionBl:
@@ -461,7 +462,7 @@ class AISuggestionBl:
                     },
                 },
             },
-            temperature=0.2,
+            **get_ai_temperature_kwargs(0.2),
         )
 
     def _process_incidents(

--- a/keep/api/bl/incident_reports.py
+++ b/keep/api/bl/incident_reports.py
@@ -12,6 +12,7 @@ from keep.api.bl.incidents_bl import IncidentBl
 from keep.api.consts import OPENAI_MODEL_NAME
 from keep.api.models.db.incident import IncidentStatus
 from keep.api.models.incident import IncidentDto
+from keep.api.utils.ai_utils import get_ai_temperature_kwargs
 
 
 class IncidentMetrics(BaseModel):
@@ -163,7 +164,7 @@ class IncidentReportsBl:
                 },
             },
             seed=1239,
-            temperature=0.2,
+            **get_ai_temperature_kwargs(0.2),
         )
 
         model_response = response.choices[0].message.content

--- a/keep/api/utils/ai_utils.py
+++ b/keep/api/utils/ai_utils.py
@@ -1,0 +1,22 @@
+import os
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def is_ai_temperature_disabled() -> bool:
+    """Whether the ``temperature`` parameter should be omitted from AI requests.
+
+    Controlled by the ``KEEP_AI_DISABLE_TEMPERATURE`` environment variable. Some
+    models (e.g. OpenAI reasoning models) only accept the default temperature and
+    reject any explicit value with a 400 error, so this allows opting out.
+    """
+    return os.environ.get("KEEP_AI_DISABLE_TEMPERATURE", "false").strip().lower() in _TRUTHY
+
+
+def get_ai_temperature_kwargs(temperature: float = 0.2) -> dict:
+    """Return the ``temperature`` kwargs for an AI completion request.
+
+    Returns an empty dict when temperature is disabled (see
+    :func:`is_ai_temperature_disabled`), so the parameter is omitted entirely.
+    """
+    return {} if is_ai_temperature_disabled() else {"temperature": temperature}

--- a/tests/test_ai_utils.py
+++ b/tests/test_ai_utils.py
@@ -1,0 +1,27 @@
+import pytest
+
+from keep.api.utils.ai_utils import (
+    get_ai_temperature_kwargs,
+    is_ai_temperature_disabled,
+)
+
+
+def test_temperature_included_by_default(monkeypatch):
+    monkeypatch.delenv("KEEP_AI_DISABLE_TEMPERATURE", raising=False)
+    assert is_ai_temperature_disabled() is False
+    assert get_ai_temperature_kwargs() == {"temperature": 0.2}
+    assert get_ai_temperature_kwargs(0.7) == {"temperature": 0.7}
+
+
+@pytest.mark.parametrize("value", ["true", "True", "TRUE", " 1 ", "yes", "on"])
+def test_temperature_omitted_when_disabled(monkeypatch, value):
+    monkeypatch.setenv("KEEP_AI_DISABLE_TEMPERATURE", value)
+    assert is_ai_temperature_disabled() is True
+    assert get_ai_temperature_kwargs(0.2) == {}
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", ""])
+def test_temperature_kept_for_falsy_values(monkeypatch, value):
+    monkeypatch.setenv("KEEP_AI_DISABLE_TEMPERATURE", value)
+    assert is_ai_temperature_disabled() is False
+    assert get_ai_temperature_kwargs(0.2) == {"temperature": 0.2}


### PR DESCRIPTION
## Closes #6538

### Problem

AI incident creation and incident reports issue OpenAI chat completions with a hardcoded `temperature=0.2`. Some models — notably OpenAI reasoning models — only accept the default temperature and reject any explicit value, failing the whole request:

```
AI incident creation failed: Error code: 400 - Unsupported value: 'temperature'
does not support 0.2 with this model. Only the default (1) value is supported.
```

There was no way to point Keep's AI features at such a model.

### Change

Add a `KEEP_AI_DISABLE_TEMPERATURE` flag (default `false`, behavior unchanged). When set to `true`, the `temperature` parameter is omitted entirely from the AI completion requests, so requests to models that reject it succeed.

- New helper `keep/api/utils/ai_utils.py` (`get_ai_temperature_kwargs` / `is_ai_temperature_disabled`) centralizes the decision.
- Wired into both call sites that send `temperature`: `AISuggestionBl._get_ai_completion` and `IncidentReportsBl` report generation.
- Documented under the OpenAI section in `docs/deployment/configuration.mdx`.

### Tests

`tests/test_ai_utils.py` covers default-on, disabled (truthy variants), and falsy variants:

```
$ pytest tests/test_ai_utils.py -q
12 passed
```

Verified fail-before/pass-after: with the flag logic removed (pre-feature behavior) the "disabled" cases fail; with it, all pass.