### PR TITLE
fix: 6598 incident enrichment foreach context

### DIFF
--- a/keep/providers/base/base_provider.py
+++ b/keep/providers/base/base_provider.py
@@ -229,6 +229,9 @@ class BaseProvider(metaclass=abc.ABCMeta):
             # in case the foreach itself doesn't have a fingerprint, use the event fingerprint
             elif self.context_manager.event_context:
                 fingerprint = self.context_manager.event_context.fingerprint
+            elif self.context_manager.incident_context:
+                entity_type = "incident"
+                fingerprint = self.context_manager.incident_context.id    
             else:
                 self.logger.warning(
                     "No fingerprint found for alert enrichment",

--- a/tests/test_enrichments.py
+++ b/tests/test_enrichments.py
@@ -1106,6 +1106,95 @@ def test_incident_workflow_enrichment_integration(db_session, client, test_app):
     ],
     indirect=True,
 )
+def test_incident_workflow_enrichment_with_foreach_service_context(
+    db_session, client, test_app
+):
+    """
+    Regression test: incident enrichment should use the incident context when a
+    workflow action is inside a foreach loop over plain service names.
+    """
+
+    workflow_definition = """workflow:
+  id: incident-foreach-service-enricher-test
+  name: Incident Foreach Service Enricher Test
+  description: Test workflow that enriches incidents from foreach service context
+  disabled: false
+  triggers:
+    - type: incident
+      events:
+        - created
+  actions:
+    - name: enrich-service-ticket
+      foreach: "{{ incident.services }}"
+      if: '{{ foreach.value }} == "service"'
+      provider:
+        type: console
+        with:
+          message: "Enriching incident {{ incident.user_generated_name }} for {{ foreach.value }}"
+          enrich_incident:
+            - key: jira_ticket_url
+              value: "https://jira.example.com/browse/KAN-1"
+"""
+
+    workflow = Workflow(
+        id="incident-foreach-service-enricher-test",
+        name="Incident Foreach Service Enricher Test",
+        tenant_id=SINGLE_TENANT_UUID,
+        description="Test workflow that enriches incidents from foreach service context",
+        created_by="test@keephq.dev",
+        interval=0,
+        workflow_raw=workflow_definition,
+        last_updated=datetime.utcnow(),
+    )
+    db_session.add(workflow)
+    db_session.commit()
+
+    incident_payload = {
+        "user_generated_name": "Test Incident for Foreach Service Enrichment",
+        "user_summary": "Test incident for foreach service enrichment regression",
+        "severity": "critical",
+        "status": "firing",
+        "affected_services": ["service"],
+    }
+
+    response = client.post(
+        "/incidents",
+        headers={"x-api-key": "some-key"},
+        json=incident_payload,
+    )
+    assert response.status_code == 202
+    incident_id = response.json()["id"]
+
+    assert wait_for_workflow_in_run_queue("incident-foreach-service-enricher-test")
+
+    workflow_execution = wait_for_workflow_execution(
+        SINGLE_TENANT_UUID, "incident-foreach-service-enricher-test"
+    )
+
+    assert workflow_execution is not None
+    assert workflow_execution.status == "success"
+
+    response = client.get(
+        f"/incidents/{incident_id}",
+        headers={"x-api-key": "some-key"},
+    )
+    assert response.status_code == 200
+    incident_data = response.json()
+
+    assert incident_data["services"] == ["service"]
+    assert incident_data["enrichments"]["jira_ticket_url"] == (
+        "https://jira.example.com/browse/KAN-1"
+    )
+
+
+@pytest.mark.parametrize(
+    "test_app, db_session",
+    [
+        ("NO_AUTH", None),
+        ("NO_AUTH", {"db": "mysql"}),
+    ],
+    indirect=True,
+)
 def test_alert_enrichment_via_api_uuid(db_session, client, test_app, create_alert):
     fingerprint = str(uuid.uuid4())
 


### PR DESCRIPTION
## Closes #6598

### Description
Fixes incident enrichment failures when an incident workflow action runs inside a `foreach` loop over `incident.services`.

### Problem
When a workflow looped over `incident.services` and then called `enrich_incident`, enrichment failed with:

```
No fingerprint found for alert enrichment
```

The Jira ticket itself was created successfully, but the subsequent enrichment step failed.

### Root Cause
`foreach.value` in this context resolves to a plain string (e.g. `"service"`) rather than an object containing a fingerprint. Enrichment relied on resolving a fingerprint from the foreach context and had no fallback when one wasn't available, even though an active incident was present.

### Fix
When the foreach context does not yield a resolvable fingerprint, enrichment now falls back to `incident_context.id` for incident-triggered workflows, allowing the result (e.g. `jira_ticket_url`) to be saved correctly on the incident.

https://github.com/user-attachments/assets/daf051c9-7542-4e59-a8a7-76c684b7a3fd

### Environment
- Setup: Local, no Docker
- Auth mode: `db`

### Testing
**Automated:**
Added a regression test covering the full flow:
- Incident-created workflow trigger
- `foreach: "{{ incident.services }}"`
- `enrich_incident` action
- Assertion that `jira_ticket_url` is saved on the incident

**Manual:**
Verified end-to-end on a local (non-Docker) setup with `auth_mode: db`, confirming both Jira issue creation and incident enrichment completed successfully.

### Time Taken
~2 hours (setup + investigation + fix + regression test)

### Checks
- [x] Adheres to project code style
- [ ] Documentation changes required
- [ ] Documentation updated
- [x] All tests passing

### Additional Notes — What I Learned
While debugging, I traced how Keep incident workflows move through the system:
1. Incident creation triggers workflow execution.
2. `foreach` changes the active workflow context per iteration.
3. Provider actions return results (e.g. a Jira `ticket_url`).
4. `enrich_incident` writes those results back onto the incident.
5. Enrichment target resolution depends on context — foreach context, alert event context, or incident context, in that order of precedence.