### PR TITLE
feat: lock an incident after a configurable max window

### DIFF
--- a/docs/overview/correlation-rules.mdx
+++ b/docs/overview/correlation-rules.mdx
@@ -26,6 +26,12 @@ Creating a rule involves defining the conditions under which an alert should be 
  - **Logical grouping**: Combine conditions using logical operators to form comprehensive rules.
  - **Manual approve**: Create Incident-candidate or full-fledged incident.
 
+## Locking an Incident After a Maximum Window
+
+By default a correlation rule keeps extending the same incident as long as matching alerts keep arriving within the rule timeframe, so a long-running condition can stay in a single incident indefinitely.
+
+Set **Max incident window** (in seconds) on a rule to cap this: once an incident is older than the window (measured from its creation time), the next matching alert opens a fresh incident instead of extending the old one. Leaving it empty keeps the default behavior.
+
 ## Dynamic Incident Naming
 
 The correlation engine supports dynamic incident naming based on alert attributes. This allows you to create more meaningful and context-aware incident names that reflect the actual alert data.

--- a/keep/api/core/db.py
+++ b/keep/api/core/db.py
@@ -48,6 +48,7 @@ from sqlalchemy.orm.attributes import flag_modified
 
 from keep.api.consts import STATIC_PRESETS
 from keep.api.core.config import config
+from keep.api.utils.incident_expiry import compute_incident_expired
 from keep.api.core.db_utils import (
     create_db_engine,
     custom_serialize,
@@ -2241,6 +2242,7 @@ def create_rule(
     multi_level_property_name=None,
     threshold=1,
     assignee=None,
+    max_incident_window=None,
 ):
     grouping_criteria = grouping_criteria or []
     with Session(engine) as session:
@@ -2264,6 +2266,7 @@ def create_rule(
             multi_level_property_name=multi_level_property_name,
             threshold=threshold,
             assignee=assignee,
+            max_incident_window=max_incident_window,
         )
         session.add(rule)
         session.commit()
@@ -2290,6 +2293,7 @@ def update_rule(
     multi_level_property_name,
     threshold,
     assignee=None,
+    max_incident_window=None,
 ):
     rule_uuid = __convert_to_uuid(rule_id)
     if not rule_uuid:
@@ -2318,6 +2322,7 @@ def update_rule(
             rule.multi_level_property_name = multi_level_property_name
             rule.threshold = threshold
             rule.assignee = assignee
+            rule.max_incident_window = max_incident_window
             session.commit()
             session.refresh(rule)
             return rule
@@ -2389,23 +2394,31 @@ def get_incident_for_grouping_rule(
             .order_by(Incident.creation_time.desc())
         ).first()
 
-        # if the last alert in the incident is older than the timeframe, create a new incident
-        is_incident_expired = False
-        if incident and incident.status in [
-            IncidentStatus.RESOLVED.value,
-            IncidentStatus.MERGED.value,
-            IncidentStatus.DELETED.value,
-        ]:
-            is_incident_expired = True
-        elif incident and incident.alerts_count > 0:
-            enrich_incidents_with_alerts(tenant_id, [incident], session)
-            is_incident_expired = max(
-                alert.timestamp for alert in incident.alerts
-            ) < datetime.utcnow() - timedelta(seconds=rule.timeframe)
-
-        # if there is no incident with the rule_fingerprint, create it or existed is already expired
+        # if there is no incident with the rule_fingerprint, create it
         if not incident:
             return None, None
+
+        # an expired incident is replaced by a fresh one on the next matching alert
+        latest_alert_timestamp = None
+        if incident.alerts_count > 0:
+            enrich_incidents_with_alerts(tenant_id, [incident], session)
+            latest_alert_timestamp = max(
+                alert.timestamp for alert in incident.alerts
+            )
+
+        is_incident_expired = compute_incident_expired(
+            is_terminal=incident.status
+            in [
+                IncidentStatus.RESOLVED.value,
+                IncidentStatus.MERGED.value,
+                IncidentStatus.DELETED.value,
+            ],
+            latest_alert_timestamp=latest_alert_timestamp,
+            creation_time=incident.creation_time,
+            timeframe=rule.timeframe,
+            max_window=rule.max_incident_window,
+            now=datetime.utcnow(),
+        )
 
     return incident, is_incident_expired
 

--- a/keep/api/models/db/migrations/versions/2026-07-07-12-00_1c46ee76d36c.py
+++ b/keep/api/models/db/migrations/versions/2026-07-07-12-00_1c46ee76d36c.py
@@ -1,0 +1,28 @@
+"""feat: add max_incident_window to Rule
+
+Revision ID: 1c46ee76d36c
+Revises: 67ff7efffed4
+Create Date: 2026-07-07 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1c46ee76d36c"
+down_revision = "67ff7efffed4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("rule", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("max_incident_window", sa.Integer(), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("rule", schema=None) as batch_op:
+        batch_op.drop_column("max_incident_window")

--- a/keep/api/models/db/rule.py
+++ b/keep/api/models/db/rule.py
@@ -58,3 +58,6 @@ class Rule(SQLModel, table=True):
     multi_level_property_name: str | None = None
     threshold: int = Field(sa_column_args=(CheckConstraint("threshold>0"),), default=1)
     assignee: str | None = None
+    # when set, the incident is locked after this many seconds from its creation:
+    # alerts arriving after the window open a fresh incident instead of extending it
+    max_incident_window: int | None = None

--- a/keep/api/routes/rules.py
+++ b/keep/api/routes/rules.py
@@ -36,6 +36,7 @@ class RuleCreateDto(BaseModel):
     multiLevelPropertyName: str = None
     threshold: int = 1
     assignee: str = None
+    maxIncidentWindow: int | None = None
 
 
 @router.get(
@@ -96,6 +97,7 @@ async def create_rule(
     multi_level_property_name = rule_create_request.multiLevelPropertyName
     threshold = rule_create_request.threshold
     assignee = rule_create_request.assignee
+    max_incident_window = rule_create_request.maxIncidentWindow
 
     if not sql:
         raise HTTPException(status_code=400, detail="SQL is required")
@@ -147,6 +149,7 @@ async def create_rule(
         multi_level_property_name=multi_level_property_name,
         threshold=threshold,
         assignee=assignee,
+        max_incident_window=max_incident_window,
     )
     logger.info("Rule created")
     return rule
@@ -204,6 +207,7 @@ async def update_rule(
         multi_level_property_name = body.get("multiLevelPropertyName", None)
         threshold = body.get("threshold", 1)
         assignee = body.get("assignee", None)
+        max_incident_window = body.get("maxIncidentWindow", None)
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid request body")
 
@@ -261,6 +265,7 @@ async def update_rule(
         multi_level_property_name=multi_level_property_name,
         threshold=threshold,
         assignee=assignee,
+        max_incident_window=max_incident_window,
     )
 
     if rule:

--- a/keep/api/utils/incident_expiry.py
+++ b/keep/api/utils/incident_expiry.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+
+def compute_incident_expired(
+    is_terminal: bool,
+    latest_alert_timestamp: Optional[datetime],
+    creation_time: Optional[datetime],
+    timeframe: int,
+    max_window: Optional[int],
+    now: datetime,
+) -> bool:
+    if is_terminal:
+        return True
+    if (
+        max_window
+        and creation_time is not None
+        and now - creation_time > timedelta(seconds=max_window)
+    ):
+        return True
+    if latest_alert_timestamp is not None:
+        return latest_alert_timestamp < now - timedelta(seconds=timeframe)
+    return False

--- a/tests/test_incident_max_window.py
+++ b/tests/test_incident_max_window.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timedelta
+
+from keep.api.utils.incident_expiry import compute_incident_expired
+
+NOW = datetime(2024, 1, 1, 12, 0, 0)
+
+
+def test_terminal_status_is_expired():
+    assert compute_incident_expired(True, None, NOW, 3600, None, NOW) is True
+
+
+def test_no_max_window_within_timeframe_not_expired():
+    latest = NOW - timedelta(seconds=60)
+    creation = NOW - timedelta(hours=5)
+    assert compute_incident_expired(False, latest, creation, 3600, None, NOW) is False
+
+
+def test_no_max_window_older_than_timeframe_expired():
+    latest = NOW - timedelta(seconds=7200)
+    creation = NOW - timedelta(hours=5)
+    assert compute_incident_expired(False, latest, creation, 3600, None, NOW) is True
+
+
+def test_no_alerts_not_expired():
+    assert compute_incident_expired(False, None, NOW, 3600, None, NOW) is False
+
+
+def test_max_window_locks_incident_even_within_timeframe():
+    latest = NOW - timedelta(seconds=60)
+    creation = NOW - timedelta(seconds=7200)
+    assert compute_incident_expired(False, latest, creation, 3600, 3600, NOW) is True
+
+
+def test_within_max_window_not_expired():
+    latest = NOW - timedelta(seconds=60)
+    creation = NOW - timedelta(seconds=1800)
+    assert compute_incident_expired(False, latest, creation, 3600, 3600, NOW) is False
+
+
+def test_max_window_boundary_exact_not_expired():
+    creation = NOW - timedelta(seconds=3600)
+    latest = NOW - timedelta(seconds=60)
+    assert compute_incident_expired(False, latest, creation, 3600, 3600, NOW) is False


### PR DESCRIPTION
## Summary

Closes #5175

A correlation rule keeps extending the same incident for as long as matching alerts keep arriving within the rule timeframe. For a condition that trickles alerts indefinitely, that means a single incident can stay open forever and grow without bound, with no way to cap how long one incident represents.

This adds an optional per-rule **max incident window** (in seconds). Once an incident is older than the window, measured from its creation time, the next matching alert opens a fresh incident instead of extending the old one. The field is nullable and defaults to off, so existing rules behave exactly as before.

## How it works

The decision already exists: `get_incident_for_grouping_rule` in `keep/api/core/db.py` computes an `is_incident_expired` flag, and the rules engine already creates a fresh incident (linked via `same_incident_in_the_past_id`) whenever that flag is set. This change adds one more way for an incident to be considered expired.

- The expiry logic is extracted into a small pure helper, `compute_incident_expired` in `keep/api/utils/incident_expiry.py`, which reproduces the existing checks (resolved/merged/deleted status, or last alert older than the timeframe) and adds the new one (`max_window` set and `now - creation_time` past the window). It depends only on `datetime`, so it is unit-tested in isolation.
- `get_incident_for_grouping_rule` now calls that helper. When `max_incident_window` is `None`, the result is identical to today.
- `Rule` gains a nullable `max_incident_window` column (with an additive Alembic migration), threaded through `create_rule` / `update_rule` and the rules API (`maxIncidentWindow`). The window is anchored on the incident creation time; resolution logic is untouched.

## Tests

`tests/test_incident_max_window.py` unit-tests `compute_incident_expired` (runs under `pytest --noconftest`, no DB):

- backward compatibility: with `max_window=None` it expires only on terminal status or a last alert older than the timeframe
- the new lock: with the window elapsed it expires even when the latest alert is still within the timeframe
- within the window it does not expire; terminal status short-circuits; the exact boundary is not yet expired

Fail-before / pass-after verified locally (neutering the new clause fails the lock test), and the existing `tests/test_rules_engine.py` correlation/grouping suite passes unchanged against the modified `get_incident_for_grouping_rule`.

## Notes

Anchored on incident creation time (not first-alert), which is the simplest and most predictable semantics; happy to switch the anchor if maintainers prefer. Correlation rules are not part of the env/file provisioning path, so no provisioning changes are needed. UI wiring for the rule builder can follow; the backend enforces the window regardless of how the rule is created.
