### PR TITLE
fix(ui): bundle Monaco workers into production build

### DIFF
--- a/keep-ui/package.json
+++ b/keep-ui/package.json
@@ -5,7 +5,7 @@
   "main": "next.config.js",
   "scripts": {
     "build-monaco-workers": "node scripts/build-monaco-workers-turbopack.js",
-    "build": "./next_build.sh",
+    "build": "npm run build-monaco-workers && ./next_build.sh",
     "build:workflow-yaml-json-schema": "ts-node -P tsconfig.scripts.json scripts/generate-workflow-yaml-json-schema.ts",
     "dev": "npm run build-monaco-workers && next dev --turbopack -p 3000",
     "dev:webpack": "next dev -p 3000",

--- a/keep-ui/shared/ui/MonacoCELEditor/MonacoCel.tsx
+++ b/keep-ui/shared/ui/MonacoCELEditor/MonacoCel.tsx
@@ -18,6 +18,21 @@ interface MonacoCelProps extends EditorProps {
 const monacoConfigPromise: Promise<void> | null =
   typeof window !== "undefined"
     ? import("monaco-editor").then((monaco) => {
+        // Workers are pre-built into public/monaco-workers by the
+        // build-monaco-workers script; Next.js standalone output doesn't
+        // trace the workers webpack emits from node_modules, so they are
+        // missing from the production Docker image otherwise.
+        self.MonacoEnvironment = {
+          getWorkerUrl: (_moduleId: string, label: string) => {
+            if (label === "json") {
+              return "/monaco-workers/json.worker.js";
+            }
+            if (label === "yaml") {
+              return "/monaco-workers/yaml.worker.js";
+            }
+            return "/monaco-workers/editor.worker.js";
+          },
+        };
         loader.config({ monaco });
       })
     : null;


### PR DESCRIPTION
## What

Fixes the `Could not create web worker(s)... You must define MonacoEnvironment.getWorkerUrl or MonacoEnvironment.getWorker` error in the production Docker image, where the CEL editor falls back to synchronous mode because no Monaco worker files exist anywhere in the image.

Fixes #6580

## Why

Two things were missing in production:

1. `scripts/build-monaco-workers-turbopack.js` (which bundles the workers into `public/monaco-workers/`) was only wired into the `dev` script, so production builds never emitted the worker files — `docker/Dockerfile.ui` copies `public/` into the image, but the directory was never populated.
2. The webpack/production CEL editor variant (`MonacoCel.tsx`) never set `MonacoEnvironment`, so even with workers present Monaco wouldn't know where to load them from. (The dev/turbopack variants already handle this.)

## How

- `package.json`: `build` now runs `npm run build-monaco-workers && ./next_build.sh`, mirroring the existing `dev` script.
- `MonacoCel.tsx`: sets `self.MonacoEnvironment.getWorkerUrl` to the pre-built `/monaco-workers/{json,yaml,editor}.worker.js` files, matching the exact filenames the build script emits (webpack entries `{editor,json,yaml}.worker` with `filename: "[name].js"`).

This is the same approach the issue thread converged on.

## How it was tested

- Ran `npm run build-monaco-workers` locally: webpack compiled successfully and emitted `editor.worker.js`, `json.worker.js`, `yaml.worker.js` into `keep-ui/public/monaco-workers/` — confirming the `getWorkerUrl` paths match the real output filenames.
- Not tested: a full `npm run build` / Docker image build was not run locally. The wiring mirrors the existing `dev` script, and `Dockerfile.ui` already copies `public/` into the runner stage, but I'd appreciate a maintainer sanity-check of the production image.
