### PR TITLE
fix: parse PUSHER_USE_SSL env var as boolean string

### DIFF
--- a/keep/api/core/dependencies.py
+++ b/keep/api/core/dependencies.py
@@ -65,6 +65,18 @@ def get_pusher_client() -> Pusher | None:
         logger.debug("Pusher is disabled or missing environment variables")
         return None
 
+    try:
+        pusher_use_ssl = config("PUSHER_USE_SSL", default=False, cast=bool)
+    except ValueError:
+        # Unrecognized values previously enabled SSL, so keep SSL on
+        # (fail-secure) rather than silently downgrading to plaintext.
+        logger.warning(
+            "Invalid PUSHER_USE_SSL value, keeping SSL enabled. "
+            "Use 'true' or 'false'.",
+            extra={"pusher_use_ssl": os.environ.get("PUSHER_USE_SSL")},
+        )
+        pusher_use_ssl = True
+
     # TODO: defaults on open source no docker
     try:
         pusher = Pusher(
@@ -77,7 +89,7 @@ def get_pusher_client() -> Pusher | None:
             app_id=pusher_app_id,
             key=pusher_app_key,
             secret=pusher_app_secret,
-            ssl=False if os.environ.get("PUSHER_USE_SSL", False) is False else True,
+            ssl=pusher_use_ssl,
             cluster=os.environ.get("PUSHER_CLUSTER"),
         )
     except ValueError:

--- a/tests/test_pusher_client.py
+++ b/tests/test_pusher_client.py
@@ -1,0 +1,55 @@
+import pytest
+
+from keep.api.core import dependencies
+
+
+class FakePusher:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+@pytest.fixture
+def pusher_env(monkeypatch):
+    monkeypatch.setattr(dependencies, "Pusher", FakePusher)
+    monkeypatch.setenv("PUSHER_APP_ID", "1")
+    monkeypatch.setenv("PUSHER_APP_KEY", "test-key")
+    monkeypatch.setenv("PUSHER_APP_SECRET", "test-secret")
+    monkeypatch.delenv("PUSHER_DISABLED", raising=False)
+    monkeypatch.delenv("PUSHER_USE_SSL", raising=False)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("true", True),
+        ("True", True),
+        ("1", True),
+    ],
+)
+def test_pusher_use_ssl_parsed_from_string(pusher_env, monkeypatch, value, expected):
+    """PUSHER_USE_SSL is always a string when set via docker-compose/k8s env."""
+    monkeypatch.setenv("PUSHER_USE_SSL", value)
+    client = dependencies.get_pusher_client()
+    assert client is not None
+    assert client.kwargs["ssl"] is expected
+
+
+def test_pusher_use_ssl_defaults_to_false(pusher_env):
+    client = dependencies.get_pusher_client()
+    assert client is not None
+    assert client.kwargs["ssl"] is False
+
+
+@pytest.mark.parametrize("value", ["yes", "on", "not-a-bool", ""])
+def test_pusher_use_ssl_unrecognized_value_keeps_ssl_enabled(
+    pusher_env, monkeypatch, value
+):
+    """Any set-but-unrecognized value enabled SSL before the fix, so keep
+    SSL on (fail-secure) instead of silently downgrading to plaintext."""
+    monkeypatch.setenv("PUSHER_USE_SSL", value)
+    client = dependencies.get_pusher_client()
+    assert client is not None
+    assert client.kwargs["ssl"] is True


### PR DESCRIPTION
## Linked Issue

Fixes #6582

## Description

`get_pusher_client` evaluates the env var with `ssl=False if os.environ.get("PUSHER_USE_SSL", False) is False else True`, so any string value — including `"false"` — enables SSL. docker-compose and Kubernetes can only pass env values as strings, so `PUSHER_USE_SSL: false` in a compose file arrives as the string `"false"` and turns SSL **on**.

The variable is now parsed with the same starlette `config(..., cast=bool)` idiom already used across the codebase (`SCHEDULER`, `REDIS_SSL`, `KEEP_DEBUG_TASKS`, ...), accepting `true/false/1/0` case-insensitively. The parse happens before the existing `try/except ValueError`, so an invalid value is no longer misreported by the "PUSHER_APP_ID must be a numeric string" handler.

**Backward compatibility / fail-secure:** before this change, *every* set value enabled SSL. Falling back to `False` for unrecognized values (`yes`, `on`, typos, empty string) would silently downgrade existing SSL deployments to plaintext, so unrecognized values keep SSL enabled and log a warning. The only behavior change is for the explicitly-false spellings — the bug being fixed.

This was the only instance of this pattern in the repo (the issue suggested other cases might be affected — none found).

## Test

Added `tests/test_pusher_client.py` with 11 cases: `false/False/0` → SSL off, `true/True/1` → SSL on, unset → off, `yes`/`on`/garbage/empty string → on (fail-secure).

Reproduced against the real pusher client: on `main`, `PUSHER_USE_SSL=false` produces a client with `ssl=True`; with this change all cases wire through correctly. Full `pytest --non-integration` suite passes with no regressions. `ruff check` passes.