### PR TITLE
fix: hold strong references to lifespan background tasks

### DIFF
--- a/keep/api/api.py
+++ b/keep/api/api.py
@@ -105,6 +105,20 @@ if not getattr(requests.Session.request, "_keep_no_redirect", False):
     requests.Session.request = no_redirect_request
 
 
+# The event loop only keeps weak references to tasks, so fire-and-forget
+# tasks must be strongly referenced somewhere to avoid being garbage-collected
+# (and silently cancelled) mid-execution.
+# https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+service_tasks = set()
+
+
+def create_service_task(coro) -> asyncio.Task:
+    task = asyncio.create_task(coro)
+    service_tasks.add(task)
+    task.add_done_callback(service_tasks.discard)
+    return task
+
+
 async def check_pending_tasks(background_tasks: set):
     while True:
         events_in_queue = len(background_tasks)
@@ -180,7 +194,7 @@ async def startup():
             except Exception:
                 logger.exception("Failed to start the maintenance windows")
         else:
-            asyncio.create_task(process_watcher_task.async_process_watcher())
+            create_service_task(process_watcher_task.async_process_watcher())
             logger.info(
                 "Added task",
                 extra={
@@ -231,7 +245,7 @@ async def lifespan(app: FastAPI):
     # if debug tasks are enabled, create a task to check for pending tasks
     if KEEP_DEBUG_TASKS:
         logger.info("Starting background task to check for pending tasks")
-        asyncio.create_task(check_pending_tasks(background_tasks))
+        create_service_task(check_pending_tasks(background_tasks))
 
     # Startup
     await startup()

--- a/tests/test_service_tasks.py
+++ b/tests/test_service_tasks.py
@@ -1,0 +1,28 @@
+import asyncio
+
+import pytest
+
+from keep.api import api
+
+
+@pytest.mark.asyncio
+async def test_create_service_task_holds_strong_reference():
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def service():
+        started.set()
+        await release.wait()
+
+    task = api.create_service_task(service())
+    await started.wait()
+
+    # the task is strongly referenced while running, so the event loop's
+    # weak reference is not the only thing keeping it alive
+    assert task in api.service_tasks
+
+    release.set()
+    await task
+
+    # completed tasks are discarded so the set doesn't grow unboundedly
+    assert task not in api.service_tasks


### PR DESCRIPTION
## Linked Issue

Fixes #6552

## Description

`startup()` and `lifespan()` create fire-and-forget tasks with `asyncio.create_task(...)` and discard the returned Task:

1. the maintenance-window watcher (`async_process_watcher`)
2. the `check_pending_tasks` debug logger

The event loop keeps only [weak references to tasks](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task), so either task can be garbage-collected and silently cancelled mid-execution — no traceback; the watcher just stops running and maintenance-window alert recovery silently breaks.

This change adds a module-level `service_tasks` set and a `create_service_task()` helper that holds a strong reference and discards the task on completion, per the pattern recommended in the asyncio docs. Both call sites now go through it.

A separate set is used instead of the request-scoped `background_tasks` set on purpose: that set's length is what `check_pending_tasks` reports as pending events (and `routes/alerts.py` adds event-processing tasks to it), so long-lived service tasks in the same set would permanently skew the count.

## Test

Added `tests/test_service_tasks.py`: the task is strongly referenced while running and discarded on completion.

Also verified under forced GC (all local references dropped, `gc.collect()` ×3 — the task survives and runs to completion) and on a live server boot with `WATCHER=true` and `KEEP_DEBUG_TASKS=true`: the watcher completed multiple full cycles and the debug logger ran continuously for 2+ minutes with zero `task was destroyed` / `exception was never retrieved` log entries. Full `pytest --non-integration` suite passes with no regressions. `ruff check` passes.