### PR TITLE
feat(netbox): pull DCIM topology into the service topology map

### DIFF
--- a/docs/providers/documentation/netbox-provider.mdx
+++ b/docs/providers/documentation/netbox-provider.mdx
@@ -81,6 +81,16 @@ X-API-KEY: your-api-key
 
 Now, you have successfully connected NetBox to Keep. You will start receiving the events in Keep based on the event rules you have created.
 
+## Pulling topology from NetBox
+
+Besides receiving alerts, Keep can pull your physical infrastructure from the NetBox DCIM API and show it on the service topology map. Devices become services (with their primary IP, role, manufacturer and site), and cables between devices become dependencies.
+
+To enable it, set the `NetBox instance URL` and a `NetBox API token` in the provider configuration. A read-only token is enough. Without these fields the provider keeps working in webhook-only mode.
+
+Optionally, enable `Group devices of the same rack into an application` so that devices sharing a rack are grouped into an application named after the rack. Combined with Keep's topology-based correlation, this lets alerts from many devices in the same rack (for example after a rack power loss) be correlated into a single incident.
+
+The number of pulled objects is limited by `Maximum number of devices to pull` (default 5000).
+
 ## Useful Links
 
 - [NetBox](https://netboxlabs.com/)

--- a/docs/snippets/providers/netbox-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/netbox-snippet-autogenerated.mdx
@@ -1,5 +1,17 @@
-{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py 
+{/* This snippet is automatically generated using scripts/docs_render_provider_snippets.py
 Do not edit it manually, as it will be overwritten */}
+
+## Authentication
+This provider requires authentication.
+- **url**: NetBox instance URL (required: False, sensitive: False)
+- **api_token**: NetBox API token (required: False, sensitive: True)
+- **verify**: Verify SSL certificates (required: False, sensitive: False)
+- **group_racks_as_applications**: Group devices of the same rack into an application (required: False, sensitive: False)
+- **max_devices**: Maximum number of devices to pull (required: False, sensitive: False)
+
+Certain scopes may be required to perform specific actions or queries via the provider. Below is a summary of relevant scopes and their use cases:
+- **authenticated**: User is authenticated  
+
 
 
 ## In workflows
@@ -7,3 +19,9 @@ Do not edit it manually, as it will be overwritten */}
 This provider can't be used as a "step" or "action" in workflows. If you want to use it, please let us know by creating an issue in the [GitHub repository](https://github.com/keephq/keep/issues).
 
 
+
+
+## Topology
+This provider pulls [topology](/overview/servicetopology) to Keep. It could be used in [correlations](/overview/correlation-topology)
+and [mapping](/overview/enrichment/mapping#mapping-with-topology-data), and as a context
+for [alerts](/alerts/sidebar#7-alert-topology-view) and [incidents](/overview#17-incident-topology).

--- a/keep/providers/netbox_provider/netbox_provider.py
+++ b/keep/providers/netbox_provider/netbox_provider.py
@@ -247,6 +247,8 @@ class NetboxProvider(BaseTopologyProvider):
             return {"authenticated": True}
         try:
             self._get("/api/status/")
+            # the token also needs DCIM read access to pull the topology
+            self._get("/api/dcim/devices/", params={"limit": 1})
             return {"authenticated": True}
         except Exception as e:
             return {"authenticated": f"Error validating scopes: {e}"}

--- a/keep/providers/netbox_provider/netbox_provider.py
+++ b/keep/providers/netbox_provider/netbox_provider.py
@@ -2,15 +2,162 @@
 NetBox combines IP address management (IPAM) and datacenter infrastructure management (DCIM) with powerful APIs and extensions, serving as the ideal "source of truth" for network automation. Thousands of organizations worldwide rely on NetBox for their infrastructure.
 """
 
+import dataclasses
+import uuid
+
+import pydantic
+import requests
+
 from keep.api.models.alert import AlertDto
+from keep.api.models.db.topology import TopologyServiceInDto
 from keep.contextmanager.contextmanager import ContextManager
-from keep.providers.base.base_provider import BaseProvider
-from keep.providers.models.provider_config import ProviderConfig
+from keep.exceptions.provider_exception import ProviderException
+from keep.providers.base.base_provider import BaseProvider, BaseTopologyProvider
+from keep.providers.models.provider_config import ProviderConfig, ProviderScope
 
 
-class NetboxProvider(BaseProvider):
+@pydantic.dataclasses.dataclass
+class NetboxProviderAuthConfig:
     """
-    Get alerts from NetBox into Keep.
+    NetboxProviderAuthConfig is a class that holds the authentication information for the NetboxProvider.
+
+    All fields are optional: NetBox can be used webhook-only (alerts pushed to Keep),
+    and the API access is only needed to pull the DCIM topology.
+    """
+
+    url: str = dataclasses.field(
+        default="",
+        metadata={
+            "required": False,
+            "description": "NetBox instance URL",
+            "hint": "e.g. https://netbox.example.com, needed only for topology pulling",
+            "sensitive": False,
+        },
+    )
+
+    api_token: str = dataclasses.field(
+        default="",
+        metadata={
+            "required": False,
+            "description": "NetBox API token",
+            "hint": "A read-only token is enough, needed only for topology pulling",
+            "sensitive": True,
+        },
+    )
+
+    verify: bool = dataclasses.field(
+        default=True,
+        metadata={
+            "required": False,
+            "description": "Verify SSL certificates",
+            "hint": "Set to false to allow self-signed certificates",
+            "sensitive": False,
+            "type": "switch",
+        },
+    )
+
+    group_racks_as_applications: bool = dataclasses.field(
+        default=False,
+        metadata={
+            "required": False,
+            "description": "Group devices of the same rack into an application",
+            "hint": "Lets topology correlation group alerts of devices sharing a rack",
+            "sensitive": False,
+            "type": "switch",
+        },
+    )
+
+    max_devices: int = dataclasses.field(
+        default=5000,
+        metadata={
+            "required": False,
+            "description": "Maximum number of devices to pull",
+            "sensitive": False,
+        },
+    )
+
+
+def _termination_device_names(cable: dict, side: str) -> set[str]:
+    # NetBox >= 3.3 exposes a list of terminations per side, older versions a single object
+    terminations = cable.get(f"{side}_terminations")
+    if terminations is None:
+        single = cable.get(f"termination_{side}")
+        terminations = [{"object": single}] if single else []
+    names = set()
+    for termination in terminations:
+        device = (termination.get("object") or {}).get("device") or {}
+        if device.get("name"):
+            names.add(device["name"])
+    return names
+
+
+def _rack_application_id(application_namespace: str, rack_id) -> uuid.UUID:
+    # stable per tenant/provider/rack, so a re-pull updates the application in place
+    namespace_uuid = uuid.uuid5(uuid.NAMESPACE_DNS, "keephq.dev")
+    return uuid.uuid5(namespace_uuid, f"{application_namespace}/netbox-rack/{rack_id}")
+
+
+def build_topology_services(
+    devices: list[dict],
+    cables: list[dict],
+    source_provider_id: str,
+    application_namespace: str,
+    group_racks_as_applications: bool = False,
+) -> list[TopologyServiceInDto]:
+    """Map NetBox DCIM devices and cables to Keep topology services.
+
+    Devices become services keyed by their name (the attribute monitoring tools
+    report alerts with), cables between two known devices become dependencies,
+    and optionally the devices of a rack are grouped into an application.
+    """
+    services: dict[str, TopologyServiceInDto] = {}
+
+    for device in devices:
+        name = device.get("name") or f"device-{device.get('id')}"
+        primary_ip = (device.get("primary_ip") or {}).get("address") or ""
+        # "role" since NetBox v4, "device_role" before
+        role = device.get("role") or device.get("device_role") or {}
+        device_type = device.get("device_type") or {}
+        rack = device.get("rack") or {}
+
+        application_relations = None
+        if group_racks_as_applications and rack.get("id") is not None:
+            rack_name = rack.get("name") or f"rack-{rack['id']}"
+            application_relations = {
+                _rack_application_id(
+                    application_namespace, rack["id"]
+                ): f"Rack {rack_name}"
+            }
+
+        services[name] = TopologyServiceInDto(
+            source_provider_id=source_provider_id,
+            service=name,
+            display_name=name,
+            description=device.get("description") or None,
+            ip_address=primary_ip.split("/")[0] or None,
+            category=role.get("name"),
+            manufacturer=(device_type.get("manufacturer") or {}).get("name"),
+            namespace=(device.get("site") or {}).get("name"),
+            tags=[tag["name"] for tag in device.get("tags") or [] if tag.get("name")],
+            application_relations=application_relations,
+        )
+
+    for cable in cables:
+        a_names = _termination_device_names(cable, "a")
+        b_names = _termination_device_names(cable, "b")
+        for a_name in a_names:
+            for b_name in b_names:
+                if a_name == b_name:
+                    continue
+                if a_name in services and b_name in services:
+                    services[a_name].dependencies[b_name] = "cable"
+
+    return list(services.values())
+
+
+class NetboxProvider(BaseTopologyProvider):
+    """
+    Get alerts and topology from NetBox into Keep.
     """
 
     webhook_documentation_here_differs_from_general_documentation = True
@@ -28,19 +175,107 @@ class NetboxProvider(BaseProvider):
   """
 
     PROVIDER_DISPLAY_NAME = "NetBox"
-    PROVIDER_TAGS = ["alert"]
+    PROVIDER_TAGS = ["alert", "topology"]
     PROVIDER_CATEGORY = ["Cloud Infrastructure", "Monitoring"]
+    PROVIDER_SCOPES = [
+        ProviderScope(name="authenticated", description="User is authenticated"),
+    ]
+
+    REQUEST_TIMEOUT = 10
 
     def __init__(
         self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
     ):
         super().__init__(context_manager, provider_id, config)
 
+    def dispose(self):
+        pass
+
     def validate_config(self):
         """
         Validates required configuration for NetBox's provider.
         """
-        pass
+        self.authentication_config = NetboxProviderAuthConfig(
+            **(self.config.authentication or {})
+        )
+
+    @property
+    def _api_configured(self) -> bool:
+        return bool(
+            self.authentication_config.url and self.authentication_config.api_token
+        )
+
+    def _get(self, path: str, params: dict | None = None) -> dict:
+        url = self.authentication_config.url.rstrip("/") + path
+        response = requests.get(
+            url,
+            headers={"Authorization": f"Token {self.authentication_config.api_token}"},
+            params=params,
+            verify=self.authentication_config.verify,
+            timeout=self.REQUEST_TIMEOUT,
+        )
+        if not response.ok:
+            raise ProviderException(
+                f"Failed to fetch {path} from NetBox: {response.status_code} {response.text}"
+            )
+        return response.json()
+
+    def _get_paginated(self, path: str, params: dict | None = None) -> list[dict]:
+        limit = self.authentication_config.max_devices
+        page_size = min(limit, 1000)
+        results: list[dict] = []
+        offset = 0
+        while True:
+            data = self._get(
+                path, params={**(params or {}), "limit": page_size, "offset": offset}
+            )
+            results.extend(data.get("results") or [])
+            if len(results) >= limit:
+                if data.get("next"):
+                    self.logger.warning(
+                        "NetBox returned more than max_devices objects, truncating",
+                        extra={"path": path, "max_devices": limit},
+                    )
+                return results[:limit]
+            if not data.get("next"):
+                return results
+            offset += page_size
+
+    def validate_scopes(self) -> dict[str, bool | str]:
+        # webhook-only installs have no API access to validate
+        if not self._api_configured:
+            return {"authenticated": True}
+        try:
+            self._get("/api/status/")
+            return {"authenticated": True}
+        except Exception as e:
+            return {"authenticated": f"Error validating scopes: {e}"}
+
+    def pull_topology(self) -> tuple[list[TopologyServiceInDto], dict]:
+        if not self._api_configured:
+            # webhook-only install, nothing to pull
+            self.logger.debug(
+                "NetBox API access is not configured, skipping topology pull"
+            )
+            return [], {}
+
+        self.logger.info("Pulling topology from NetBox")
+        devices = self._get_paginated(
+            "/api/dcim/devices/", params={"exclude": "config_context"}
+        )
+        cables = self._get_paginated("/api/dcim/cables/")
+        services = build_topology_services(
+            devices,
+            cables,
+            source_provider_id=self.provider_id,
+            application_namespace=f"{self.context_manager.tenant_id}/{self.provider_id}",
+            group_racks_as_applications=self.authentication_config.group_racks_as_applications,
+        )
+        self.logger.info(
+            "Pulled topology from NetBox",
+            extra={"devices": len(devices), "cables": len(cables)},
+        )
+        return services, {}
 
     @staticmethod
     def _format_alert(

--- a/tests/providers/netbox_provider/test_netbox_topology.py
+++ b/tests/providers/netbox_provider/test_netbox_topology.py
@@ -160,7 +160,28 @@ class TestPullTopology:
 
     def test_webhook_only_install_validates_scopes(self):
         provider = _make_provider()
-        assert provider.validate_scopes() == {"authenticated": True}
+        with patch(REQUESTS_GET) as mock_get:
+            assert provider.validate_scopes() == {"authenticated": True}
+        mock_get.assert_not_called()
+
+    def test_validate_scopes_checks_status_and_dcim_read(self):
+        provider = _make_provider(url="https://netbox.example.com", api_token="token")
+        responses = [_response({}), _response({"results": []})]
+        with patch(REQUESTS_GET, side_effect=responses) as mock_get:
+            assert provider.validate_scopes() == {"authenticated": True}
+        paths = [call.args[0] for call in mock_get.call_args_list]
+        assert paths == [
+            "https://netbox.example.com/api/status/",
+            "https://netbox.example.com/api/dcim/devices/",
+        ]
+
+    def test_validate_scopes_reports_dcim_permission_error(self):
+        provider = _make_provider(url="https://netbox.example.com", api_token="token")
+        responses = [_response({}), _response({}, ok=False, status_code=403)]
+        with patch(REQUESTS_GET, side_effect=responses):
+            result = provider.validate_scopes()
+        assert result["authenticated"] != True  # noqa: E712
+        assert "403" in result["authenticated"]
 
     def test_pulls_devices_and_cables(self):
         provider = _make_provider(url="https://netbox.example.com", api_token="token")

--- a/tests/providers/netbox_provider/test_netbox_topology.py
+++ b/tests/providers/netbox_provider/test_netbox_topology.py
@@ -1,0 +1,326 @@
+"""Tests for NetBox topology pulling (issue #3931).
+
+The mapping tests exercise build_topology_services directly with NetBox API
+payloads, the provider tests patch the HTTP layer and cover the webhook-only
+backward compatibility, pagination and error handling of pull_topology.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.exceptions.provider_exception import ProviderException
+from keep.providers.models.provider_config import ProviderConfig
+from keep.providers.netbox_provider.netbox_provider import (
+    NetboxProvider,
+    _rack_application_id,
+    build_topology_services,
+)
+
+REQUESTS_GET = "keep.providers.netbox_provider.netbox_provider.requests.get"
+
+
+def _device(id, name, site=None, rack=None, role=None, manufacturer=None, ip=None):
+    return {
+        "id": id,
+        "name": name,
+        "site": {"name": site} if site else None,
+        "rack": rack,
+        "role": {"name": role} if role else None,
+        "device_type": (
+            {"manufacturer": {"name": manufacturer}} if manufacturer else {}
+        ),
+        "primary_ip": {"address": ip} if ip else None,
+        "description": "",
+        "tags": [],
+    }
+
+
+def _cable(a_device, b_device):
+    return {
+        "a_terminations": [{"object": {"device": {"name": a_device}}}],
+        "b_terminations": [{"object": {"device": {"name": b_device}}}],
+    }
+
+
+class TestBuildTopologyServices:
+    def test_devices_become_services(self):
+        devices = [
+            _device(
+                1,
+                "sw-01",
+                site="dc1",
+                role="switch",
+                manufacturer="Cisco",
+                ip="10.0.0.1/24",
+            )
+        ]
+        services = build_topology_services(devices, [], "netbox-1", "tenant/netbox-1")
+
+        assert len(services) == 1
+        service = services[0]
+        assert service.service == "sw-01"
+        assert service.display_name == "sw-01"
+        assert service.source_provider_id == "netbox-1"
+        assert service.ip_address == "10.0.0.1"
+        assert service.category == "switch"
+        assert service.manufacturer == "Cisco"
+        assert service.namespace == "dc1"
+
+    def test_unnamed_device_falls_back_to_id(self):
+        services = build_topology_services(
+            [_device(7, None)], [], "netbox-1", "tenant/netbox-1"
+        )
+        assert services[0].service == "device-7"
+
+    def test_cables_become_dependencies(self):
+        devices = [_device(1, "sw-01"), _device(2, "sw-02")]
+        cables = [_cable("sw-01", "sw-02")]
+        services = build_topology_services(
+            devices, cables, "netbox-1", "tenant/netbox-1"
+        )
+
+        by_name = {service.service: service for service in services}
+        assert by_name["sw-01"].dependencies == {"sw-02": "cable"}
+        assert by_name["sw-02"].dependencies == {}
+
+    def test_cable_to_unknown_device_is_skipped(self):
+        devices = [_device(1, "sw-01")]
+        cables = [_cable("sw-01", "not-in-netbox")]
+        services = build_topology_services(
+            devices, cables, "netbox-1", "tenant/netbox-1"
+        )
+        assert services[0].dependencies == {}
+
+    def test_legacy_single_termination_cable(self):
+        devices = [_device(1, "sw-01"), _device(2, "sw-02")]
+        cables = [
+            {
+                "termination_a": {"device": {"name": "sw-01"}},
+                "termination_b": {"device": {"name": "sw-02"}},
+            }
+        ]
+        services = build_topology_services(
+            devices, cables, "netbox-1", "tenant/netbox-1"
+        )
+        by_name = {service.service: service for service in services}
+        assert by_name["sw-01"].dependencies == {"sw-02": "cable"}
+
+    def test_racks_not_grouped_by_default(self):
+        devices = [_device(1, "sw-01", rack={"id": 3, "name": "R1"})]
+        services = build_topology_services(devices, [], "netbox-1", "tenant/netbox-1")
+        assert services[0].application_relations is None
+
+    def test_racks_grouped_as_applications_when_enabled(self):
+        rack = {"id": 3, "name": "R1"}
+        devices = [
+            _device(1, "sw-01", rack=rack),
+            _device(2, "sw-02", rack=rack),
+            _device(3, "sw-03"),
+        ]
+        services = build_topology_services(
+            devices, [], "netbox-1", "tenant/netbox-1", group_racks_as_applications=True
+        )
+
+        by_name = {service.service: service for service in services}
+        rack_id = _rack_application_id("tenant/netbox-1", 3)
+        assert by_name["sw-01"].application_relations == {rack_id: "Rack R1"}
+        assert by_name["sw-02"].application_relations == {rack_id: "Rack R1"}
+        assert by_name["sw-03"].application_relations is None
+
+    def test_rack_application_id_is_stable_and_namespaced(self):
+        assert _rack_application_id("t1/p1", 3) == _rack_application_id("t1/p1", 3)
+        assert _rack_application_id("t1/p1", 3) != _rack_application_id("t2/p1", 3)
+        assert _rack_application_id("t1/p1", 3) != _rack_application_id("t1/p1", 4)
+
+
+def _make_provider(**auth):
+    context_manager = ContextManager(tenant_id="test", workflow_id="test")
+    config = ProviderConfig(authentication=auth or None, name="test-netbox")
+    return NetboxProvider(context_manager, "netbox-1", config)
+
+
+def _response(json_data, ok=True, status_code=200):
+    response = MagicMock()
+    response.ok = ok
+    response.status_code = status_code
+    response.json.return_value = json_data
+    return response
+
+
+class TestPullTopology:
+    def test_webhook_only_install_is_a_noop(self):
+        provider = _make_provider()
+        with patch(REQUESTS_GET) as mock_get:
+            services, applications = provider.pull_topology()
+        assert services == []
+        assert applications == {}
+        mock_get.assert_not_called()
+
+    def test_webhook_only_install_validates_scopes(self):
+        provider = _make_provider()
+        assert provider.validate_scopes() == {"authenticated": True}
+
+    def test_pulls_devices_and_cables(self):
+        provider = _make_provider(url="https://netbox.example.com", api_token="token")
+        responses = [
+            _response(
+                {"results": [_device(1, "sw-01"), _device(2, "sw-02")], "next": None}
+            ),
+            _response({"results": [_cable("sw-01", "sw-02")], "next": None}),
+        ]
+        with patch(REQUESTS_GET, side_effect=responses) as mock_get:
+            services, _ = provider.pull_topology()
+
+        assert {service.service for service in services} == {"sw-01", "sw-02"}
+        urls = [call.args[0] for call in mock_get.call_args_list]
+        assert urls == [
+            "https://netbox.example.com/api/dcim/devices/",
+            "https://netbox.example.com/api/dcim/cables/",
+        ]
+        for call in mock_get.call_args_list:
+            assert call.kwargs["headers"] == {"Authorization": "Token token"}
+            assert call.kwargs["timeout"] == NetboxProvider.REQUEST_TIMEOUT
+
+    def test_follows_pagination(self):
+        provider = _make_provider(url="https://netbox.example.com", api_token="token")
+        responses = [
+            _response({"results": [_device(1, "sw-01")], "next": "page2"}),
+            _response({"results": [_device(2, "sw-02")], "next": None}),
+            _response({"results": [], "next": None}),
+        ]
+        with patch(REQUESTS_GET, side_effect=responses) as mock_get:
+            services, _ = provider.pull_topology()
+
+        assert {service.service for service in services} == {"sw-01", "sw-02"}
+        offsets = [
+            call.kwargs["params"]["offset"] for call in mock_get.call_args_list[:2]
+        ]
+        assert offsets == [0, 1000]
+
+    def test_max_devices_caps_the_pull(self):
+        provider = _make_provider(
+            url="https://netbox.example.com", api_token="token", max_devices=2
+        )
+        responses = [
+            _response(
+                {
+                    "results": [_device(1, "sw-01"), _device(2, "sw-02")],
+                    "next": "page2",
+                }
+            ),
+            _response({"results": [], "next": None}),
+        ]
+        with patch(REQUESTS_GET, side_effect=responses):
+            services, _ = provider.pull_topology()
+        assert len(services) == 2
+
+    def test_api_error_raises(self):
+        provider = _make_provider(url="https://netbox.example.com", api_token="token")
+        with patch(REQUESTS_GET, return_value=_response({}, ok=False, status_code=403)):
+            with pytest.raises(ProviderException):
+                provider.pull_topology()
+
+    def test_verify_is_wired_through(self):
+        provider = _make_provider(
+            url="https://netbox.example.com", api_token="token", verify=False
+        )
+        responses = [
+            _response({"results": [], "next": None}),
+            _response({"results": [], "next": None}),
+        ]
+        with patch(REQUESTS_GET, side_effect=responses) as mock_get:
+            provider.pull_topology()
+        for call in mock_get.call_args_list:
+            assert call.kwargs["verify"] is False
+
+
+class TestProcessTopologyIntegration:
+    def _pull(self, provider):
+        rack = {"id": 3, "name": "R1"}
+        responses = [
+            _response(
+                {
+                    "results": [
+                        _device(1, "sw-01", rack=rack),
+                        _device(2, "sw-02", rack=rack),
+                    ],
+                    "next": None,
+                }
+            ),
+            _response({"results": [_cable("sw-01", "sw-02")], "next": None}),
+        ]
+        with patch(REQUESTS_GET, side_effect=responses):
+            services, _ = provider.pull_topology()
+        return services
+
+    def test_pulled_topology_is_processed_and_repull_is_idempotent(self, db_session):
+        from keep.api.core.dependencies import SINGLE_TENANT_UUID
+        from keep.api.models.db.topology import TopologyApplication, TopologyService
+        from keep.api.tasks.process_topology_task import process_topology
+        from sqlmodel import Session, select
+
+        import keep.api.core.db as db
+
+        context_manager = ContextManager(
+            tenant_id=SINGLE_TENANT_UUID, workflow_id="test"
+        )
+        provider = NetboxProvider(
+            context_manager,
+            "netbox-1",
+            ProviderConfig(
+                authentication={
+                    "url": "https://netbox.example.com",
+                    "api_token": "token",
+                    "group_racks_as_applications": True,
+                },
+                name="test-netbox",
+            ),
+        )
+
+        for _ in range(2):
+            services = self._pull(provider)
+            process_topology(SINGLE_TENANT_UUID, services, "netbox-1", "netbox")
+
+        with Session(db.engine) as session:
+            db_services = session.exec(
+                select(TopologyService).where(
+                    TopologyService.tenant_id == SINGLE_TENANT_UUID
+                )
+            ).all()
+            db_applications = session.exec(
+                select(TopologyApplication).where(
+                    TopologyApplication.tenant_id == SINGLE_TENANT_UUID
+                )
+            ).all()
+
+            assert {service.service for service in db_services} == {"sw-01", "sw-02"}
+            by_name = {service.service: service for service in db_services}
+            assert by_name["sw-01"].source_provider_id == "netbox-1"
+            assert [
+                dependency.depends_on_service_id
+                for dependency in by_name["sw-01"].dependencies
+            ] == [by_name["sw-02"].id]
+
+            assert len(db_applications) == 1
+            assert db_applications[0].name == "Rack R1"
+            assert db_applications[0].id == _rack_application_id(
+                f"{SINGLE_TENANT_UUID}/netbox-1", 3
+            )
+
+
+class TestWebhookAlertFormat:
+    def test_format_alert_unchanged(self):
+        event = {
+            "timestamp": "2025-01-01T00:00:00Z",
+            "model": "device",
+            "username": "admin",
+            "request_id": "abc",
+            "event": "updated",
+            "data": {"name": "sw-01", "created": "2024-01-01T00:00:00Z"},
+            "snapshots": {},
+        }
+        alert = NetboxProvider._format_alert(event)
+        assert alert.name == "sw-01"
+        assert alert.source == ["netbox"]


### PR DESCRIPTION
## Why are these changes needed?

Towards #3931. Users monitoring physical networks (routers, switches) get alerts from tools like Nagios and Graylog, and when a shared failure hits (the issue describes a rack power loss) hundreds of alerts arrive with no way to correlate them by the physical infrastructure they belong to. NetBox is the source of truth for that infrastructure, but the Keep NetBox provider only received webhook alerts.

This upgrades the NetBox provider to a topology provider, so Keep pulls the DCIM inventory and feeds it to the existing topology map and topology based correlation:

- **Devices become services**: name (the attribute monitoring tools report alerts with), primary IP, role, manufacturer, site and tags, using the existing `TopologyService` columns. No migration needed.
- **Cables become dependencies**: a cable between two known devices creates a service dependency, so the topology map draws the physical connections. Both the current (`a_terminations`/`b_terminations`) and pre-3.3 (`termination_a`/`termination_b`) cable formats are supported.
- **Racks optionally become applications** (off by default, opt-in via `group_racks_as_applications`): devices sharing a rack are grouped into an application named after the rack. With the topology processor enabled (`KEEP_TOPOLOGY_PROCESSOR=true`), alerts from many devices in the same rack can then be correlated into a single incident, which is the rack power loss scenario from the issue. Application semantics for a physical container is a design choice, which is why it sits behind a flag.

Rack applications use a stable id derived from tenant, provider and rack, so re-pulls update the application in place instead of creating a new one on every pull.

## Backward compatibility

The API access fields are all optional and existing webhook-only installs are unaffected:

- With no URL or token configured, `pull_topology` is a silent no-op and scope validation passes, so the topology polling loop does not produce errors for legacy installs.
- The webhook alert path (`_format_alert`) is unchanged.
- On configured installs an API failure raises, so a transient NetBox outage never wipes previously pulled topology (`process_topology` only rewrites on non-empty data).

## Scale

Pulling paginates the NetBox API (`limit`/`offset`, 1000 per page) with a hard cap (`max_devices`, default 5000, truncation logged) and excludes `config_context` from device payloads to keep responses small. Every request carries a timeout, and the SSL verify switch matches the other on-prem providers.

## Out of scope (kept for follow-ups)

- No changes to the topology processor or correlation logic.
- No new "infrastructure topology" category or UI work; the existing topology map renders the pulled data as is.
- No AI context integration.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests

`tests/providers/netbox_provider/test_netbox_topology.py` (17 tests): device and cable mapping (including the legacy cable format and dangling cable ends), rack grouping on and off with stable namespaced application ids, webhook-only no-op with no HTTP calls, pagination, `max_devices` cap, API error raising, verify wiring, the unchanged webhook alert format, and an end-to-end test through `process_topology` proving a re-pull is idempotent (services recreated, the rack application updated in place). Existing topology tests (`tests/test_topology.py`) stay green, and the docs snippet was regenerated with the provider docs updated.
