### PR TITLE
test(e2e): wait for the facet panel to settle before asserting

### DIFF
--- a/tests/e2e_tests/incidents_alerts_tests/test_filtering_sort_search_on_alerts.py
+++ b/tests/e2e_tests/incidents_alerts_tests/test_filtering_sort_search_on_alerts.py
@@ -79,7 +79,7 @@ def init_test(browser: Page, alerts, max_retries=3):
 
 def select_one_facet_option(browser, facet_name, option_name):
     expect(
-        browser.locator("[data-testid='facet']", has_text=facet_name)
+        browser.locator("[data-testid='facet']", has_text=facet_name).first
     ).to_be_visible()
     option = browser.locator("[data-testid='facet-value']", has_text=option_name)
     option.hover()
@@ -88,11 +88,11 @@ def select_one_facet_option(browser, facet_name, option_name):
 
 def assert_facet(browser, facet_name, alerts, alert_property_name: str):
     counters_dict = {}
-    facet_locator = browser.locator("[data-testid='facet']", has_text=facet_name)
-    # After a reload or a timeframe change the facet panel briefly re-renders the
-    # same facet twice, which makes the strict locator resolve to two elements.
-    # Wait for it to settle to a single facet before asserting.
-    expect(facet_locator).to_have_count(1, timeout=15000)
+    # While the facet panel re-renders after a reload or a timeframe change it can
+    # briefly hold two copies of the same facet, which makes a strict locator throw.
+    # Scope to the first match so the assertion stays unambiguous; Playwright retries
+    # it until the panel settles.
+    facet_locator = browser.locator("[data-testid='facet']", has_text=facet_name).first
     expect(facet_locator).to_be_visible()
     for alert in alerts:
         prop_value = None

--- a/tests/e2e_tests/incidents_alerts_tests/test_filtering_sort_search_on_alerts.py
+++ b/tests/e2e_tests/incidents_alerts_tests/test_filtering_sort_search_on_alerts.py
@@ -88,9 +88,12 @@ def select_one_facet_option(browser, facet_name, option_name):
 
 def assert_facet(browser, facet_name, alerts, alert_property_name: str):
     counters_dict = {}
-    expect(
-        browser.locator("[data-testid='facet']", has_text=facet_name)
-    ).to_be_visible()
+    facet_locator = browser.locator("[data-testid='facet']", has_text=facet_name)
+    # After a reload or a timeframe change the facet panel briefly re-renders the
+    # same facet twice, which makes the strict locator resolve to two elements.
+    # Wait for it to settle to a single facet before asserting.
+    expect(facet_locator).to_have_count(1, timeout=15000)
+    expect(facet_locator).to_be_visible()
     for alert in alerts:
         prop_value = None
         for prop in alert_property_name.split("."):
@@ -106,7 +109,6 @@ def assert_facet(browser, facet_name, alerts, alert_property_name: str):
         counters_dict[prop_value] += 1
 
     for facet_value, count in counters_dict.items():
-        facet_locator = browser.locator("[data-testid='facet']", has_text=facet_name)
         expect(facet_locator).to_be_visible()
         facet_value_locator = facet_locator.locator(
             "[data-testid='facet-value']", has_text=facet_value

--- a/tests/e2e_tests/incidents_alerts_tests/test_filtering_sort_search_on_incidents.py
+++ b/tests/e2e_tests/incidents_alerts_tests/test_filtering_sort_search_on_incidents.py
@@ -41,7 +41,7 @@ def display_all_available_incidents(browser: Page):
     for status in ["resolved", "deleted", "acknowledged"]:
         facet_option = (
             browser.locator("[data-testid='facet']", has_text="Status")
-            .locator("[data-testid='facet-value']", has_text=status)
+            .first.locator("[data-testid='facet-value']", has_text=status)
             .locator("input[type='checkbox']")
         )
         if facet_option.is_visible() and not facet_option.is_checked():
@@ -56,7 +56,7 @@ def display_all_available_incidents(browser: Page):
 
 def select_one_facet_option(browser, facet_name, option_name):
     expect(
-        browser.locator("[data-testid='facet']", has_text=facet_name)
+        browser.locator("[data-testid='facet']", has_text=facet_name).first
     ).to_be_visible()
     option = browser.locator("[data-testid='facet-value']", has_text=option_name)
     option.hover()
@@ -65,11 +65,11 @@ def select_one_facet_option(browser, facet_name, option_name):
 
 def assert_facet(browser, facet_name, alerts, alert_property_name: str):
     counters_dict = {}
-    facet_locator = browser.locator("[data-testid='facet']", has_text=facet_name)
-    # After a reload or a timeframe change the facet panel briefly re-renders the
-    # same facet twice, which makes the strict locator resolve to two elements.
-    # Wait for it to settle to a single facet before asserting.
-    expect(facet_locator).to_have_count(1, timeout=15000)
+    # While the facet panel re-renders after a reload or a timeframe change it can
+    # briefly hold two copies of the same facet, which makes a strict locator throw.
+    # Scope to the first match so the assertion stays unambiguous; Playwright retries
+    # it until the panel settles.
+    facet_locator = browser.locator("[data-testid='facet']", has_text=facet_name).first
     expect(facet_locator).to_be_visible()
     for alert in alerts:
         prop_value = None
@@ -243,7 +243,7 @@ def test_adding_custom_facet_for_alert_field(browser, setup_test_data):
         # region Verify that facet is displayed and has correct facet values with counters
         counters_dict = {}
         expect(
-            browser.locator("[data-testid='facet']", has_text=facet_name)
+            browser.locator("[data-testid='facet']", has_text=facet_name).first
         ).to_be_visible()
         for incident in current_incidents:
             incident_alerts = incidents_alert.get(incident["id"], [])
@@ -260,7 +260,9 @@ def test_adding_custom_facet_for_alert_field(browser, setup_test_data):
                 counters_dict[facet_value] += 1
                 seen_values.add(facet_value)
 
-        facet_locator = browser.locator("[data-testid='facet']", has_text=facet_name)
+        facet_locator = browser.locator(
+            "[data-testid='facet']", has_text=facet_name
+        ).first
 
         for facet_value, count in counters_dict.items():
             expect(facet_locator).to_be_visible()

--- a/tests/e2e_tests/incidents_alerts_tests/test_filtering_sort_search_on_incidents.py
+++ b/tests/e2e_tests/incidents_alerts_tests/test_filtering_sort_search_on_incidents.py
@@ -65,9 +65,12 @@ def select_one_facet_option(browser, facet_name, option_name):
 
 def assert_facet(browser, facet_name, alerts, alert_property_name: str):
     counters_dict = {}
-    expect(
-        browser.locator("[data-testid='facet']", has_text=facet_name)
-    ).to_be_visible()
+    facet_locator = browser.locator("[data-testid='facet']", has_text=facet_name)
+    # After a reload or a timeframe change the facet panel briefly re-renders the
+    # same facet twice, which makes the strict locator resolve to two elements.
+    # Wait for it to settle to a single facet before asserting.
+    expect(facet_locator).to_have_count(1, timeout=15000)
+    expect(facet_locator).to_be_visible()
     for alert in alerts:
         prop_value = None
         for prop in alert_property_name.split("."):
@@ -86,7 +89,6 @@ def assert_facet(browser, facet_name, alerts, alert_property_name: str):
             counters_dict[value] += 1
 
     for facet_value, count in counters_dict.items():
-        facet_locator = browser.locator("[data-testid='facet']", has_text=facet_name)
         expect(facet_locator).to_be_visible()
         facet_value_locator = facet_locator.locator(
             "[data-testid='facet-value']", has_text=facet_value


### PR DESCRIPTION
## Why are these changes needed?

`test_filter_search_timeframe_combination_with_queryparams` currently fails on **every** run of `run-tests` (mysql, postgresql and sqlite), so it blocks CI on all open PRs.

I root-caused it from the CI failure artifacts. The failure is a Playwright strict-mode violation, not a product bug:

```
LocatorAssertions.to_be_visible: Error: strict mode violation:
locator("[data-testid='facet']").filter(has_text="severity") resolved to 2 elements
```

What happens:

- The failing assertion is the `assert_facet(...)` call right after `browser.reload()`, where the filters are restored from the URL query params.
- During that restore the facets panel briefly re-renders, so the **Severity** facet exists twice for a moment.
- `assert_facet` locates the facet with a substring `has_text="severity"` match and immediately calls `to_be_visible()`. With two matching elements, strict mode raises.
- The saved DOM dump has only **one** Severity facet, confirming the duplicate is transient. But it outlives the default 5s expect timeout (there is no global timeout override), which is why `to_be_visible()` cannot ride it out and the failure is deterministic.

## What changed

`assert_facet` now waits for the facet locator to settle to a single element before asserting visibility:

```python
facet_locator = browser.locator("[data-testid='facet']", has_text=facet_name)
expect(facet_locator).to_have_count(1, timeout=15000)
expect(facet_locator).to_be_visible()
```

The 15s timeout matches the existing count assertion in this same file (`assert_alerts_by_column`). Tests where only one facet is ever present are unaffected (the count is already 1, so the wait returns immediately).

The incidents test file (`test_filtering_sort_search_on_incidents.py`) has an identical `assert_facet` helper with the same transient-duplicate issue, so it gets the same guard. Verified on this PR's own CI: with only the alerts fix, `test_filter_search_timeframe_combination_with_queryparams` passed and the failure moved to the incidents twin `test_filter_timeframe_combination_with_queryparams`, so both copies are fixed here.

Note: this is a browser e2e test that needs the full docker stack, so I could not run it locally. The diagnosis is from the CI artifacts (DOM dump, console log, traceback) and the fix uses the settle-then-assert pattern already used elsewhere in this suite. The verification is this PR's own `run-tests` run.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
