### PR TITLE
feat(db): expose SQLAlchemy pool_recycle and pool_timeout as env vars

### DIFF
--- a/keep/api/core/db_utils.py
+++ b/keep/api/core/db_utils.py
@@ -104,6 +104,12 @@ DB_POOL_SIZE = config(
 DB_MAX_OVERFLOW = config(
     "DATABASE_MAX_OVERFLOW", default=10, cast=int
 )  # pylint: disable=invalid-name
+DB_POOL_RECYCLE = config(
+    "DATABASE_POOL_RECYCLE", default=-1, cast=int
+)  # pylint: disable=invalid-name
+DB_POOL_TIMEOUT = config(
+    "DATABASE_POOL_TIMEOUT", default=30, cast=int
+)  # pylint: disable=invalid-name
 DB_ECHO = config(
     "DATABASE_ECHO", default=False, cast=bool
 )  # pylint: disable=invalid-name
@@ -142,6 +148,8 @@ def create_db_engine():
             json_serializer=dumps,
             pool_size=DB_POOL_SIZE,
             max_overflow=DB_MAX_OVERFLOW,
+            pool_recycle=DB_POOL_RECYCLE,
+            pool_timeout=DB_POOL_TIMEOUT,
         )
     elif DB_CONNECTION_STRING == "impersonate":
         engine = create_engine(
@@ -157,6 +165,8 @@ def create_db_engine():
                 DB_CONNECTION_STRING,
                 pool_size=DB_POOL_SIZE,
                 max_overflow=DB_MAX_OVERFLOW,
+                pool_recycle=DB_POOL_RECYCLE,
+                pool_timeout=DB_POOL_TIMEOUT,
                 json_serializer=dumps,
                 echo=DB_ECHO,
                 pool_pre_ping=True if KEEP_DB_PRE_PING_ENABLED else False,


### PR DESCRIPTION
## Summary

Adds two new optional environment variables, `DATABASE_POOL_RECYCLE` and `DATABASE_POOL_TIMEOUT`, wired into the SQLAlchemy engine's `pool_recycle` and `pool_timeout` kwargs in `keep/api/core/db_utils.py`.

Running Keep's Postgres backend behind PgBouncer in transaction pooling mode can hit intermittent `psycopg2.OperationalError: SSL connection has been closed unexpectedly` errors, because SQLAlchemy's pooled connections outlive PgBouncer's own connection lifetime. Recycling connections on a schedule (`pool_recycle`) and bounding how long a request waits for a pooled connection (`pool_timeout`) avoids this, but neither was previously configurable.

Defaults are set to SQLAlchemy's own defaults (`pool_recycle=-1`, `pool_timeout=30`), so deployments that do not set these vars get exactly the same engine configuration as before this change.

Fixes #6634

## Test plan

- [x] `poetry install`
- [x] `ruff check keep/api/core/db_utils.py` passes
- [x] `black --check keep/api/core/db_utils.py` passes
- [x] Manual check: `create_db_engine()` with no env vars set still produces `pool_recycle=-1`, `pool_timeout=30`
- [x] Manual check: `DATABASE_POOL_RECYCLE=300`, `DATABASE_POOL_TIMEOUT=30` with a Postgres connection string correctly sets `engine.pool._recycle=300`, `engine.pool._timeout=30`
- [x] `pytest tests/ --collect-only`: 1164 tests collected, no import errors
- [x] `pytest tests/test_incidents.py`: 25 passed