### PR TITLE
chore: remove external dependencies on Keep/Elastic infra

### DIFF
--- a/docker-compose.common.yml
+++ b/docker-compose.common.yml
@@ -6,9 +6,8 @@ services:
       - NEXTAUTH_SECRET=secret
       - NEXTAUTH_URL=http://localhost:3000
       - NEXT_PUBLIC_API_URL=http://localhost:8080
-      - POSTHOG_KEY=phc_muk9qE3TfZsX3SZ9XxX52kCGJBclrjhkP9JxAQcm1PZ
-      - POSTHOG_HOST=https://ingest.keephq.dev
-      - NEXT_PUBLIC_SENTRY_DSN=https://0d4d59e3105ffe8afa27dcb95a222009@o4505515398922240.ingest.us.sentry.io/4508258058764288
+      - POSTHOG_DISABLED=true
+      - SENTRY_DISABLED=true
       - PUSHER_HOST=localhost
       - PUSHER_PORT=6001
       - PUSHER_APP_KEY=keepappkey
@@ -28,6 +27,8 @@ services:
       - PUSHER_HOST=keep-websocket-server
       - PUSHER_PORT=6001
       - USE_NGROK=false
+      - POSTHOG_DISABLED=true
+      - SENTRY_DISABLED=true
 
   keep-websocket-server-common:
     image: quay.io/soketi/soketi:1.4-16-debian

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ services:
     extends:
       file: docker-compose.common.yml
       service: keep-frontend-common
-    image: us-central1-docker.pkg.dev/keephq/keep/keep-ui
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.ui
     environment:
       - AUTH_TYPE=NO_AUTH
       - API_URL=http://keep-backend:8080
@@ -16,7 +18,9 @@ services:
     extends:
       file: docker-compose.common.yml
       service: keep-backend-common
-    image: us-central1-docker.pkg.dev/keephq/keep/keep-api
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.api
     environment:
       - AUTH_TYPE=NO_AUTH
       - PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus

--- a/keep-ui/app/(keep)/ai/ai-plugins.tsx
+++ b/keep-ui/app/(keep)/ai/ai-plugins.tsx
@@ -125,7 +125,7 @@ export function AIPlugins() {
                     </p>
                     <p className="pt-2">
                       <a
-                        href="https://www.keephq.dev/meet-keep"
+                        href="https://docs.optes.internal/contact"
                         className="text-orange-500 underline"
                       >
                         Talk to us to get access!

--- a/keep-ui/app/(keep)/deduplication/DeduplicationSidebar.tsx
+++ b/keep-ui/app/(keep)/deduplication/DeduplicationSidebar.tsx
@@ -228,7 +228,7 @@ const DeduplicationSidebar: React.FC<DeduplicationSidebarProps> = ({
             <br></br>
             <a
               href={`${
-                config?.KEEP_DOCS_URL || "https://docs.keephq.dev"
+                config?.KEEP_DOCS_URL || "https://docs.optes.internal"
               }/overview/deduplication`}
               target="_blank"
               className="text-orange-600 hover:underline mt-4"

--- a/keep-ui/app/(keep)/extraction/create-or-update-extraction-rule.tsx
+++ b/keep-ui/app/(keep)/extraction/create-or-update-extraction-rule.tsx
@@ -193,7 +193,7 @@ export default function CreateOrUpdateExtractionRule({
         Extraction Definition{" "}
         <a
           href={`${
-            config?.KEEP_DOCS_URL || "https://docs.keephq.dev"
+            config?.KEEP_DOCS_URL || "https://docs.optes.internal"
           }/overview/enrichment/extraction`}
           target="_blank"
         >
@@ -246,7 +246,7 @@ export default function CreateOrUpdateExtractionRule({
           Condition
           <a
             href={`${
-              config?.KEEP_DOCS_URL || "https://docs.keephq.dev"
+              config?.KEEP_DOCS_URL || "https://docs.optes.internal"
             }/overview/presets`}
             target="_blank"
           >

--- a/keep-ui/app/(keep)/extraction/extractions-table.tsx
+++ b/keep-ui/app/(keep)/extraction/extractions-table.tsx
@@ -106,7 +106,7 @@ export default function ExtractionsTable({ extractions, editCallback }: Props) {
           Condition{" "}
           <a
             href={`${
-              config?.KEEP_DOCS_URL || "https://docs.keephq.dev"
+              config?.KEEP_DOCS_URL || "https://docs.optes.internal"
             }/overview/enrichment/extraction`}
             target="_blank"
           >

--- a/keep-ui/app/(keep)/incidents/[id]/not-found.tsx
+++ b/keep-ui/app/(keep)/incidents/[id]/not-found.tsx
@@ -13,7 +13,7 @@ export default function NotFound() {
       <Subtitle>
         If you believe this is an error, please contact us on{" "}
         <Link
-          href="https://slack.keephq.dev/"
+          href="https://docs.optes.internal/contact"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/keep-ui/app/(keep)/not-found.tsx
+++ b/keep-ui/app/(keep)/not-found.tsx
@@ -13,7 +13,7 @@ export default function NotFound() {
       <Subtitle>
         If you believe this is an error, please contact us on{" "}
         <Link
-          href="https://slack.keephq.dev/"
+          href="https://docs.optes.internal/contact"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/keep-ui/app/(keep)/providers/page.client.tsx
+++ b/keep-ui/app/(keep)/providers/page.client.tsx
@@ -29,7 +29,7 @@ export const useFetchProviders = () => {
       <br />
       <Link
         href={`${
-          config?.KEEP_DOCS_URL || "https://docs.keephq.dev"
+          config?.KEEP_DOCS_URL || "https://docs.optes.internal"
         }/development/external-url`}
         target="_blank"
         rel="noreferrer noopener"
@@ -55,7 +55,7 @@ export const useFetchProviders = () => {
         autoClose: 10000,
         onClick: () =>
           window.open(
-            `${config?.KEEP_DOCS_URL || "https://docs.keephq.dev"}`,
+            `${config?.KEEP_DOCS_URL || "https://docs.optes.internal"}`,
             "_blank"
           ),
         style: {

--- a/keep-ui/app/(keep)/providers/provider-form.tsx
+++ b/keep-ui/app/(keep)/providers/provider-form.tsx
@@ -598,7 +598,7 @@ const ProviderForm = ({
                   >
                     <a
                       href={`${
-                        config?.KEEP_DOCS_URL || "https://docs.keephq.dev"
+                        config?.KEEP_DOCS_URL || "https://docs.optes.internal"
                       }/development/external-url`}
                       target="_blank"
                       rel="noopener noreferrer"
@@ -728,7 +728,7 @@ const ProviderForm = ({
           <Link
             className="text-orange-600 underline"
             href={`${
-              config?.KEEP_DOCS_URL || "http://docs.keephq.dev"
+              config?.KEEP_DOCS_URL || "https://docs.optes.internal"
             }/providers/documentation/${provider.docs_slug ?? provider.type}-provider`}
             target="_blank"
           >

--- a/keep-ui/app/(keep)/providers/provider-logs.tsx
+++ b/keep-ui/app/(keep)/providers/provider-logs.tsx
@@ -38,7 +38,7 @@ const ProviderLogs: React.FC<ProviderLogsProps> = ({ providerId }) => {
               variant="primary"
               onClick={() =>
                 window.open(
-                  `${config?.KEEP_DOCS_URL || "https://docs.keephq.dev"}`,
+                  `${config?.KEEP_DOCS_URL || "https://docs.optes.internal"}`,
                   "_blank"
                 )
               }

--- a/keep-ui/app/(keep)/rules/CorrelationSidebar/CorrelationSidebarBody.tsx
+++ b/keep-ui/app/(keep)/rules/CorrelationSidebar/CorrelationSidebarBody.tsx
@@ -129,7 +129,7 @@ export const CorrelationSidebarBody = ({
             className="!text-orange-500 hover:!text-orange-700 ml-0.5"
             target="_blank"
             href={`${
-              config?.KEEP_DOCS_URL || "https://docs.keephq.dev"
+              config?.KEEP_DOCS_URL || "https://docs.optes.internal"
             }/overview/correlation`}
           >
             docs

--- a/keep-ui/app/(keep)/settings/settings.client.tsx
+++ b/keep-ui/app/(keep)/settings/settings.client.tsx
@@ -55,7 +55,7 @@ export default function SettingsPage() {
   const [userSubTabIndex, setUserSubTabIndex] = useState<number>(0);
 
   const authType = configData?.AUTH_TYPE as AuthType;
-  const docsUrl = configData?.KEEP_DOCS_URL || "https://docs.keephq.dev";
+  const docsUrl = configData?.KEEP_DOCS_URL || "https://docs.optes.internal";
 
   // future: feature flags
   const usersAllowed = authType !== AuthType.NOAUTH;

--- a/keep-ui/app/(keep)/workflows/[workflow_id]/workflow-detail-page.tsx
+++ b/keep-ui/app/(keep)/workflows/[workflow_id]/workflow-detail-page.tsx
@@ -74,7 +74,7 @@ export default function WorkflowDetailPage({
     }
   );
 
-  const docsUrl = configData?.KEEP_DOCS_URL || "https://docs.keephq.dev";
+  const docsUrl = configData?.KEEP_DOCS_URL || "https://docs.optes.internal";
 
   if (error) {
     return <ErrorComponent error={error} />;

--- a/keep-ui/app/(keep)/workflows/noworkflows.tsx
+++ b/keep-ui/app/(keep)/workflows/noworkflows.tsx
@@ -14,7 +14,7 @@ import {
 const WorkflowsEmptyState = () => {
   const router = useRouter();
   const { data: configData } = useConfig();
-  const docsUrl = configData?.KEEP_DOCS_URL || "https://docs.keephq.dev";
+  const docsUrl = configData?.KEEP_DOCS_URL || "https://docs.optes.internal";
 
   const links = [
     {
@@ -28,7 +28,7 @@ const WorkflowsEmptyState = () => {
       icon: BellAlertIcon,
     },
     {
-      href: "https://slack.keephq.dev",
+      href: "https://docs.optes.internal/contact",
       label: "Get support on your Workflow",
       icon: FaSlack,
     },

--- a/keep-ui/app/not-authorized.tsx
+++ b/keep-ui/app/not-authorized.tsx
@@ -18,7 +18,7 @@ export default function NotAuthorized({ message }: { message?: string }) {
           <br />
           If you need help, please contact us on{" "}
           <Link
-            href="https://slack.keephq.dev/"
+            href="https://docs.optes.internal/contact"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/keep-ui/components/banners/BannerBase.tsx
+++ b/keep-ui/components/banners/BannerBase.tsx
@@ -55,10 +55,10 @@ const KeepBanner = ({
                 source: bannerId,
               });
               {newWindow ? window.open(
-                "https://www.keephq.dev/meet-keep",
+                "https://docs.optes.internal/contact",
                 "_blank",
                 "noopener,noreferrer"
-              ) : window.location.href = "https://www.keephq.dev/meet-keep"}
+              ) : window.location.href = "https://docs.optes.internal/contact"}
             }}
             color="orange"
             variant="secondary"

--- a/keep-ui/components/navbar/Search.tsx
+++ b/keep-ui/components/navbar/Search.tsx
@@ -100,7 +100,7 @@ export const Search = ({ session }: SearchProps) => {
   const router = useRouter();
   const comboboxInputRef = useRef<ElementRef<"input">>(null);
   const { data: configData } = useConfig();
-  const docsUrl = configData?.KEEP_DOCS_URL || "https://docs.keephq.dev";
+  const docsUrl = configData?.KEEP_DOCS_URL || "https://docs.optes.internal";
   const [isLoading, setIsLoading] = useState(false);
 
   // Log session for debugging

--- a/keep-ui/components/navbar/UserInfo.tsx
+++ b/keep-ui/components/navbar/UserInfo.tsx
@@ -111,7 +111,7 @@ type UserInfoProps = {
 export const UserInfo = ({ session }: UserInfoProps) => {
   const { data: config } = useConfig();
 
-  const docsUrl = config?.KEEP_DOCS_URL || "https://docs.keephq.dev";
+  const docsUrl = config?.KEEP_DOCS_URL || "https://docs.optes.internal";
 
   return (
     <>
@@ -124,7 +124,7 @@ export const UserInfo = ({ session }: UserInfoProps) => {
         <li className="flex text-xs items-center gap-2">
           <LinkWithIcon
             icon={FaSlack}
-            href="https://slack.keephq.dev/"
+            href="https://docs.optes.internal/contact"
             className="w-auto pr-3.5"
             target="_blank"
           >

--- a/keep-ui/features/alerts/alert-detail-sidebar/lib/alertSidebarFields.tsx
+++ b/keep-ui/features/alerts/alert-detail-sidebar/lib/alertSidebarFields.tsx
@@ -152,7 +152,7 @@ export const alertSidebarFieldsConfig: Record<
                 are calculated based on.{" "}
                 <Link
                   href={`${
-                    config?.KEEP_DOCS_URL || "https://docs.keephq.dev"
+                    config?.KEEP_DOCS_URL || "https://docs.optes.internal"
                   }/overview/fingerprints`}
                   className="text-white"
                 >

--- a/keep-ui/features/presets/presets-manager/ui/alerts-rules-builder.tsx
+++ b/keep-ui/features/presets/presets-manager/ui/alerts-rules-builder.tsx
@@ -393,7 +393,7 @@ export const AlertsRulesBuilder = ({
                                 {...props}
                                 docsUrl={
                                   config?.KEEP_DOCS_URL ||
-                                  "https://docs.keephq.dev"
+                                  "https://docs.optes.internal"
                                 }
                               />
                             ),

--- a/keep-ui/features/workflows/ai-assistant/ui/WorkflowBuilderChatSafe.tsx
+++ b/keep-ui/features/workflows/ai-assistant/ui/WorkflowBuilderChatSafe.tsx
@@ -41,7 +41,7 @@ export function WorkflowBuilderChatSafe({
             <Title>AI is disabled</Title>
             <Text>Contact us to enable AI for you.</Text>
             <Link
-              href="https://slack.keephq.dev/"
+              href="https://docs.optes.internal/contact"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/keep-ui/instrumentation.ts
+++ b/keep-ui/instrumentation.ts
@@ -4,7 +4,8 @@ import * as Sentry from "@sentry/nextjs";
 export async function register() {
   if (
     process.env.SENTRY_DISABLED === "true" ||
-    process.env.NODE_ENV === "development"
+    process.env.NODE_ENV === "development" ||
+    !process.env.NEXT_PUBLIC_SENTRY_DSN
   ) {
     return;
   }

--- a/keep-ui/next.config.js
+++ b/keep-ui/next.config.js
@@ -2,7 +2,8 @@ const { withSentryConfig } = require("@sentry/nextjs");
 
 const isSentryDisabled =
   process.env.SENTRY_DISABLED === "true" ||
-  process.env.NODE_ENV === "development";
+  process.env.NODE_ENV === "development" ||
+  !process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 // Turbopack doesn't support dynamic imports yet, so we need to fallback to CDN for development
 // Checking NODE_ENV because in the future we may use turbopack in production as well

--- a/keep-ui/shared/lib/server/getConfig.ts
+++ b/keep-ui/shared/lib/server/getConfig.ts
@@ -78,9 +78,9 @@ export function getConfig(): InternalConfig {
     // NOISY ALERTS DISABLED BY DEFAULT TO SPARE SPACE ON THE TABLE
     NOISY_ALERTS_ENABLED: process.env.NOISY_ALERTS_ENABLED === "true",
     // The URL of the documentation site
-    KEEP_DOCS_URL: process.env.KEEP_DOCS_URL || "https://docs.keephq.dev",
+    KEEP_DOCS_URL: process.env.KEEP_DOCS_URL || "https://docs.optes.internal",
     KEEP_CONTACT_US_URL:
-      process.env.KEEP_CONTACT_US_URL || "https://slack.keephq.dev/",
+      process.env.KEEP_CONTACT_US_URL || "https://docs.optes.internal/contact",
     KEEP_HIDE_SENSITIVE_FIELDS:
       process.env.KEEP_HIDE_SENSITIVE_FIELDS === "true",
     KEEP_WORKFLOW_DEBUG: process.env.KEEP_WORKFLOW_DEBUG === "true",

--- a/keep-ui/shared/ui/ErrorComponent/ErrorComponent.tsx
+++ b/keep-ui/shared/ui/ErrorComponent/ErrorComponent.tsx
@@ -31,7 +31,7 @@ export function ErrorComponent({
   const { data: config } = useConfig();
 
   const contactUsUrl =
-    config?.KEEP_CONTACT_US_URL || "https://slack.keephq.dev/";
+    config?.KEEP_CONTACT_US_URL || "https://docs.optes.internal/contact";
 
   useEffect(() => {
     Sentry.captureException(originalError);

--- a/keep-ui/shared/ui/utils/showErrorToast.tsx
+++ b/keep-ui/shared/ui/utils/showErrorToast.tsx
@@ -1,4 +1,3 @@
-import { Link } from "@/components/ui";
 import { KeepApiError, KeepApiReadOnlyError } from "@/shared/api";
 import { toast, ToastOptions, ToastPosition } from "react-toastify";
 
@@ -22,20 +21,7 @@ export function showErrorToast(
     ...options,
   };
   if (error instanceof KeepApiReadOnlyError) {
-    toast.warning(
-      <>
-        You&apos;re in read-only mode. Sign up at{" "}
-        <Link
-          href="https://keephq.dev"
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          keephq.dev
-        </Link>{" "}
-        to get your own instance!
-      </>,
-      toastOptions
-    );
+    toast.warning("You're in read-only mode.", toastOptions);
   } else if (error instanceof KeepApiError) {
     toast.error(
       messageOverride ||

--- a/keep/api/core/posthog.py
+++ b/keep/api/core/posthog.py
@@ -1,7 +1,4 @@
 import os
-import posthog
-import requests
-from posthog import Posthog
 from importlib import metadata
 
 from keep.api.core.db import get_or_creat_posthog_instance_id
@@ -14,32 +11,39 @@ except metadata.PackageNotFoundError:
     except metadata.PackageNotFoundError:
         KEEP_VERSION = os.environ.get("KEEP_VERSION", "unknown")
 
-POSTHOG_DISABLED = os.getenv("POSTHOG_DISABLED", "false").lower() == "true"
+# Telemetry to Keep's own infrastructure (app.posthog.com) is disabled by
+# default in this fork so that self-hosted instances never phone home unless
+# an operator explicitly opts in with both POSTHOG_DISABLED=false and a
+# POSTHOG_API_KEY they control.
+POSTHOG_DISABLED = os.getenv("POSTHOG_DISABLED", "true").lower() != "false"
 
-POSTHOG_API_KEY = (
-    os.getenv("POSTHOG_API_KEY")
-    or "phc_muk9qE3TfZsX3SZ9XxX52kCGJBclrjhkP9JxAQcm1PZ"  # It's a public PH API key, not a leaked secret ;)
-)
+POSTHOG_API_KEY = os.getenv("POSTHOG_API_KEY")
 
-if POSTHOG_DISABLED:
-    posthog.disabled = True
-    posthog_client = None
-else:
+posthog_client = None
+
+if not POSTHOG_DISABLED and POSTHOG_API_KEY:
+    from posthog import Posthog
+
     posthog_client = Posthog(
-        api_key=POSTHOG_API_KEY, 
-        host="https://app.posthog.com", 
+        api_key=POSTHOG_API_KEY,
+        host=os.getenv("POSTHOG_HOST", "https://app.posthog.com"),
     )
 
 
 def is_posthog_reachable():
+    if POSTHOG_DISABLED or not POSTHOG_API_KEY:
+        return False
     try:
+        import requests
+        from posthog import Posthog
+
         Posthog(
-            api_key=POSTHOG_API_KEY, 
-            host="https://app.posthog.com", 
+            api_key=POSTHOG_API_KEY,
+            host=os.getenv("POSTHOG_HOST", "https://app.posthog.com"),
             feature_flags_request_timeout_seconds=3,
-            sync_mode=True  # Explicitly to trigger exception if it's not reachable.
+            sync_mode=True,  # Explicitly to trigger exception if it's not reachable.
         ).capture(
-            get_or_creat_posthog_instance_id(), 
+            get_or_creat_posthog_instance_id(),
             "connectivity_check",
         )
         return True

--- a/keep/cli/cli.py
+++ b/keep/cli/cli.py
@@ -87,7 +87,10 @@ def make_keep_request(method, url, **kwargs):
 class Info:
     """An information object to pass data between CLI functions."""
 
-    KEEP_MANAGED_API_URL = "https://api.keephq.dev"
+    # Managed/cloud login against Keep's own SaaS is disabled in this fork.
+    # Self-hosted deployments must set KEEP_API_URL (or keep_api_url in the
+    # config file) explicitly.
+    KEEP_MANAGED_API_URL = None
 
     def __init__(self):  # Note: This object must have an empty constructor.
         """Create a new instance."""
@@ -113,7 +116,7 @@ class Info:
         self.keep_api_url = (
             self.config.get("keep_api_url")
             or os.getenv("KEEP_API_URL")
-            or Info.KEEP_MANAGED_API_URL
+            or "http://localhost:8080"
         )
         self.random_user_id = self.config.get("random_user_id")
         # if we don't have a random user id, we create one and keep it on the config file
@@ -1488,112 +1491,28 @@ def auth(info: Info):
     pass
 
 
-# global token will be populated in the callback
-token = None
-
-
 @auth.command()
 @pass_info
 def login(info: Info):
-    # first, prepare the oauth2 session:
-    import os
-    import threading
-    import time
-    import webbrowser
+    """Disabled in this fork.
 
-    import uvicorn
-    from fastapi import FastAPI
-    from fastapi.responses import PlainTextResponse
-    from requests_oauthlib import OAuth2Session
+    There is no managed/cloud Keep account to log into here. Configure
+    KEEP_API_URL (env var or `keep_api_url` in the config file) and an API
+    key instead, e.g.:
 
-    app = FastAPI()
-
-    @app.get("/callback")
-    def callback(code: str, state: str):
-        global token
-        token_url = "https://auth.keephq.dev/oauth/token"
-        token = oauth_session.fetch_token(
-            token_url,
-            code=code,
-            client_secret="",
-            include_client_id=True,
-            authorization_response=redirect_uri,
+        keep --api-url http://localhost:8080 --api-key <your-api-key> whoami
+    """
+    click.echo(
+        click.style(
+            "`keep auth login` is disabled in this fork -- there is no managed "
+            "Keep account to authenticate against. Set KEEP_API_URL and pass an "
+            "API key via `keep --api-url ... --api-key ...` (or the config file) "
+            "instead.",
+            fg="yellow",
+            bold=True,
         )
-        print("Got the token")
-        return PlainTextResponse(
-            "Authenticated successfully, you can close this tab now, Keep rulezzz!"
-        )
-
-    # We needed a way to run a server without blocking the main thread:
-    #   https://github.com/encode/uvicorn/discussions/1103#discussioncomment-1389875
-    class UvicornServer:
-        def __init__(self):
-            super().__init__()
-
-        def start(self):
-            # Define the FastAPI app running logic here
-            uvicorn.run(app, host="127.0.0.1", port=8085, log_level="critical")
-
-    # These are the public client_id of KeepHQ auth0
-    # If you have your own identity provider, we'll need to implement to flow
-    client_id = os.getenv("KEEP_OAUTH_CLIENT_ID", "P7zzubZGLNe8BQ4HRzvrhT5qPgRFa0BL")
-    authorization_base_url = os.getenv(
-        "KEEP_OAUTH_AUTHORIZATION_BASE_URL", "https://auth.keephq.dev/authorize"
     )
-    scope = ["openid", "profile", "email"]
-    redirect_uri = "http://localhost:8085/callback"
-    oauth_session = OAuth2Session(client_id, scope=scope, redirect_uri=redirect_uri)
-    # now that we have the state parameter, we can start the fast api server
-    # start the server on another process
-    server_thread = threading.Thread(target=UvicornServer().start)
-    server_thread.start()
-    # now, open the browser and wait for the authentication
-    webbrowser.open(oauth_session.authorization_url(authorization_base_url)[0])
-    # Now wait for the callback
-    timeout = 60 * 2  # 2 minutes
-    times = 0
-    time_start = time.time()
-    while not token:
-        if time.time() - time_start > timeout:
-            print("Timeout waiting for callback")
-            # kill the server
-            os._exit(1)
-        # print every 15 seconds
-        if times % 15 == 0:
-            print("Still waiting for callback")
-        time.sleep(1)
-
-    # Ok, we got the token from the oauth2 flow, now let's get a permanent api key
-    print("Got the token, getting the api key")
-    id_token = token["id_token"]
-    api_key_resp = make_keep_request(
-        "GET",
-        info.keep_api_url + "/settings/apikey",
-        headers={"accept": "application/json", "Authorization": f"Bearer {id_token}"},
-    )
-    if not api_key_resp.ok:
-        print(f"Error getting api key: {api_key_resp.text}")
-        # kill the server
-        os._exit(2)
-
-    api_key = api_key_resp.json().get("apiKey")
-    # keep it in the config file
-    with open(f"{get_default_conf_file_path()}", "w") as f:
-        f.write(f"api_key: {api_key}\n")
-    # Authenticated successfully
-    print("Authenticated successfully!")
-    # Check that we can get whoami
-    resp = make_keep_request(
-        "GET",
-        info.keep_api_url + "/whoami",
-        headers={"x-api-key": api_key, "accept": "application/json"},
-    )
-    if not resp.ok:
-        raise Exception(f"Error getting whoami: {resp.text}")
-    print("Authenticated to Keep successfully!")
-    print(resp.json())
-    # kills the server also, great success
-    os._exit(0)
+    sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Build UI and API images locally (docker/Dockerfile.*) instead of pulling from us-central1-docker.pkg.dev/keephq/keep/*, which is Keep's own GCP Artifact Registry and outside our control.
- Remove hardcoded PostHog API key/host and Sentry DSN from docker-compose.common.yml; default POSTHOG_DISABLED/SENTRY_DISABLED to true so telemetry never leaves the deployment unless explicitly enabled with credentials the operator controls.
- Rework keep/api/core/posthog.py so the backend never builds a PostHog client (and therefore the hourly uptime-reporting thread in report_uptime.py never fires) unless POSTHOG_DISABLED=false AND a POSTHOG_API_KEY are both explicitly set.
- Add defense-in-depth on the frontend: Sentry stays off unless NEXT_PUBLIC_SENTRY_DSN is explicitly provided, regardless of SENTRY_DISABLED being set.
- Disable `keep auth login`, which depended on Keep's own Auth0 tenant (auth.keephq.dev) and managed API (api.keephq.dev). CLI now defaults to a local self-hosted API URL and the command explains how to configure KEEP_API_URL/API key instead.
- Point docs/contact link fallbacks (docs.keephq.dev, slack.keephq.dev, keephq.dev/meet-keep) to an internal placeholder (docs.optes.internal) via KEEP_DOCS_URL/KEEP_CONTACT_US_URL, to be swapped for our own docs/support page once it exists.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
