### PR TITLE
ci: pin ruff version to make lint deterministic (#6648)

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: chartboost/ruff-action@v1
         with:
           src: "./keep"
+          version: 0.11.4
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test-pr-ut.yml
+++ b/.github/workflows/test-pr-ut.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: chartboost/ruff-action@v1
         with:
           src: "./keep"
+          version: 0.11.4
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4

--- a/.github/workflows/test-workflow-examples.yml
+++ b/.github/workflows/test-workflow-examples.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: chartboost/ruff-action@v1
         with:
           src: "./keep"
+          version: 0.11.4
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         stages: [commit, push, manual]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.6
+    rev: v0.11.4
     hooks:
       # Run the linter.
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,9 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.scripts]
 keep = "keep.cli.cli:cli"
 
+[tool.ruff]
+required-version = "0.11.4"
+
 [tool.ruff.lint]
 ignore = ["F405", "F811", "E712", "E711", "F403"]
 


### PR DESCRIPTION
## Summary

Fixes #6648 — the root cause of ruff CI "suddenly" failing on unrelated PRs.

The `chartboost/ruff-action@v1` steps did **not** pin a `version`, so CI installed whatever ruff release was newest at job time (the dev dependency pin `ruff = "^0.11.4"` in `pyproject.toml` does **not** apply — the action installs ruff into its own throwaway venv). When a newer ruff shipped new/stricter default rules, `ruff check ./keep` began flagging thousands of pre-existing violations in files contributors never touched (see #6644, which hit 3,492 violations on a 6-line change).

This pins ruff to a single deterministic version everywhere so lint results no longer drift with upstream ruff releases.

## Changes

- Add `version: 0.11.4` to all three `chartboost/ruff-action@v1` steps (`test-pr-ut.yml`, `test-docs.yml`, `test-workflow-examples.yml`).
- Add `[tool.ruff] required-version = "0.11.4"` to `pyproject.toml` so local/dev ruff runs are locked too.
- Bump the `ruff-pre-commit` hook from `v0.1.6` → `v0.11.4` so pre-commit, CI, and the dev dependency all agree.

`0.11.4` matches the existing `ruff = "^0.11.4"` dev dependency.

## Why this approach

This is the minimal, durable fix: it stops the version drift that causes the flakiness. It is complementary to the large lint-cleanup effort in #6649 — pinning ensures that once the tree is clean under a known ruff, it *stays* deterministic and a future ruff release can't silently re-break CI.

## Test plan

- [ ] CI `ruff check` step installs ruff `0.11.4` (visible in the action's "installing ruff" log line).
- [ ] Lint results are reproducible locally with `ruff check ./keep` using ruff `0.11.4`.

Closes #6648

Made with [Cursor](https://cursor.com)