### PR TITLE
fix: stabilize OAuth2-Proxy session hydration

### DIFF
--- a/keep-ui/app/auth-provider.tsx
+++ b/keep-ui/app/auth-provider.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import { Session } from "next-auth";
+import type { Session } from "next-auth";
 import { SessionProvider } from "next-auth/react";
-
-declare global {
-  interface Window {
-    __NEXT_AUTH_SESSION__?: Session | null;
-  }
-}
 
 type Props = {
   children?: React.ReactNode;
@@ -15,10 +9,5 @@ type Props = {
 };
 
 export const NextAuthProvider = ({ children, session }: Props) => {
-  // Hydrate session on mount
-  if (typeof window !== "undefined" && !!session) {
-    window.__NEXT_AUTH_SESSION__ = session;
-  }
-
-  return <SessionProvider>{children}</SessionProvider>;
+  return <SessionProvider session={session}>{children}</SessionProvider>;
 };

--- a/keep-ui/shared/lib/hooks/__tests__/useHydratedSession.test.tsx
+++ b/keep-ui/shared/lib/hooks/__tests__/useHydratedSession.test.tsx
@@ -1,0 +1,173 @@
+import { act, render, screen } from "@testing-library/react";
+import type { Session } from "next-auth";
+import type { ReactNode } from "react";
+import { NextAuthProvider } from "@/app/auth-provider";
+import { useHydratedSession } from "../useHydratedSession";
+
+type SessionState = {
+  data: Session | null | undefined;
+  status: "authenticated" | "loading" | "unauthenticated";
+  update: jest.Mock;
+};
+
+let mockInitialClientState: SessionState | undefined;
+let mockSetSessionState:
+  React.Dispatch<React.SetStateAction<SessionState>> | undefined;
+const mockUpdate = jest.fn();
+
+jest.mock("next-auth/react", () => {
+  const React = jest.requireActual<typeof import("react")>("react");
+  const SessionContext = React.createContext<SessionState | undefined>(
+    undefined
+  );
+
+  return {
+    SessionProvider: ({
+      children,
+      session,
+    }: {
+      children: ReactNode;
+      session?: Session | null;
+    }) => {
+      const [sessionState, setSessionState] = React.useState<SessionState>(
+        session
+          ? {
+              data: session,
+              status: "authenticated",
+              update: mockUpdate,
+            }
+          : (mockInitialClientState ?? {
+              data: null,
+              status: "unauthenticated",
+              update: mockUpdate,
+            })
+      );
+
+      mockSetSessionState = setSessionState;
+
+      return (
+        <SessionContext.Provider value={sessionState}>
+          {children}
+        </SessionContext.Provider>
+      );
+    },
+    useSession: () => {
+      const sessionState = React.useContext(SessionContext);
+
+      if (!sessionState) {
+        throw new Error("useSession must be wrapped in a SessionProvider");
+      }
+
+      return sessionState;
+    },
+  };
+});
+
+const oauth2ProxySession: Session = {
+  accessToken: "oauth2-proxy-access-token",
+  tenantId: "keep",
+  expires: "2099-01-01T00:00:00.000Z",
+  user: {
+    id: "oauth2-proxy-user",
+    name: "OAuth2 Proxy User",
+    email: "oauth2-proxy@example.com",
+    accessToken: "oauth2-proxy-access-token",
+    tenantId: "keep",
+  },
+};
+
+function SessionConsumer() {
+  const session = useHydratedSession();
+
+  return (
+    <div>
+      <span data-testid="status">{session.status}</span>
+      <span data-testid="access-token">
+        {session.data?.accessToken ?? "no-token"}
+      </span>
+      <span data-testid="tenant">{session.data?.tenantId ?? "no-tenant"}</span>
+    </div>
+  );
+}
+
+function renderConsumer(session: Session | null) {
+  return render(
+    <NextAuthProvider session={session}>
+      <SessionConsumer />
+    </NextAuthProvider>
+  );
+}
+
+describe("useHydratedSession", () => {
+  beforeEach(() => {
+    mockInitialClientState = undefined;
+    mockSetSessionState = undefined;
+    mockUpdate.mockReset();
+  });
+
+  it("uses the server-resolved OAuth2-Proxy session on the first render", () => {
+    mockInitialClientState = {
+      data: undefined,
+      status: "loading",
+      update: mockUpdate,
+    };
+
+    renderConsumer(oauth2ProxySession);
+
+    expect(screen.getByTestId("status")).toHaveTextContent("authenticated");
+    expect(screen.getByTestId("access-token")).toHaveTextContent(
+      "oauth2-proxy-access-token"
+    );
+    expect(screen.getByTestId("tenant")).toHaveTextContent("keep");
+  });
+
+  it("returns a defined unauthenticated session context for null input", () => {
+    renderConsumer(null);
+
+    expect(screen.getByTestId("status")).toHaveTextContent("unauthenticated");
+    expect(screen.getByTestId("access-token")).toHaveTextContent("no-token");
+    expect(screen.getByTestId("tenant")).toHaveTextContent("no-tenant");
+  });
+
+  it("stays defined while the client session transitions from loading to authenticated", () => {
+    mockInitialClientState = {
+      data: undefined,
+      status: "loading",
+      update: mockUpdate,
+    };
+
+    renderConsumer(null);
+
+    expect(screen.getByTestId("status")).toHaveTextContent("loading");
+    expect(screen.getByTestId("access-token")).toHaveTextContent("no-token");
+
+    act(() => {
+      mockSetSessionState?.({
+        data: oauth2ProxySession,
+        status: "authenticated",
+        update: mockUpdate,
+      });
+    });
+
+    expect(screen.getByTestId("status")).toHaveTextContent("authenticated");
+    expect(screen.getByTestId("access-token")).toHaveTextContent(
+      "oauth2-proxy-access-token"
+    );
+  });
+
+  it("uses an explicit unauthenticated state after an empty client refresh", () => {
+    renderConsumer(oauth2ProxySession);
+
+    act(() => {
+      mockSetSessionState?.({
+        data: null,
+        status: "unauthenticated",
+        update: mockUpdate,
+      });
+    });
+
+    expect(screen.getByTestId("status")).toHaveTextContent("unauthenticated");
+    expect(screen.getByTestId("access-token")).toHaveTextContent("no-token");
+    expect(screen.getByTestId("tenant")).toHaveTextContent("no-tenant");
+  });
+});

--- a/keep-ui/shared/lib/hooks/useHydratedSession.tsx
+++ b/keep-ui/shared/lib/hooks/useHydratedSession.tsx
@@ -1,37 +1,6 @@
 "use client";
-import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
-import type { Session } from "next-auth";
-
-// Define window augmentation for Next Auth session
-declare global {
-  interface Window {
-    __NEXT_AUTH?: {
-      session?: Session;
-    };
-  }
-}
 
 export function useHydratedSession() {
-  const [isHydrated, setIsHydrated] = useState(false);
-  const session = useSession();
-
-  useEffect(() => {
-    setIsHydrated(true);
-  }, []);
-
-  // If we're in the browser and have a preloaded session
-  if (
-    !isHydrated &&
-    typeof window !== "undefined" &&
-    window.__NEXT_AUTH?.session
-  ) {
-    return {
-      data: window.__NEXT_AUTH.session,
-      status: "authenticated" as const,
-      update: session.update,
-    };
-  }
-
-  return session;
+  return useSession();
 }


### PR DESCRIPTION
With `AUTH_TYPE=OAUTH2PROXY`, the UI can authenticate successfully but crash while client state is being constructed after the initial loading screen. The current session wiring still exposes the race: `NextAuthProvider` receives the server-resolved session but does not pass it to `SessionProvider`, and its `window.__NEXT_AUTH_SESSION__` cache does not match the `window.__NEXT_AUTH.session` value read by `useHydratedSession`. Consequently, layout-level consumers such as websocket polling and PostHog can observe an avoidable loading transition instead of the already-resolved session. The issue remains present on current `main`; the post-0.52 Monaco render-loop fix addressed a separate OAuth2-Proxy symptom and did not repair this hydration contract.

## Summary

Make `NextAuthProvider` seed NextAuth's `SessionProvider` with the session already resolved by `app/(keep)/layout.tsx`, so every client consumer starts from one authoritative session value. Simplify `useHydratedSession` around that provider contract, removing or aligning the mismatched browser-global fallback so the hook always returns a valid session-context object throughout hydration. Add a focused hook/provider regression test that exercises an OAuth2-Proxy-shaped session from the server through initial render and subsequent NextAuth state updates.

## Test plan

- Render the session provider with an OAuth2-Proxy-shaped authenticated session and verify a `useHydratedSession` consumer receives its access token, tenant, and authenticated status on the first client render.
- Cover null/unauthenticated input and the loading-to-authenticated transition, verifying the hook always returns a defined session-context object and does not replace the server session with an undefined intermediate state.
- Simulate a failed or empty client session refresh after initial hydration and verify consumers receive NextAuth's explicit unauthenticated/error state rather than a destructuring crash.

Closes #6546
