### PR TITLE
fix: avoid double-encoding alert URLs

### DIFF
--- a/keep/api/models/alert.py
+++ b/keep/api/models/alert.py
@@ -2,6 +2,7 @@ import datetime
 import hashlib
 import json
 import logging
+import re
 import urllib.parse
 import uuid
 from enum import Enum
@@ -16,6 +17,9 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
+
+_INVALID_PERCENT_ESCAPE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_URL_SAFE_CHARACTERS = "/:?=&%#"
 
 
 def get_fingerprint(fingerprint, values):
@@ -165,7 +169,8 @@ class AlertDto(BaseModel):
             # @tb: in some cases we drop the event because of invalid url with no scheme
             # invalid or missing URL scheme (type=value_error.url.scheme)
             url = f"https://{url}"
-        return urllib.parse.quote(url, safe="/:?=&")
+        url = _INVALID_PERCENT_ESCAPE.sub("%25", url)
+        return urllib.parse.quote(url, safe=_URL_SAFE_CHARACTERS)
 
     @validator("lastReceived", pre=True, always=True)
     def validate_last_received(cls, last_received):

--- a/tests/test_alert_dto.py
+++ b/tests/test_alert_dto.py
@@ -1,5 +1,4 @@
 import hashlib
-import urllib.parse
 from datetime import datetime, timedelta, timezone
 
 import freezegun
@@ -168,20 +167,47 @@ def test_alert_dto_invalid_timestamps():
             pytest.fail(f"Expected ValueError for timestamp {timestamp}")
 
 
-def test_alert_dto_url_encoding():
-    """Test that the url is encoded correctly and no exception is raised"""
-    unencoded_urls = [
-        "https://platform.keephq.dev?alertId=NetworkConnection-IF-HGD100000/2 [lan3] [0.0.0.0] [fswintf]<->IF-HGD100000/2 [internal] [0.0.0.0] [internal]-Down",
-        "https://platform.keephq.dev?alertId=NetworkConnection-IF-HGD100000/2#[lan3] [0.0.0.0] [fswintf]<->IF-HGD100000/2 [internal] [0.0.0.0] [internal]-Down",
-        " https://platform.keephq.dev?alertId=NetworkConnection-IF-HGD100000/2 [lan3] [0.0.0.0] [fswintf]<->IF-HGD100000/2 [internal] [0.0.0.0] [internal]-Down ",
-    ]
-    for url in unencoded_urls:
-        alert = create_basic_alert(
-            name="Test Alert", last_received="1970-01-01T00:00:00.000Z", url=url
-        )
-        unquoted_url = urllib.parse.unquote(str(alert.url))
-        reencoded_url = urllib.parse.quote(unquoted_url, safe="/:?=&")
-        assert alert.url == reencoded_url
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (
+            "https://www.google.com/search?q=%E9%93%B6%E6%B2%B3",
+            "https://www.google.com/search?q=%E9%93%B6%E6%B2%B3",
+        ),
+        (
+            "https://wazuh.example/#/agents?name=production%20server",
+            "https://wazuh.example/#/agents?name=production%20server",
+        ),
+        (
+            "https://platform.keephq.dev?alertId=service a<->service b",
+            "https://platform.keephq.dev?alertId=service%20a%3C-%3Eservice%20b",
+        ),
+        (
+            " example.com/progress/100% complete ",
+            "https://example.com/progress/100%25%20complete",
+        ),
+        (
+            "https://example.com/银河",
+            "https://example.com/%E9%93%B6%E6%B2%B3",
+        ),
+        (
+            "https://example.com/%2/%GG",
+            "https://example.com/%252/%25GG",
+        ),
+    ],
+)
+def test_alert_dto_url_encoding_is_idempotent(url, expected):
+    alert = create_basic_alert(
+        name="Test Alert", last_received="1970-01-01T00:00:00.000Z", url=url
+    )
+    reconstructed_alert = create_basic_alert(
+        name="Test Alert",
+        last_received="1970-01-01T00:00:00.000Z",
+        url=str(alert.url),
+    )
+
+    assert str(alert.url) == expected
+    assert str(reconstructed_alert.url) == expected
 
 
 @pytest.mark.parametrize("test_app", ["NO_AUTH"], indirect=True)


### PR DESCRIPTION
Closes #4737

## 📑 Description

Alert URL validation encoded the `%` in existing `%HH` sequences each time an alert DTO was reconstructed. It also encoded `#`, which broke hash-based URLs such as Wazuh agent links.

This change preserves valid percent escapes and fragments while encoding malformed percent signs exactly once. It adds regression coverage for encoded Unicode, hash fragments, raw unsafe characters, scheme-less URLs, raw Unicode paths, and malformed percent escapes, including reconstruction idempotence.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information

Validation completed:

- `pytest tests/test_alert_dto.py -k url_encoding_is_idempotent --noconftest -o addopts='' -q`
- `pytest tests/test_alert_dto.py -k 'not test_alert_started_at' -o addopts='' -q`
- `ruff check keep/api/models/alert.py tests/test_alert_dto.py`
- `isort --check-only keep/api/models/alert.py tests/test_alert_dto.py`
- `black --check tests/test_alert_dto.py`