### PR TITLE
ci: read the PR description from env instead of interpolating it into the shell

### DIFF
--- a/.github/workflows/auto-resolve-keep.yml
+++ b/.github/workflows/auto-resolve-keep.yml
@@ -28,8 +28,10 @@ jobs:
       - name: Extract Keep ID from PR description
         if: github.event_name == 'pull_request'
         id: extract_id
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          PR_DESC="${{ github.event.pull_request.body }}"
+          PR_DESC="$PR_BODY"
           INCIDENT_ID=$(echo "$PR_DESC" | grep -ioP 'close keep incident:\s*\K[a-f0-9-]+' || true)
           ALERT_FINGERPRINT=$(echo "$PR_DESC" | grep -ioP 'close keep alert:\s*\K[a-f0-9-]+' || true)
           echo "incident_id=$INCIDENT_ID" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Hi, and thanks for Keep.

In `.github/workflows/auto-resolve-keep.yml`, the PR description is read into the shell by interpolation:

```yaml
run: |
  PR_DESC="${{ github.event.pull_request.body }}"
  INCIDENT_ID=$(echo "$PR_DESC" | grep -ioP 'close keep incident:\s*\K[a-f0-9-]+' || true)
```

Actions expands `${{ ... }}` into the script text before bash runs, so the description becomes part of the script rather than a string assigned to `PR_DESC`. A PR body is free text chosen by whoever opens the PR, and `$(...)` and backticks still run inside double quotes — so a body containing `$(...)` would execute on the runner instead of being searched for `close keep incident: <id>`.

The `grep -ioP ... [a-f0-9-]+` pattern is nicely tight about what it will accept as an ID, which is good — it just runs after the value has already been part of the command.

The change binds the body to an environment variable:

```yaml
env:
  PR_BODY: ${{ github.event.pull_request.body }}
run: |
  PR_DESC="$PR_BODY"
```

Both `grep` extractions and both `$GITHUB_OUTPUT` writes are untouched, so incident IDs and alert fingerprints are found exactly as they are today. Two lines added, one changed.

On scope: this is a `pull_request` trigger, so a fork PR gets a read-only token and no secrets — hardening rather than a live exploit.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow myself.

Fixes #6655
