### PR TITLE
feat: enforce incident trigger CEL in insert_incident

### DIFF
--- a/keep/workflowmanager/workflowmanager.py
+++ b/keep/workflowmanager/workflowmanager.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import re
@@ -141,17 +142,18 @@ class WorkflowManager:
             if workflow is None:
                 continue
 
-            # Using list comprehension instead of pandas flatten() for better performance
-            # and to avoid pandas dependency
-            # @tb: I removed pandas so if we'll have performance issues we can revert to pandas
-            incident_triggers = [
-                event
-                for trigger in workflow.workflow_triggers
-                if trigger["type"] == "incident"
-                for event in trigger.get("events", [])
-            ]
+            # Find the incident trigger (if any) that declares interest in this event name.
+            matching_trigger = next(
+                (
+                    workflow_trigger
+                    for workflow_trigger in workflow.workflow_triggers
+                    if workflow_trigger.get("type") == "incident"
+                    and trigger in workflow_trigger.get("events", [])
+                ),
+                None,
+            )
 
-            if trigger not in incident_triggers:
+            if matching_trigger is None:
                 self.logger.debug(
                     "workflow does not contain trigger %s, skipping", trigger
                 )
@@ -161,6 +163,46 @@ class WorkflowManager:
             if incident_enrichment:
                 for k, v in incident_enrichment.enrichments.items():
                     setattr(incident, k, v)
+
+            # Evaluate the trigger's CEL (if any) against the (now enrichment-merged)
+            # incident, mirroring how insert_events() gates alert triggers. Without this,
+            # a trigger's "cel" is parsed but never enforced for incident events.
+            cel = matching_trigger.get("cel", "")
+            if cel:
+                try:
+                    cel = preprocess_cel_expression(cel)
+                    compiled_ast = self.cel_environment.compile(cel)
+                    program = self.cel_environment.program(compiled_ast)
+                    # incident.dict() leaves UUID/enum fields as native Python objects,
+                    # which celpy.json_to_cel rejects; round-trip through JSON first.
+                    incident_payload = json.loads(incident.json())
+                    activation = celpy.json_to_cel(incident_payload)
+                    should_run = program.evaluate(activation)
+                except Exception as e:
+                    self.logger.exception(
+                        "Error evaluating CEL for incident trigger",
+                        extra={
+                            "exception": e,
+                            "incident_id": str(incident.id),
+                            "trigger": matching_trigger,
+                            "workflow_id": workflow_model.id,
+                            "tenant_id": tenant_id,
+                            "cel": cel,
+                        },
+                    )
+                    continue
+
+                if bool(should_run) is False:
+                    self.logger.debug(
+                        "Workflow should not run for incident, skipping",
+                        extra={
+                            "incident_id": str(incident.id),
+                            "workflow_id": workflow_model.id,
+                            "tenant_id": tenant_id,
+                            "cel": cel,
+                        },
+                    )
+                    continue
 
             self.logger.info("Adding workflow to run")
             with self.scheduler.lock:


### PR DESCRIPTION
Fixes: #6656 

## Problem

`WorkflowManager.insert_incident()` only checked whether the incoming event
name (`created` / `updated`) was declared on the trigger. It never compiled
or evaluated the trigger's `cel` expression, unlike `insert_events()`, which
does this for alert triggers. As a result, a `cel` guard on an incident
trigger — e.g. `!has(incident_id)`, meant to stop a workflow from re-running
once it has already completed and enriched the incident — had no effect at
all. The workflow ran on every matching event regardless.

## Change

`insert_incident()` now:

1. Finds the specific incident trigger (if any) whose `events` list contains
   the incoming event name, instead of only checking membership across a
   flattened list of all incident triggers' events.
2. Merges the incident's persisted enrichments onto the `IncidentDto` (as
   before), so fields set by a prior successful run (e.g. `incident_id`) are
   visible.
3. If the matching trigger declares a `cel`, compiles and evaluates it via
   the same `celpy` environment `insert_events()` uses, and skips scheduling
   the workflow when it evaluates to `false`. Evaluation errors are caught,
   logged, and treated as "don't run" rather than raised.

`incident.dict()` leaves UUID fields (like `incident.id`) as native Python
objects, which `celpy.json_to_cel` rejects. The activation payload is built
from `json.loads(incident.json())` instead, so pydantic's own JSON encoders
handle that conversion first.
