### PR TITLE
fix: widen alert table column resize hit target

### DIFF
--- a/keep-ui/widgets/alerts-table/ui/alert-table-headers.tsx
+++ b/keep-ui/widgets/alerts-table/ui/alert-table-headers.tsx
@@ -406,13 +406,15 @@ const DraggableHeaderCell = ({
       {column.getIsPinned() === false && (
         <div
           className={clsx(
-            "h-full absolute top-0 right-0 w-0.5 cursor-col-resize inline-block opacity-0 group-hover:opacity-100",
+            "h-full absolute top-0 right-0 w-2 -mr-1 cursor-col-resize select-none touch-none z-10",
             {
-              "hover:w-2 bg-blue-100": column.getIsResizing() === false,
-              "w-2 bg-blue-400": column.getIsResizing(),
+              "bg-transparent hover:bg-blue-100":
+                column.getIsResizing() === false,
+              "bg-blue-400": column.getIsResizing(),
             }
           )}
           onMouseDown={getResizeHandler()}
+          onTouchStart={getResizeHandler()}
         />
       )}
     </TableHeaderCell>


### PR DESCRIPTION
Widens the column-resize hit target in the alerts table header from a hover-dependent 2px sliver to a constant 8px area centered on the column boundary, and adds `onTouchStart` alongside the existing `onMouseDown` for touch parity.

Fixes #6660

**Test plan:** drag a column border in the alerts table (e.g. Presets → Feed) and confirm the width changes live.