### PR TITLE
fix: widen column resize handle hit target from 2px to 8px (Fixes #6660)

### DIFF
--- a/keep-ui/widgets/alerts-table/ui/alert-table-headers.tsx
+++ b/keep-ui/widgets/alerts-table/ui/alert-table-headers.tsx
@@ -406,7 +406,7 @@ const DraggableHeaderCell = ({
       {column.getIsPinned() === false && (
         <div
           className={clsx(
-            "h-full absolute top-0 right-0 w-0.5 cursor-col-resize inline-block opacity-0 group-hover:opacity-100",
+            "h-full absolute top-0 right-0 w-2 cursor-col-resize inline-block opacity-0 group-hover:opacity-100",
             {
               "hover:w-2 bg-blue-100": column.getIsResizing() === false,
               "w-2 bg-blue-400": column.getIsResizing(),


### PR DESCRIPTION
## Problem

The column resize handle in the alerts table has a near-invisible hit target. The handle is  (2px wide) by default, and only expands to  on `:hover` — but users can't hover it without already landing on the 2px sliver. Most drag attempts land just outside and silently do nothing.

## Fix

Changed the default width from `w-0.5` (2px) to `w-2` (8px), matching the hover width. This gives users a reasonable hit area they can actually target with their mouse, while keeping the handle visually subtle (`opacity-0 group-hover:opacity-100`).

## Before/After

- **Before**: 2px default hit target — nearly impossible to mouse over
- **After**: 8px default hit target — easy to find and drag

Closes #6660