### PR TITLE
fix: prevent horizontal scroll on Extractions page by adding overflow-x-auto and truncating long text

### DIFF
--- a/keep-ui/app/(keep)/extraction/extraction.tsx
+++ b/keep-ui/app/(keep)/extraction/extraction.tsx
@@ -60,7 +60,7 @@ export default function Extraction() {
         </div>
       </div>
 
-      <Card className="p-0 overflow-hidden">
+      <Card className="p-0 overflow-x-auto">
         <SidePanel
           isOpen={isSidePanelOpen}
           onClose={() => handleSidePanelExit(null)}

--- a/keep-ui/app/(keep)/extraction/extractions-table.tsx
+++ b/keep-ui/app/(keep)/extraction/extractions-table.tsx
@@ -61,7 +61,11 @@ export default function ExtractionsTable({ extractions, editCallback }: Props) {
     columnHelper.display({
       id: "description",
       header: "Description",
-      cell: (context) => context.row.original.description,
+      cell: (context) => (
+        <div className="max-w-[200px] truncate" title={context.row.original.description}>
+          {context.row.original.description}
+        </div>
+      ),
     }),
     columnHelper.display({
       id: "pre",
@@ -97,7 +101,11 @@ export default function ExtractionsTable({ extractions, editCallback }: Props) {
           </a>
         </div>
       ),
-      cell: (context) => context.row.original.regex,
+      cell: (context) => (
+        <div className="max-w-[200px] truncate font-mono text-xs" title={context.row.original.regex}>
+          {context.row.original.regex}
+        </div>
+      ),
     }),
     columnHelper.display({
       id: "conditon",
@@ -120,7 +128,11 @@ export default function ExtractionsTable({ extractions, editCallback }: Props) {
           </a>
         </div>
       ),
-      cell: (context) => context.row.original.condition,
+      cell: (context) => (
+        <div className="max-w-[150px] truncate" title={context.row.original.condition}>
+          {context.row.original.condition}
+        </div>
+      ),
     }),
     columnHelper.display({
       id: "newAttributes",


### PR DESCRIPTION
## Summary

Fixes #5202 — The Extractions page requires horizontal scrolling to access test/edit/delete actions when extraction rules have long regex patterns or descriptions.

## Changes

### `keep-ui/app/(keep)/extraction/extraction.tsx`
- Changed `overflow-hidden` to `overflow-x-auto` on the Card wrapper so the table can scroll horizontally when content exceeds the viewport width.

### `keep-ui/app/(keep)/extraction/extractions-table.tsx`
- Added `max-w-[200px] truncate` with `title` tooltip to the **Description** column cell.
- Added `max-w-[200px] truncate font-mono text-xs` with `title` tooltip to the **Regex** column cell.
- Added `max-w-[150px] truncate` with `title` tooltip to the **Condition** column cell.

Long text in these columns is now truncated with an ellipsis, and the full value is shown on hover via the native `title` attribute. The table is also allowed to scroll horizontally when the combined column widths exceed the container.

## How to test

1. Create an extraction rule with a long regex pattern (e.g., `(?P<service>[a-zA-Z]+)_(?P<environment>prod|staging|dev)_(?P<region>[a-z]+-[a-z]+-[0-9])-(?P<version>\\d+\\.\\d+\\.\\d+)`)
2. Create an extraction rule with a long description
3. Verify that the table does not cause the page to have a horizontal scrollbar
4. Verify that long text in Description, Regex, and Condition columns is truncated with ellipsis
5. Hover over truncated text to see the full value in a tooltip
6. Verify that the actions column (Run, Edit, Delete) is always visible without horizontal scrolling

## Acceptance criteria

- [x] The change matches the summary above
- [x] Lint, type-check, and tests pass locally
- [x] PR description references this issue with `Closes #5202`

Closes #5202