### PR TITLE
fix: rightmost column cannot be moved in preset view despite saved config (Fixes #5118)

### DIFF
--- a/keep-ui/entities/presets/model/usePresetColumnState.ts
+++ b/keep-ui/entities/presets/model/usePresetColumnState.ts
@@ -166,7 +166,26 @@ export const usePresetColumnState = ({
         };
 
         try {
-          return await updateColumnConfig(batchedUpdate);
+          const result = await updateColumnConfig(batchedUpdate);
+          // After successful backend update, also update local state immediately
+          // so the UI reflects the change without waiting for mutate() to re-fetch.
+          // This prevents the "configuration saved but column didn't move" bug.
+          if (updates.columnOrder !== undefined) {
+            setLocalColumnOrder(updates.columnOrder);
+          }
+          if (updates.columnVisibility !== undefined) {
+            setLocalColumnVisibility(updates.columnVisibility);
+          }
+          if (updates.columnRenameMapping !== undefined) {
+            setLocalColumnRenameMapping(updates.columnRenameMapping);
+          }
+          if (updates.columnTimeFormats !== undefined) {
+            setLocalColumnTimeFormats(updates.columnTimeFormats);
+          }
+          if (updates.columnListFormats !== undefined) {
+            setLocalColumnListFormats(updates.columnListFormats);
+          }
+          return result;
         } catch (err) {
           // If backend update fails, fall back to local storage
           console.warn(

--- a/keep-ui/widgets/alerts-table/ui/alert-table-headers.tsx
+++ b/keep-ui/widgets/alerts-table/ui/alert-table-headers.tsx
@@ -213,11 +213,19 @@ const DraggableHeaderCell = ({
   };
 
   const isRightmostColumn = () => {
-    const visibleColumns = table.getVisibleLeafColumns();
-
-    // the alertMenu is always the rightmost column
-    // so we need to check the second rightmost column
-    return column.id === visibleColumns[visibleColumns.length - 2].id;
+    // Use columnOrder to determine the rightmost column instead of
+    // table.getVisibleLeafColumns(), because the rendered column order
+    // may not match the actual columnOrder state (especially in preset views).
+    // The alertMenu is always the rightmost pinned column, so we check
+    // the last column in columnOrder that is not alertMenu and is visible.
+    const orderedDataColumns = columnOrder.filter(
+      (id) =>
+        id !== "alertMenu" &&
+        table.getColumn(id)?.getIsVisible() !== false
+    );
+    return (
+      column.id === orderedDataColumns[orderedDataColumns.length - 1]
+    );
   };
 
   const isLeftmostUnpinnedColumn = () => {


### PR DESCRIPTION
## Background

When using the preset view, the rightmost data column (before the `alertMenu` pinned column) cannot be moved. Two symptoms were reported:

1. **Rightmost column**: clicking "Move column left" shows "Column configuration saved" toast, but the column does not move visually.
2. **Second-to-last column**: incorrectly lacks a "Move column right" option.

## Root Cause

Two separate bugs were found:

### Bug 1: `isRightmostColumn()` used wrong column source

The function checked `table.getVisibleLeafColumns()` (the rendered column order) instead of the `columnOrder` prop (the actual state). In preset views, these can differ, causing the wrong column to be identified as the rightmost.

**Fix**: Filter `columnOrder` by visible columns (excluding `alertMenu`) to determine the rightmost data column.

### Bug 2: Local state not updated after backend API call

In `updateMultipleColumnConfigs()`, after a successful backend API call (`updateColumnConfig`), the local state was not updated. The UI relied solely on SWR's `mutate()` to re-fetch the config from the backend, creating a delay where the UI appeared to not update even though the backend had saved the new order.

**Fix**: After a successful backend API call, immediately update the corresponding local state fields (`localColumnOrder`, `localColumnVisibility`, etc.) so the UI reflects the change instantly.

## Changes

- `keep-ui/widgets/alerts-table/ui/alert-table-headers.tsx`: `isRightmostColumn()` now uses `columnOrder` prop instead of `table.getVisibleLeafColumns()`
- `keep-ui/entities/presets/model/usePresetColumnState.ts`: Local state is updated immediately after a successful backend API call

## Testing

1. Open a saved preset with at least 3 columns
2. Click the header menu of the rightmost data column (before `alertMenu`)
3. Verify "Move column right" is disabled (correct behavior)
4. Click "Move column left" - the column should move left immediately
5. Verify the second-to-last column now shows "Move column right" as enabled