### PR TITLE
fix: skip grouped columns when moving columns left/right (Fixes #4853)

### DIFF
--- a/keep-ui/widgets/alerts-table/ui/alert-table-headers.tsx
+++ b/keep-ui/widgets/alerts-table/ui/alert-table-headers.tsx
@@ -128,30 +128,44 @@ const DraggableHeaderCell = ({
     [listeners, handleSortingMenuClick]
   );
 
-  const moveColumn = async (direction: "left" | "right") => {
+  /**
+   * Find the index of the nearest non-grouped column in the given direction.
+   * Grouped columns are visually hidden, so they should be skipped when
+   * determining the adjacent column for movement.
+   */
+  const findNonGroupedIndex = (direction: "left" | "right"): number => {
     const currentIndex = columnOrder.indexOf(column.id);
-    if (direction === "left" && currentIndex > 0) {
-      const newOrder = [...columnOrder];
-      [newOrder[currentIndex], newOrder[currentIndex - 1]] = [
-        newOrder[currentIndex - 1],
-        newOrder[currentIndex],
-      ];
-      try {
-        await setColumnOrder(newOrder);
-      } catch (error) {
-        console.error("Failed to update column order:", error);
+    if (currentIndex === -1) return -1;
+
+    const step = direction === "left" ? -1 : 1;
+    let targetIndex = currentIndex + step;
+
+    while (targetIndex >= 0 && targetIndex < columnOrder.length) {
+      const targetCol = table.getColumn(columnOrder[targetIndex]);
+      if (targetCol && !targetCol.getIsGrouped()) {
+        return targetIndex;
       }
-    } else if (direction === "right" && currentIndex < columnOrder.length - 1) {
-      const newOrder = [...columnOrder];
-      [newOrder[currentIndex], newOrder[currentIndex + 1]] = [
-        newOrder[currentIndex + 1],
-        newOrder[currentIndex],
-      ];
-      try {
-        await setColumnOrder(newOrder);
-      } catch (error) {
-        console.error("Failed to update column order:", error);
-      }
+      targetIndex += step;
+    }
+
+    return -1;
+  };
+
+  const moveColumn = async (direction: "left" | "right") => {
+    const targetIndex = findNonGroupedIndex(direction);
+    const currentIndex = columnOrder.indexOf(column.id);
+
+    if (targetIndex === -1 || currentIndex === -1) return;
+
+    const newOrder = [...columnOrder];
+    [newOrder[currentIndex], newOrder[targetIndex]] = [
+      newOrder[targetIndex],
+      newOrder[currentIndex],
+    ];
+    try {
+      await setColumnOrder(newOrder);
+    } catch (error) {
+      console.error("Failed to update column order:", error);
     }
   };
 
@@ -212,19 +226,35 @@ const DraggableHeaderCell = ({
     return null;
   };
 
+  /**
+   * Check if this column is the rightmost visible (non-grouped) column.
+   * Grouped columns are visually hidden, so they should not be counted.
+   */
   const isRightmostColumn = () => {
     const visibleColumns = table.getVisibleLeafColumns();
 
-    // the alertMenu is always the rightmost column
-    // so we need to check the second rightmost column
-    return column.id === visibleColumns[visibleColumns.length - 2].id;
+    // Filter out grouped columns since they are visually hidden
+    const nonGroupedColumns = visibleColumns.filter(
+      (col) => !col.getIsGrouped()
+    );
+
+    // The alertMenu is always the rightmost column
+    // so we need to check the second rightmost non-grouped column
+    if (nonGroupedColumns.length < 2) return true;
+    return column.id === nonGroupedColumns[nonGroupedColumns.length - 2].id;
   };
 
+  /**
+   * Check if this column is the leftmost unpinned (non-grouped) column.
+   * Grouped columns are visually hidden, so they should not prevent
+   * moving a column that is visually to their right.
+   */
   const isLeftmostUnpinnedColumn = () => {
     const visibleColumns = table.getVisibleLeafColumns();
 
+    // Skip grouped columns since they are visually hidden
     const firstUnpinnedIndex = visibleColumns.findIndex(
-      (col) => !col.getIsPinned()
+      (col) => !col.getIsPinned() && !col.getIsGrouped()
     );
     return column.id === visibleColumns[firstUnpinnedIndex]?.id;
   };


### PR DESCRIPTION
## Problem

When a column is grouped (e.g., grouped by "Name"), the "Move column left" and "Move column right" dropdown options do not work correctly. The `isLeftmostUnpinnedColumn()` and `isRightmostColumn()` checks do not account for grouped columns, which are visually hidden but still present in the column order. This causes the move operations to either fail silently or move to the wrong position.

Fixes #4853

## Changes

1. **`moveColumn()`**: Added `findNonGroupedIndex()` helper that skips grouped columns when calculating the adjacent column position. Instead of swapping with the immediate neighbor in `columnOrder`, it now finds the nearest non-grouped column in the desired direction.

2. **`isLeftmostUnpinnedColumn()`**: Added `!col.getIsGrouped()` check to skip grouped columns when determining the leftmost unpinned column. This ensures the "Move column left" option is not incorrectly disabled for columns that are visually to the right of a grouped column.

3. **`isRightmostColumn()`**: Filtered out grouped columns from the visible columns list when determining the rightmost column. This ensures the "Move column right" option correctly reflects the visual position.

## Testing

- Group by "Name" column
- Try moving "Time" column to the left → should now work correctly
- Try moving columns to the right → should work correctly
- Drag-and-drop reordering should continue to work as before