### PR TITLE
fix(litellm): fail loudly on null content and accept fenced JSON

### DIFF
--- a/keep/providers/litellm_provider/litellm_provider.py
+++ b/keep/providers/litellm_provider/litellm_provider.py
@@ -60,6 +60,19 @@ class LitellmProvider(BaseProvider):
         """Format the prompt as a chat message."""
         return [{"role": "user", "content": prompt}]
 
+    @staticmethod
+    def _strip_code_fence(text: str) -> str:
+        """Unwrap a ```json ... ``` fence, which models add unprompted."""
+        stripped = text.strip()
+        if not stripped.startswith("```"):
+            return text
+        stripped = stripped[3:]
+        if stripped.lower().startswith("json"):
+            stripped = stripped[4:]
+        if stripped.endswith("```"):
+            stripped = stripped[:-3]
+        return stripped.strip()
+
     def _query(
         self,
         prompt: str,
@@ -105,10 +118,22 @@ class LitellmProvider(BaseProvider):
             except KeyError:
                 generated_text = ""
 
+            # Reasoning models return content=None when the whole max_tokens
+            # budget went into reasoning tokens. Without this the step would
+            # silently succeed with {"response": None}.
+            if generated_text is None:
+                finish_reason = result["choices"][0].get("finish_reason")
+                raise ProviderException(
+                    "LiteLLM API returned no content "
+                    f"(finish_reason={finish_reason!r}). Reasoning models can "
+                    "spend the whole max_tokens budget on reasoning tokens; "
+                    "raise max_tokens or use a model that does not reason."
+                )
+
             # Try to parse as JSON if it's meant to be structured
             if structured_output_format:
                 try:
-                    generated_text = json.loads(generated_text)
+                    generated_text = json.loads(self._strip_code_fence(generated_text))
                 except json.JSONDecodeError:
                     raise ProviderException(
                         f"Failed to parse generated text as JSON: {generated_text}. Model not following the structured output format. Response: {result}"

--- a/tests/providers/litellm_provider/test_litellm_response_parsing.py
+++ b/tests/providers/litellm_provider/test_litellm_response_parsing.py
@@ -1,0 +1,90 @@
+"""
+Tests for how the LiteLLM provider parses a chat completion response.
+
+Two failure modes this covers, both silent or misleading before the fix:
+
+1. A reasoning model can return `content: null` when the whole `max_tokens`
+   budget went into reasoning tokens. The provider returned
+   `{"response": None}` and the workflow step counted as successful.
+2. Models frequently wrap structured output in a ```json fence, which made
+   `json.loads()` fail and killed the step even though the JSON was valid.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.exceptions.provider_exception import ProviderException
+from keep.providers.litellm_provider.litellm_provider import LitellmProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+SCHEMA = {
+    "type": "object",
+    "properties": {"verdict": {"type": "string"}},
+    "required": ["verdict"],
+}
+
+
+def _build_provider() -> LitellmProvider:
+    config = ProviderConfig(
+        description="LiteLLM Provider",
+        authentication={"api_url": "https://litellm.example.com/v1"},
+    )
+    return LitellmProvider(ContextManager(tenant_id="test"), "litellm-test", config)
+
+
+def _response(content, finish_reason="stop"):
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(
+        return_value={
+            "choices": [
+                {"message": {"content": content}, "finish_reason": finish_reason}
+            ]
+        }
+    )
+    return response
+
+
+class TestStripCodeFence:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            '```json\n{"verdict": "ok"}\n```',
+            '```\n{"verdict": "ok"}\n```',
+            '  ```json\n{"verdict": "ok"}\n```  ',
+        ],
+    )
+    def test_fenced_json_is_unwrapped(self, text):
+        assert LitellmProvider._strip_code_fence(text) == '{"verdict": "ok"}'
+
+    def test_plain_json_is_untouched(self):
+        assert LitellmProvider._strip_code_fence('{"verdict": "ok"}') == (
+            '{"verdict": "ok"}'
+        )
+
+
+def test_structured_output_accepts_fenced_json():
+    provider = _build_provider()
+    with patch(
+        "requests.post", return_value=_response('```json\n{"verdict": "ok"}\n```')
+    ):
+        result = provider._query(prompt="hi", structured_output_format=SCHEMA)
+    assert result["response"] == {"verdict": "ok"}
+
+
+def test_none_content_raises_instead_of_returning_null():
+    provider = _build_provider()
+    with patch("requests.post", return_value=_response(None, finish_reason="length")):
+        with pytest.raises(ProviderException) as excinfo:
+            provider._query(prompt="hi")
+    message = str(excinfo.value)
+    assert "no content" in message
+    assert "length" in message
+
+
+def test_plain_text_response_still_works():
+    provider = _build_provider()
+    with patch("requests.post", return_value=_response("plain answer")):
+        assert provider._query(prompt="hi")["response"] == "plain answer"


### PR DESCRIPTION
## Problem

See #6670. `LitellmProvider._query` returns `{"response": None}` as a success when a reasoning model exhausts `max_tokens` on reasoning tokens, and fails a step outright when a model wraps otherwise-valid structured output in a ```json fence.

## Fix

- Raise `ProviderException` when `content` is `null`, naming `finish_reason` and pointing at the `max_tokens`/reasoning cause instead of silently yielding an empty answer.
- Add `_strip_code_fence()` and apply it before `json.loads()` for `structured_output_format`, so a fenced reply parses. Plain JSON and plain text are untouched.

## Tests

Adds `tests/providers/litellm_provider/test_litellm_response_parsing.py`: fence unwrapping (with and without the `json` tag, and with surrounding whitespace), plain JSON left as is, structured output accepting a fenced reply, `null` content raising with `finish_reason` in the message, and a plain-text reply still working. 7 tests, all passing.

`black` is clean on both files. `isort` reports the provider's imports as unsorted, but that is pre-existing on `main` and untouched here.

Fixes #6670