### PR TITLE
feat(litellm): return token usage and cost with the response

### DIFF
--- a/keep/providers/litellm_provider/litellm_provider.py
+++ b/keep/providers/litellm_provider/litellm_provider.py
@@ -139,8 +139,16 @@ class LitellmProvider(BaseProvider):
                         f"Failed to parse generated text as JSON: {generated_text}. Model not following the structured output format. Response: {result}"
                     )
 
+            # Surface usage so a workflow can report what a run cost. Absent
+            # on some OpenAI-compatible backends, hence the .get() chain.
+            usage = result.get("usage") or {}
             return {
                 "response": generated_text,
+                "model": result.get("model", model),
+                "prompt_tokens": usage.get("prompt_tokens"),
+                "completion_tokens": usage.get("completion_tokens"),
+                "total_tokens": usage.get("total_tokens"),
+                "cost": usage.get("cost"),
             }
 
         except requests.exceptions.RequestException as e:

--- a/tests/providers/litellm_provider/test_litellm_response_parsing.py
+++ b/tests/providers/litellm_provider/test_litellm_response_parsing.py
@@ -34,16 +34,17 @@ def _build_provider() -> LitellmProvider:
     return LitellmProvider(ContextManager(tenant_id="test"), "litellm-test", config)
 
 
-def _response(content, finish_reason="stop"):
+def _response(content, finish_reason="stop", usage=None, model=None):
     response = MagicMock()
     response.raise_for_status = MagicMock()
-    response.json = MagicMock(
-        return_value={
-            "choices": [
-                {"message": {"content": content}, "finish_reason": finish_reason}
-            ]
-        }
-    )
+    payload = {
+        "choices": [{"message": {"content": content}, "finish_reason": finish_reason}]
+    }
+    if usage is not None:
+        payload["usage"] = usage
+    if model is not None:
+        payload["model"] = model
+    response.json = MagicMock(return_value=payload)
     return response
 
 
@@ -88,3 +89,35 @@ def test_plain_text_response_still_works():
     provider = _build_provider()
     with patch("requests.post", return_value=_response("plain answer")):
         assert provider._query(prompt="hi")["response"] == "plain answer"
+
+
+def test_usage_is_returned_alongside_the_response():
+    """A workflow needs the token count and cost to report what a run spent."""
+    provider = _build_provider()
+    usage = {
+        "prompt_tokens": 256,
+        "completion_tokens": 98,
+        "total_tokens": 354,
+        "cost": 0.00042,
+    }
+    with patch(
+        "requests.post", return_value=_response("hi", usage=usage, model="gpt-4o")
+    ):
+        result = provider._query(prompt="hi")
+    assert result["response"] == "hi"
+    assert result["prompt_tokens"] == 256
+    assert result["completion_tokens"] == 98
+    assert result["total_tokens"] == 354
+    assert result["cost"] == 0.00042
+    assert result["model"] == "gpt-4o"
+
+
+def test_missing_usage_does_not_break_the_response():
+    """Not every OpenAI-compatible backend reports usage."""
+    provider = _build_provider()
+    with patch("requests.post", return_value=_response("hi")):
+        result = provider._query(prompt="hi", model="local-model")
+    assert result["response"] == "hi"
+    assert result["prompt_tokens"] is None
+    assert result["cost"] is None
+    assert result["model"] == "local-model"


### PR DESCRIPTION
## Problem

See #6677. `LitellmProvider._query` returns only `{"response": ...}` and discards the `usage` block, so a workflow cannot tell how many tokens an analysis consumed or what it cost. The only way to get that today is to skip the provider and call the API from a `python` step.

## Fix

Return the usage fields next to the response:

- `prompt_tokens`, `completion_tokens`, `total_tokens`, `cost` — read through `.get()` so a backend that reports no usage yields `None` rather than raising;
- `model` as reported by the API, which can differ from the requested one when a proxy routes the call.

`response` keeps its meaning, so existing workflows are unaffected.

## Tests

Two added to `tests/providers/litellm_provider/test_litellm_response_parsing.py`: usage and model surfaced from a normal response, and a response without a `usage` block leaving the fields `None` while the text still comes through. 9 tests in the file, all passing; `black` clean.

Fixes #6677