### PR TITLE
fix(maintenance_windows): handle invalid CEL syntax gracefully

### DIFF
--- a/keep/api/bl/maintenance_windows_bl.py
+++ b/keep/api/bl/maintenance_windows_bl.py
@@ -120,20 +120,19 @@ class MaintenanceWindowsBl:
     @staticmethod
     def evaluate_cel(maintenance_window: MaintenanceWindowRule, alert: AlertDto | Alert, environment: celpy.Environment, logger, logger_extra_info: dict) -> bool:
 
-        cel = preprocess_cel_expression(maintenance_window.cel_query)
-        ast = environment.compile(cel)
-        prgm = environment.program(ast)
-
-        if isinstance(alert, AlertDto):
-            payload = alert.dict()
-        else:
-            payload = alert.event
-        # todo: fix this in the future
-        payload["source"] = payload["source"][0]
-
-        activation = celpy.json_to_cel(json.loads(json.dumps(payload, default=str)))
-
         try:
+            cel = preprocess_cel_expression(maintenance_window.cel_query)
+            ast = environment.compile(cel)
+            prgm = environment.program(ast)
+
+            if isinstance(alert, AlertDto):
+                payload = alert.dict()
+            else:
+                payload = alert.event
+            # todo: fix this in the future
+            payload["source"] = payload["source"][0]
+
+            activation = celpy.json_to_cel(json.loads(json.dumps(payload, default=str)))
             cel_result = prgm.evaluate(activation)
             return True if cel_result else False
         except celpy.evaluation.CELEvalError as e:
@@ -144,9 +143,14 @@ class MaintenanceWindowsBl:
                     extra={**logger_extra_info, "maintenance_rule_id": maintenance_window.id},
                 )
                 return False
-            # Log unexpected CEL errors but don't fail the entire event processing
             logger.error(
-                f"Unexpected CEL evaluation error: {str(e)}",
+                f"Failed to evaluate maintenance window CEL rule: {str(e)}",
+                extra={**logger_extra_info, "maintenance_rule_id": maintenance_window.id},
+            )
+            return False
+        except Exception as e:
+            logger.error(
+                f"Failed to evaluate maintenance window CEL rule: {str(e)}",
                 extra={**logger_extra_info, "maintenance_rule_id": maintenance_window.id},
             )
             return False


### PR DESCRIPTION


## 📑 Description
Wrap CEL compilation and evaluation in a single try-except block to catch all exceptions, including invalid CEL syntax errors. Previously, invalid CEL expressions would crash the event processing pipeline.

Example error that is now handled:
  maintenance_window.cel_query = "alert.severity = 'high'"  # Invalid: = instead of ==
  → CELParseError: syntax error in expression

Now invalid rules are logged and safely skipped, returning False so alerts continue processing instead of being dropped.

## ✅ Checks
- ✅ My pull request adheres to the code style of this project
- ✅ All the tests have passed

Closed #6683 

