### PR TITLE
fix: correctly parse PUSHER_USE_SSL environment variable (#6582)

### DIFF
--- a/keep/api/core/dependencies.py
+++ b/keep/api/core/dependencies.py
@@ -67,6 +67,10 @@ def get_pusher_client() -> Pusher | None:
 
     # TODO: defaults on open source no docker
     try:
+        pusher_use_ssl = os.environ.get("PUSHER_USE_SSL", "false")
+        if isinstance(pusher_use_ssl, str):
+            pusher_use_ssl = pusher_use_ssl.lower() in ("1", "true", "yes", "on")
+        
         pusher = Pusher(
             host=pusher_host,
             port=(
@@ -77,7 +81,7 @@ def get_pusher_client() -> Pusher | None:
             app_id=pusher_app_id,
             key=pusher_app_key,
             secret=pusher_app_secret,
-            ssl=False if os.environ.get("PUSHER_USE_SSL", False) is False else True,
+            ssl=pusher_use_ssl,
             cluster=os.environ.get("PUSHER_CLUSTER"),
         )
     except ValueError:


### PR DESCRIPTION
Closes #6582.

This PR fixes a bug where setting `PUSHER_USE_SSL=false` in Docker Compose or other environments would evaluate to `True`. 
This occurred because `os.environ.get` returns a string (e.g. `"false"`), which evaluated to `True` since any non-empty string in Python evaluates to `True` when checked against `False` (e.g. `ssl=False if os.environ.get("PUSHER_USE_SSL", False) is False else True`).

### Changes
- Updated `PUSHER_USE_SSL` parsing to properly handle string booleans (`"false"`, `"0"`, `"true"`, `"1"`, `"yes"`, `"on"`).
- Defaults to `"false"` if the environment variable is not present, matching the existing fallback logic.
