### PR TITLE
fix: Surface total SignalFx alert formatting failure

### DIFF
--- a/keep/providers/signalfx_provider/signalfx_provider.py
+++ b/keep/providers/signalfx_provider/signalfx_provider.py
@@ -153,13 +153,20 @@ class SignalfxProvider(BaseProvider):
         incidents = response.json()
         # Map SignalFx alert data to AlertDto objects
         alerts = []
+        first_formatting_error = None
         # TODO: incident may have more than one alert?
         for incident in incidents:
             try:
                 alerts.append(self._format_alert_get_alert(incident))
             except Exception as e:
                 self.logger.error(f"Failed to format SignalFx alert: {e}")
-                pass
+                if first_formatting_error is None:
+                    first_formatting_error = e
+
+        if incidents and not alerts:
+            raise RuntimeError(
+                f"Failed to format any of {len(incidents)} SignalFx incidents"
+            ) from first_formatting_error
 
         return alerts
 

--- a/tests/providers/signalfx_provider/test_signalfx_get_alerts.py
+++ b/tests/providers/signalfx_provider/test_signalfx_get_alerts.py
@@ -1,0 +1,118 @@
+from unittest.mock import MagicMock, call, patch, sentinel
+
+import pytest
+import requests
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.models.provider_config import ProviderConfig
+from keep.providers.signalfx_provider.signalfx_provider import SignalfxProvider
+
+
+def _build_provider() -> SignalfxProvider:
+    config = ProviderConfig(
+        description="SignalFx Provider",
+        authentication={"sf_token": "test-token"},
+    )
+    return SignalfxProvider(ContextManager(tenant_id="test"), "signalfx-test", config)
+
+
+def _response(incidents):
+    response = MagicMock()
+    response.json.return_value = incidents
+    return response
+
+
+def test_empty_response_returns_empty_list():
+    provider = _build_provider()
+    response = _response([])
+
+    with (
+        patch("requests.get", return_value=response),
+        patch.object(provider, "_format_alert_get_alert") as formatter,
+    ):
+        assert provider._get_alerts() == []
+
+    response.raise_for_status.assert_called_once_with()
+    formatter.assert_not_called()
+
+
+def test_successful_incidents_return_all_formatted_alerts_in_order():
+    provider = _build_provider()
+    incidents = [{"incidentId": "first"}, {"incidentId": "second"}]
+    response = _response(incidents)
+
+    with (
+        patch("requests.get", return_value=response),
+        patch.object(
+            provider,
+            "_format_alert_get_alert",
+            side_effect=[sentinel.first_alert, sentinel.second_alert],
+        ) as formatter,
+    ):
+        alerts = provider._get_alerts()
+
+    assert alerts == [sentinel.first_alert, sentinel.second_alert]
+    assert formatter.call_args_list == [call(incidents[0]), call(incidents[1])]
+
+
+def test_mixed_response_logs_failure_and_returns_successful_alerts():
+    provider = _build_provider()
+    incidents = [{"incidentId": "bad"}, {"incidentId": "good"}]
+    response = _response(incidents)
+    formatting_error = ValueError("malformed incident")
+
+    with (
+        patch("requests.get", return_value=response),
+        patch.object(
+            provider,
+            "_format_alert_get_alert",
+            side_effect=[formatting_error, sentinel.alert],
+        ),
+        patch.object(provider.logger, "error") as log_error,
+    ):
+        alerts = provider._get_alerts()
+
+    assert alerts == [sentinel.alert]
+    log_error.assert_called_once_with(
+        "Failed to format SignalFx alert: malformed incident"
+    )
+
+
+def test_all_formatting_failures_raise_with_underlying_cause():
+    provider = _build_provider()
+    incidents = [{"incidentId": "first"}, {"incidentId": "second"}]
+    response = _response(incidents)
+    first_error = ValueError("first malformed incident")
+    second_error = KeyError("second malformed incident")
+
+    with (
+        patch("requests.get", return_value=response),
+        patch.object(
+            provider,
+            "_format_alert_get_alert",
+            side_effect=[first_error, second_error],
+        ),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        provider._get_alerts()
+
+    assert str(exc_info.value) == "Failed to format any of 2 SignalFx incidents"
+    assert exc_info.value.__cause__ is first_error
+
+
+def test_http_error_propagates_before_formatting():
+    provider = _build_provider()
+    response = _response([{"incidentId": "unused"}])
+    http_error = requests.exceptions.HTTPError("SignalFx unavailable")
+    response.raise_for_status.side_effect = http_error
+
+    with (
+        patch("requests.get", return_value=response),
+        patch.object(provider, "_format_alert_get_alert") as formatter,
+        pytest.raises(requests.exceptions.HTTPError) as exc_info,
+    ):
+        provider._get_alerts()
+
+    assert exc_info.value is http_error
+    response.json.assert_not_called()
+    formatter.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"


### PR DESCRIPTION
Closes #

## 📑 Description

Keep the existing per-incident isolation so one malformed incident does not discard valid alerts from the same response. Track whether formatting failures occurred and, after processing, raise a descriptive exception only when the upstream response was non-empty and no incident could be converted; preserve the original formatting failure as the cause where practical. Continue returning `[]` for a genuinely empty response and returning the successful subset for mixed valid/invalid responses.

`SignalfxProvider._get_alerts` catches and logs each incident-formatting exception, then returns the successfully formatted alerts. This preserves useful partial results, but when a non-empty API response contains only malformed incidents it returns `[]`, making total data loss indistinguishable from a genuinely empty SignalFx response. Transport errors already propagate through `raise_for_status`, so the defect is limited to the per-incident formatting boundary. The base provider's `get_alerts` method already delegates to this method and will propagate its exception, so no caller or registry change is required.

Closes #6674

## ✅ Checks

- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] All the tests have passed

## ℹ Additional Information

Nothing beyond what is described above.
