### PR TITLE
fix(http-provider): stop duplicating results on notify

### DIFF
--- a/keep/providers/http_provider/http_provider.py
+++ b/keep/providers/http_provider/http_provider.py
@@ -63,7 +63,9 @@ class HttpProvider(BaseProvider):
         """
         Send a HTTP request to the given url.
         """
-        return self.query(
+        # _query, not query: BaseProvider.notify() already appends the result,
+        # and BaseProvider.query() would append it a second time (#6431).
+        return self._query(
             url=url,
             method=method,
             headers=headers,

--- a/tests/providers/http_provider/test_http_provider_bugs.py
+++ b/tests/providers/http_provider/test_http_provider_bugs.py
@@ -1,0 +1,81 @@
+"""Tests for HTTP provider result duplication (issue #6431).
+
+Bug: HttpProvider._notify() called the public self.query() instead of the
+private self._query(). BaseProvider.notify() appends to self.results after
+_notify() returns, and BaseProvider.query() appends as well, so every notify()
+recorded the same result twice in the workflow execution output.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.http_provider.http_provider import HttpProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+
+def _build_provider() -> HttpProvider:
+    config = ProviderConfig(description="HTTP Provider", authentication={})
+    return HttpProvider(ContextManager(tenant_id="test"), "http-test", config)
+
+
+def _response(payload, ok=True, status_code=200):
+    response = MagicMock()
+    response.ok = ok
+    response.status_code = status_code
+    response.reason = "OK"
+    response.text = "body"
+    response.json = MagicMock(return_value=payload)
+    return response
+
+
+class TestNotifyDoesNotDuplicateResults:
+    """Bug #6431: results appended twice per action execution."""
+
+    def test_notify_appends_exactly_one_result(self):
+        provider = _build_provider()
+        with patch("requests.post", return_value=_response({"ok": True})):
+            provider.notify(
+                url="http://example.com/api", method="POST", body={"message": "Hello"}
+            )
+        assert len(provider.results) == 1
+
+    @pytest.mark.parametrize("method", ["POST", "PUT", "DELETE"])
+    def test_no_duplication_for_any_write_method(self, method):
+        provider = _build_provider()
+        with patch(f"requests.{method.lower()}", return_value=_response({"ok": True})):
+            provider.notify(url="http://example.com/api", method=method, body={})
+        assert len(provider.results) == 1
+
+    def test_repeated_notifies_append_one_each(self):
+        """Two executions record two results, not four."""
+        provider = _build_provider()
+        with patch("requests.post", return_value=_response({"ok": True})):
+            provider.notify(url="http://example.com/api", method="POST", body={})
+            provider.notify(url="http://example.com/api", method="POST", body={})
+        assert len(provider.results) == 2
+
+    def test_notify_still_returns_the_response(self):
+        """The fix must not change what notify() hands back to the workflow."""
+        provider = _build_provider()
+        with patch("requests.post", return_value=_response({"ok": True})):
+            result = provider.notify(
+                url="http://example.com/api", method="POST", body={}
+            )
+        assert result == {
+            "status": True,
+            "status_code": 200,
+            "body": {"ok": True},
+        }
+        assert provider.results == [result]
+
+
+class TestQueryStillRecordsItsOwnResult:
+    """Guard: the fix must not stop query() from recording when used directly."""
+
+    def test_query_appends_one_result(self):
+        provider = _build_provider()
+        with patch("requests.get", return_value=_response({"ok": True})):
+            provider.query(url="http://example.com/api", method="GET")
+        assert len(provider.results) == 1


### PR DESCRIPTION
Fixes #6431

## The bug

`HttpProvider._notify()` calls the public `self.query()` instead of the private `self._query()`.

`BaseProvider.notify()` appends the return value to `self.results`, and `BaseProvider.query()` appends as well — so every HTTP action records its result twice in the workflow execution output:

```json
[
  {"status": true, "status_code": 200, "body": "..."},
  {"status": true, "status_code": 200, "body": "..."}
]
```

Thanks to @DANIILSKRIPCHENKO for the diagnosis in the issue — it was accurate, this PR is that fix plus tests.

## Why calling `_query()` directly is equivalent

`query()` does two things `_query()` does not, and neither applies here:

- it pops `enrich_alert` / `audit_enabled` from kwargs — but `notify()` has already popped those before it calls `_notify()`, so they are never present at this point
- it adds `results[0].__class__` to `context_manager.dependencies` when the result is a list — `_query()` returns a dict, so that branch is a no-op for this provider

## Tests

New file: `tests/providers/http_provider/test_http_provider_bugs.py`

The tests were written before the fix and run against unmodified `main`: **6 failed, 1 passed**, failing with `Left contains one more item`. With the one-line change: **7 passed**.

- exactly one result appended, on POST / PUT / DELETE
- two `notify()` calls append two results, not four
- `notify()` still returns the same payload
- guard: `query()` called directly still records its own result, so the fix does not over-correct

`tests/providers` in full: 60 passed. I have not run the suites that need Docker and a database locally — leaving those to CI.
