### PR TITLE
feat(prometheus): expose an instant PromQL query as a provider method

### DIFF
--- a/keep/providers/prometheus_provider/prometheus_provider.py
+++ b/keep/providers/prometheus_provider/prometheus_provider.py
@@ -15,6 +15,7 @@ from keep.api.models.alert import AlertDto, AlertSeverity, AlertStatus
 from keep.contextmanager.contextmanager import ContextManager
 from keep.providers.base.base_provider import BaseProvider, ProviderHealthMixin
 from keep.providers.models.provider_config import ProviderConfig, ProviderScope
+from keep.providers.models.provider_method import ProviderMethod
 
 
 @pydantic.dataclasses.dataclass
@@ -94,6 +95,15 @@ receivers:
             name="connectivity", description="Connectivity Test", mandatory=True
         )
     ]
+    PROVIDER_METHODS = [
+        ProviderMethod(
+            name="Query Prometheus",
+            func_name="query_instant",
+            scopes=["connectivity"],
+            description="Run an instant PromQL query and return the result set",
+            type="view",
+        ),
+    ]
     FINGERPRINT_FIELDS = ["fingerprint"]
 
     def __init__(
@@ -116,6 +126,24 @@ receivers:
         except Exception as e:
             validated_scopes["connectivity"] = str(e)
         return validated_scopes
+
+    def query_instant(self, query: str) -> dict:
+        """
+        Run an instant PromQL query against the Prometheus server.
+
+        Exposed as a provider method so it can be called from the UI and by
+        agents, which previously saw `methods: []` on this provider and had no
+        way to run a query (#6475).
+
+        Args:
+            query (str): a PromQL expression, e.g. `up{job="prometheus"}` or
+                `rate(http_requests_total[5m])`.
+
+        Returns:
+            dict: the Prometheus response envelope; the samples are under
+                `data.result`.
+        """
+        return self._query(query)
 
     def _query(self, query):
         """

--- a/tests/providers/prometheus_provider/test_prometheus_query_method.py
+++ b/tests/providers/prometheus_provider/test_prometheus_query_method.py
@@ -1,0 +1,103 @@
+"""Tests for exposing a PromQL query as a provider method (issue #6475).
+
+The provider could already run instant queries through _query(), but
+PROVIDER_METHODS was empty, so the UI and agents reported `methods: []` and had
+no way to reach it. These tests cover the new query_instant() method and the
+invariants ProvidersFactory relies on when it reflects PROVIDER_METHODS.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.models.provider_config import ProviderConfig
+from keep.providers.prometheus_provider.prometheus_provider import PrometheusProvider
+
+RESULT = {
+    "status": "success",
+    "data": {
+        "resultType": "vector",
+        "result": [
+            {"metric": {"__name__": "up", "job": "prometheus"}, "value": [1, "1"]}
+        ],
+    },
+}
+
+
+def _build_provider(**auth) -> PrometheusProvider:
+    config = ProviderConfig(
+        description="Prometheus Provider",
+        authentication={"url": "http://prometheus.example.com", **auth},
+    )
+    return PrometheusProvider(ContextManager(tenant_id="test"), "prom-test", config)
+
+
+def _response(payload, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.content = b"error"
+    response.json = MagicMock(return_value=payload)
+    return response
+
+
+class TestProviderMethodIsDiscoverable:
+    """ProvidersFactory reflects PROVIDER_METHODS; these are its preconditions."""
+
+    def test_provider_exposes_a_method(self):
+        assert PrometheusProvider.PROVIDER_METHODS, "provider still reports no methods"
+
+    def test_func_name_resolves_on_the_class_itself(self):
+        """__get_methods uses provider_class.__dict__, so an inherited method
+        would make inspect.signature(None) raise at provider-load time."""
+        for method in PrometheusProvider.PROVIDER_METHODS:
+            assert PrometheusProvider.__dict__.get(method.func_name) is not None
+
+    def test_declared_scopes_exist_on_the_provider(self):
+        declared = {scope.name for scope in PrometheusProvider.PROVIDER_SCOPES}
+        for method in PrometheusProvider.PROVIDER_METHODS:
+            assert set(method.scopes) <= declared
+
+    def test_query_is_a_read_only_view(self):
+        method = PrometheusProvider.PROVIDER_METHODS[0]
+        assert method.type == "view"
+
+
+class TestQueryInstant:
+    def test_hits_the_instant_query_endpoint(self):
+        provider = _build_provider()
+        with patch("requests.get", return_value=_response(RESULT)) as get:
+            provider.query_instant('up{job="prometheus"}')
+        args, kwargs = get.call_args
+        assert args[0] == "http://prometheus.example.com/api/v1/query"
+        assert kwargs["params"] == {"query": 'up{job="prometheus"}'}
+
+    def test_returns_the_response_envelope(self):
+        provider = _build_provider()
+        with patch("requests.get", return_value=_response(RESULT)):
+            assert provider.query_instant("up") == RESULT
+
+    def test_empty_query_is_rejected(self):
+        provider = _build_provider()
+        with pytest.raises(ValueError):
+            provider.query_instant("")
+
+    def test_non_200_raises(self):
+        provider = _build_provider()
+        with patch("requests.get", return_value=_response({}, status_code=500)):
+            with pytest.raises(Exception, match="Prometheus query failed"):
+                provider.query_instant("up")
+
+    def test_basic_auth_used_when_credentials_are_set(self):
+        provider = _build_provider(username="u", password="p")
+        with patch("requests.get", return_value=_response(RESULT)) as get:
+            provider.query_instant("up")
+        auth = get.call_args.kwargs["auth"]
+        assert auth is not None
+        assert (auth.username, auth.password) == ("u", "p")
+
+    def test_no_auth_when_credentials_are_absent(self):
+        provider = _build_provider()
+        with patch("requests.get", return_value=_response(RESULT)) as get:
+            provider.query_instant("up")
+        assert get.call_args.kwargs["auth"] is None


### PR DESCRIPTION
Fixes #6475

## What was actually missing

The provider can already run instant queries — `_query()` hits `/api/v1/query` with the configured basic auth. What was missing is any way to *reach* it: `PROVIDER_METHODS` was empty, so the UI and agents report `methods: []`, which is what the issue shows.

So this is an exposure change, not a new query implementation. No change to the endpoint, the auth handling or the error behaviour.

## The change

- `query_instant(query: str) -> dict`, a public wrapper over the existing `_query()`
- declared in `PROVIDER_METHODS` as a read-only `view`, scoped to `connectivity` (the provider's existing scope)

## Why the tests check the declaration and not just the call

`ProvidersFactory.__get_methods` reflects methods with:

```python
inspect.signature(provider_class.__dict__.get(method.func_name))
```

A `func_name` that doesn't resolve on the class itself — a typo, or a method that is inherited rather than defined here — makes that `inspect.signature(None)`, which raises when the **provider is loaded**, not when the method is called. The tests assert that invariant, and that every scope a method declares exists in `PROVIDER_SCOPES`.

Reflection output with this change:

```
name: Query Prometheus | func_name: query_instant
type: view | scopes: ['connectivity']
params: [('query', 'str', True)]
```

## Tests

New file: `tests/providers/prometheus_provider/test_prometheus_query_method.py`

Against unmodified `main`: **8 failed, 2 passed** — the 2 are loop-based guards that pass vacuously while `PROVIDER_METHODS` is empty, so they are regression protection rather than evidence. With the change: **10 passed**.

- the method is declared, resolves on the class, and its scope exists
- the endpoint and `params` sent for an instant query
- the response envelope returned unchanged
- empty query rejected; non-200 raises
- basic auth used when credentials are set, omitted when they are not

`tests/providers` in full: 63 passed. I have not run the suites needing Docker and a database locally — leaving those to CI.

## Question before I extend this

I have deliberately left out `/api/v1/query_range`. It needs `start`/`stop`/`step` and a decision about capping result size, and the issue only asks to run PromQL. Happy to add it in this PR if you'd like it — I'd rather ask than guess at the parameter shape.

Worth noting separately: `_query()` sends its request with no timeout, so a slow or hanging Prometheus will block the caller. I left that alone to keep this focused, but I'm glad to open a separate PR for it.
