### PR TITLE
fix: prevent duplicate workflow runs on rapid manual run clicks

### DIFF
--- a/keep-ui/features/workflows/manual-run-workflow/ui/manual-run-workflow-modal.tsx
+++ b/keep-ui/features/workflows/manual-run-workflow/ui/manual-run-workflow-modal.tsx
@@ -300,7 +300,12 @@ export function ManualRunWorkflowModal({
       ) : null}
 
       <div className="flex justify-end gap-2 mt-4">
-        <Button onClick={clearAndClose} color="orange" variant="secondary">
+        <Button
+          onClick={clearAndClose}
+          color="orange"
+          variant="secondary"
+          disabled={isRunning}
+        >
           Cancel
         </Button>
         <Button

--- a/keep-ui/features/workflows/manual-run-workflow/ui/manual-run-workflow-modal.tsx
+++ b/keep-ui/features/workflows/manual-run-workflow/ui/manual-run-workflow-modal.tsx
@@ -166,12 +166,12 @@ export function ManualRunWorkflowModal({
           </div>
         );
       }
+      clearAndClose();
     } catch (error) {
       showErrorToast(error, "Failed to start workflow");
     } finally {
       setIsRunning(false);
     }
-    clearAndClose();
   };
 
   const WorkflowSelect = (props: any) => {

--- a/keep-ui/features/workflows/manual-run-workflow/ui/manual-run-workflow-modal.tsx
+++ b/keep-ui/features/workflows/manual-run-workflow/ui/manual-run-workflow-modal.tsx
@@ -48,6 +48,7 @@ export function ManualRunWorkflowModal({
   >(undefined);
   const [workflowInputs, setWorkflowInputs] = useState<WorkflowInput[]>([]);
   const [inputValues, setInputValues] = useState<Record<string, any>>({});
+  const [isRunning, setIsRunning] = useState(false);
   const { workflows } = useWorkflowsV2({
     ...DEFAULT_WORKFLOWS_QUERY,
     limit: 100, // Fetch more workflows at once for the dropdown
@@ -128,6 +129,10 @@ export function ManualRunWorkflowModal({
   };
 
   const handleRun = async () => {
+    if (isRunning) {
+      return;
+    }
+    setIsRunning(true);
     try {
       if (onSubmit) {
         // If onSubmit prop is provided, use it (for WorkflowDetailHeader usage)
@@ -163,6 +168,8 @@ export function ManualRunWorkflowModal({
       }
     } catch (error) {
       showErrorToast(error, "Failed to start workflow");
+    } finally {
+      setIsRunning(false);
     }
     clearAndClose();
   };
@@ -299,7 +306,9 @@ export function ManualRunWorkflowModal({
         <Button
           onClick={handleRun}
           color="orange"
+          loading={isRunning}
           disabled={
+            isRunning ||
             !effectiveWorkflow ||
             (workflowInputs.length > 0 &&
               !areRequiredInputsFilled(workflowInputs, inputValues))


### PR DESCRIPTION
## 📑 Description

Fixes #6707

The manual run workflow modal fired a new `POST /workflows/{id}/run` request on every click of the "Run" button, with no visual feedback. Rapid clicks therefore triggered the workflow multiple times.

This PR adds an `isRunning` guard to `handleRun` (the same pattern used in #6622 for the alert change status modal) and wires it into the buttons so that:

- `handleRun` returns early if a run is already in flight.
- The Run button shows a `loading` spinner and is `disabled` while running.
- The Cancel button is `disabled` while running, so the modal can't be closed mid-request.
- The state is reset in a `finally` block so errors or slow requests don't leave the buttons stuck.
- The modal only closes on success, so a failed run keeps the modal open with the user's inputs for retry.

## Changes

- `keep-ui/features/workflows/manual-run-workflow/ui/manual-run-workflow-modal.tsx`
  - Added `isRunning` state.
  - Guard `handleRun` against re-entry.
  - Set `loading` / `disabled` on the Run button.
  - Disable the Cancel button while a run is in flight.
  - Reset `isRunning` in `finally`.
  - Close the modal only on success.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
