### PR TITLE
fix(rulesengine): report matched sub-rules as written

### DIFF
--- a/keep/rulesengine/rulesengine.py
+++ b/keep/rulesengine/rulesengine.py
@@ -480,9 +480,13 @@ class RulesEngine:
             #          So we need to replace "null" with ""
             #
             #          TODO: it works for strings now, but we need to add support on list/dict when needed
-            if "null" in sub_rule:
-                sub_rule = sub_rule.replace("null", '""')
-            ast = self.env.compile(sub_rule)
+            # Evaluate the rewritten rule but keep sub_rule as written, since
+            # callers compare what matched against the sub-rules extracted from
+            # the rule definition, which still says "null".
+            evaluated_rule = sub_rule
+            if "null" in evaluated_rule:
+                evaluated_rule = evaluated_rule.replace("null", '""')
+            ast = self.env.compile(evaluated_rule)
             prgm = self.env.program(ast)
             activation = celpy.json_to_cel(json.loads(json.dumps(payload, default=str)))
             try:
@@ -498,7 +502,7 @@ class RulesEngine:
                 ):
                     try:
                         coerced = self._coerce_eq_type_error(
-                            sub_rule, prgm, activation, event
+                            evaluated_rule, prgm, activation, event
                         )
                         if coerced:
                             sub_rules_matched.append(sub_rule)

--- a/tests/test_alert_evaluation.py
+++ b/tests/test_alert_evaluation.py
@@ -1074,3 +1074,55 @@ def test_check_if_rule_apply_int_str_type_coercion(db_session):
     assert (
         len(matched_rules4) == 1
     ), "Rule with 'field == \"2\"' should match alert with field='2'"
+
+
+def test_check_if_rule_apply_returns_subrule_as_written_for_null(db_session):
+    """
+    _check_if_rule_apply rewrites "null" before evaluating, but callers compare
+    what it returns against the sub-rules extracted from the rule definition,
+    which still says "null". It has to return the sub-rule as written.
+    """
+    from datetime import datetime
+
+    from keep.api.core.dependencies import SINGLE_TENANT_UUID
+    from keep.api.models.alert import AlertDto
+    from keep.api.models.db.rule import Rule
+    from keep.rulesengine.rulesengine import RulesEngine
+
+    definition_cel = '(source == "sentry") || (service != null)'
+
+    rule = Rule(
+        id="test-rule-null",
+        tenant_id=SINGLE_TENANT_UUID,
+        name="Test Rule - null subrule",
+        definition_cel=definition_cel,
+        definition={},
+        timeframe=60,
+        timeunit="seconds",
+        created_by="test@keephq.dev",
+        creation_time=datetime.utcnow(),
+        grouping_criteria=[],
+        threshold=1,
+        create_on="all",
+    )
+
+    engine = RulesEngine(tenant_id=SINGLE_TENANT_UUID)
+    all_sub_rules = set(engine._extract_subrules(definition_cel))
+
+    alert_sentry = AlertDto(
+        id="a1", name="test", fingerprint="fp1", source=["sentry"], service=None
+    )
+    alert_service = AlertDto(
+        id="a2", name="test", fingerprint="fp2", source=["grafana"], service="api"
+    )
+
+    matched = set()
+    for alert in (alert_sentry, alert_service):
+        matched = matched.union(engine._check_if_rule_apply(rule, alert))
+
+    assert matched.issubset(
+        all_sub_rules
+    ), f"matched sub-rules must be reported as written, got {matched}"
+    assert (
+        all_sub_rules == matched
+    ), "both sub-rules were satisfied, so the sets should be equal"

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -795,6 +795,56 @@ def test_rule_multiple_alerts(db_session, create_alert):
     assert alert_3.fingerprint in fingerprints
 
 
+def test_rule_multiple_alerts_with_null_in_definition(db_session, create_alert):
+    """A create_on=all rule whose CEL contains null should still start an incident."""
+
+    create_rule_db(
+        tenant_id=SINGLE_TENANT_UUID,
+        name="test-rule-null",
+        definition={
+            "sql": "N/A",  # we don't use it anymore
+            "params": {},
+        },
+        timeframe=600,
+        timeunit="seconds",
+        require_approve=False,
+        definition_cel=(
+            '(severity == "critical") || (service != null && severity == "high")'
+        ),
+        created_by="test@keephq.dev",
+        create_on=CreateIncidentOn.ALL.value,
+    )
+
+    create_alert(
+        "Critical Alert",
+        AlertStatus.FIRING,
+        datetime.datetime.utcnow(),
+        {
+            "severity": AlertSeverity.CRITICAL.value,
+        },
+    )
+
+    # Only the first sub-rule is satisfied so far, so the incident stays hidden.
+    assert db_session.query(Incident).filter(Incident.is_visible == True).count() == 0
+    assert db_session.query(Incident).filter(Incident.is_visible == False).count() == 1
+    incident = db_session.query(Incident).first()
+
+    create_alert(
+        "Service Alert",
+        AlertStatus.FIRING,
+        datetime.datetime.utcnow(),
+        {
+            "severity": AlertSeverity.HIGH.value,
+            "service": "api",
+        },
+    )
+
+    enrich_incidents_with_alerts(SINGLE_TENANT_UUID, [incident], db_session)
+
+    # Both sub-rules are now satisfied, so the incident should be started.
+    assert db_session.query(Incident).filter(Incident.is_visible == True).count() == 1
+
+
 def test_rule_event_groups_expires(db_session, create_alert):
 
     create_rule_db(


### PR DESCRIPTION

Fixes #6694

`_check_if_rule_apply` rewrote `null` to `""` by rebinding the loop variable, then appended that rewritten string as the sub-rule that matched. `_process_event_for_history_based_rule` compares those against sub-rules taken from `rule.definition_cel`, which still says `null`, so the sets could never be equal. Correlation rules with `create_on: all` and a null-bearing definition never reached `is_all_conditions_met`, so the incident was never made visible and the created event never fired.

The rewrite now happens on a separate variable, so evaluation is unchanged and the sub-rule is reported as written. The length check at line 158 was already unaffected, since it compares counts, so the single-alert case behaved correctly before and still does.

Added a regression test alongside the existing `_check_if_rule_apply` coercion test. It feeds two alerts to `(source == "sentry") || (service != null)`, one satisfying each side, and asserts the matched set equals the extracted sub-rules. It fails on main and passes here.

`pytest tests/test_alert_evaluation.py` is green, 21 passed.
