### PR TITLE
fix(gemini): default to a model Google still serves

### DIFF
--- a/keep/providers/gemini_provider/gemini_provider.py
+++ b/keep/providers/gemini_provider/gemini_provider.py
@@ -43,7 +43,7 @@ class GeminiProvider(BaseProvider):
     def _query(
         self,
         prompt,
-        model="gemini-pro",
+        model="gemini-3.7-flash",
         max_tokens=1024,
         structured_output_format=None,
     ):
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     print(
         provider.query(
             prompt="Here is an alert, define environment for it: Clients are panicking, nothing works.",
-            model="gemini-pro",
+            model="gemini-3.7-flash",
             structured_output_format={
                 "type": "json_schema",
                 "json_schema": {


### PR DESCRIPTION
Closes #6696

`GeminiProvider._query` defaulted to `gemini-pro`, which resolves to Gemini 1.0 Pro. Google's changelog records it as no longer supported since 2025-02-18, so calling the provider without naming a model targets something the API no longer serves.

https://ai.google.dev/gemini-api/docs/changelog

This sets the default to `gemini-3.7-flash`, keeping the provider on a cheap fast model. Note `gemini-2.0-flash` and `gemini-2.0-flash-lite` are not viable replacements either, both shut down on 2026-06-01.

https://ai.google.dev/gemini-api/docs/deprecations

Anyone relying on the default gets a different model after this, so the output is worth a sanity check by someone who can run the provider against a real key.

The two `gpt-3.5-turbo` defaults in the OpenAI and LiteLLM providers have a shutdown date of 2026-10-23 rather than being already gone, so I left those out. Happy to send them separately.