### PR TITLE
fix(presets): don't rewrite search text when translating CEL contains

### DIFF
--- a/keep-ui/features/presets/presets-manager/lib/__tests__/eval-with-context.test.ts
+++ b/keep-ui/features/presets/presets-manager/lib/__tests__/eval-with-context.test.ts
@@ -1,0 +1,75 @@
+import { AlertDto } from "@/entities/alerts/model";
+import { evalWithContext } from "../eval-with-context";
+
+// sanitizeCELIntoJS rewrites the CEL `contains` operator to JS `includes`
+// before the expression is evaluated. It used to do so with an unanchored
+// /contains/g, which also rewrote the inside of quoted search strings and any
+// identifier that merely contained those letters. Nothing threw: the preset
+// saved and filtered, just against something the user never typed.
+const alert = {
+  id: "1",
+  name: "test",
+  description: "this contains errors",
+  severity: "critical",
+  status: "firing",
+  source: ["prometheus"],
+} as unknown as AlertDto;
+
+describe("evalWithContext - contains", () => {
+  it("matches on a plain substring", () => {
+    expect(evalWithContext(alert, 'description.contains("errors")')).toBe(true);
+  });
+
+  it("does not match a substring that is absent", () => {
+    expect(evalWithContext(alert, 'description.contains("timeout")')).toBe(
+      false
+    );
+  });
+
+  // The search term is the operator's own name. Rewriting the operator must
+  // not rewrite what the user is searching for.
+  it("searches for the literal word 'contains'", () => {
+    expect(evalWithContext(alert, 'description.contains("contains")')).toBe(
+      true
+    );
+  });
+
+  it("does not match 'includes' when the user searched for 'contains'", () => {
+    const other = { ...alert, description: "this includes errors" } as AlertDto;
+    expect(evalWithContext(other, 'description.contains("contains")')).toBe(
+      false
+    );
+  });
+
+  it("keeps the search term intact inside a longer phrase", () => {
+    expect(
+      evalWithContext(alert, 'description.contains("this contains errors")')
+    ).toBe(true);
+  });
+
+  it("still rewrites several contains calls in one expression", () => {
+    expect(
+      evalWithContext(
+        alert,
+        'description.contains("this") && description.contains("errors")'
+      )
+    ).toBe(true);
+  });
+});
+
+describe("evalWithContext - identifiers holding the operator name", () => {
+  // A field whose name merely contains those letters was renamed to one that
+  // does not exist, so the comparison silently evaluated against undefined.
+  const labelled = {
+    ...alert,
+    contains_pii: "true",
+  } as unknown as AlertDto;
+
+  it("does not rename a field whose name starts with the operator name", () => {
+    expect(evalWithContext(labelled, 'contains_pii == "true"')).toBe(true);
+  });
+
+  it("reports a genuine mismatch on such a field", () => {
+    expect(evalWithContext(labelled, 'contains_pii == "false"')).toBe(false);
+  });
+});

--- a/keep-ui/features/presets/presets-manager/lib/eval-with-context.ts
+++ b/keep-ui/features/presets/presets-manager/lib/eval-with-context.ts
@@ -9,8 +9,19 @@ const getAllMatches = (pattern: RegExp, string: string) =>
   // make sure string is a String, and make sure pattern has the /g flag
   String(string).match(new RegExp(pattern, "g"));
 const sanitizeCELIntoJS = (celExpression: string): string => {
-  // First, replace "contains" with "includes"
-  let jsExpression = celExpression.replace(/contains/g, "includes");
+  // Rewrite the CEL `contains` operator to JS `includes`.
+  //
+  // Matching the call form `.contains(` rather than the bare word: an
+  // unanchored /contains/g also rewrote the inside of quoted search strings
+  // and any identifier that merely contained those letters, so
+  // `description.contains("contains")` searched for "includes", and a label
+  // named `contains_pii` became `includes_pii` -- a field that does not
+  // exist, which then evaluated to undefined and quietly matched nothing.
+  //
+  // A search string holding the literal `.contains(` is still rewritten;
+  // separating code from string literals properly needs a tokenizer rather
+  // than a regex.
+  let jsExpression = celExpression.replace(/\.contains\(/g, ".includes(");
 
   // Replace severity comparisons with mapped values
   jsExpression = jsExpression.replace(


### PR DESCRIPTION
Fixes #6699.

## What was wrong

`sanitizeCELIntoJS` turns the CEL `contains` operator into JS `includes` before the expression is evaluated. It did so with an unanchored `/contains/g`, which also rewrote the inside of quoted search strings and any identifier that merely held those letters.

| The user typed | What was evaluated |
|---|---|
| `description.contains("contains")` | `description.includes("includes")` |
| `name.contains("this contains errors")` | `name.includes("this includes errors")` |
| `contains_pii == "true"` | `includes_pii == "true"` |
| `labels.contains_secret == "yes"` | `labels.includes_secret == "yes"` |
| `description.contains("db")` | `description.includes("db")` ✔ |

Two separate failures. The search term gets rewritten, so the filter looks for a word the user never typed. And a field or label whose name holds those letters is renamed to one that does not exist, so the comparison evaluates against `undefined` and quietly matches nothing.

Nothing throws at any point. The preset saves and filters, just against the wrong thing.

## The fix

Match the call form `.contains(` instead of the bare word. That fixes every row above.

**What it does not fix:** a search string containing the literal `.contains(` is still rewritten. Doing that correctly means separating code from string literals with a tokenizer rather than a regex, which is a larger change to a function whose own neighbouring comment already says `// this pattern is far from robust`. I would rather send the narrow correct change than a rewrite bundled with a bug fix, but happy to take it further if you would prefer that.

## Tests

The file had none. Added `__tests__/eval-with-context.test.ts`, testing through the exported `evalWithContext` so it exercises the real path rather than the private helper:

- the plain substring case that always worked, and a genuine non-match
- the literal word `contains` as the search term, plus the inverse — that it does *not* match an alert whose text says "includes"
- the same word inside a longer phrase
- several `contains` calls in one expression
- a field named `contains_pii`, matching and mismatching

**Against the unfixed function 4 of the 8 fail** and the 4 covering ordinary behaviour still pass, so the tests pin the bug rather than the implementation. `npx jest features/presets` is 18/18 green.

Related to #6274, which reports the same class of silent rewriting in the workflow YAML editor. This is a different code path — that one is covered by #6647 — but the underlying pattern is the same, so it seemed worth fixing here too.
