### PR TITLE
fix(providers): don't crash on an empty choices list

### DIFF
--- a/keep/providers/litellm_provider/litellm_provider.py
+++ b/keep/providers/litellm_provider/litellm_provider.py
@@ -115,7 +115,7 @@ class LitellmProvider(BaseProvider):
             # Extract the generated text from the response
             try:
                 generated_text = result["choices"][0]["message"]["content"]
-            except KeyError:
+            except (KeyError, IndexError):
                 generated_text = ""
 
             # Reasoning models return content=None when the whole max_tokens

--- a/keep/providers/vllm_provider/vllm_provider.py
+++ b/keep/providers/vllm_provider/vllm_provider.py
@@ -100,7 +100,7 @@ class VllmProvider(BaseProvider):
             # Adjust this based on your vLLM API response structure
             try:
                 generated_text = result["choices"][0]['text']
-            except KeyError:
+            except (KeyError, IndexError):
                 generated_text = ""
             
             # Try to parse as JSON if it's meant to be structured

--- a/tests/providers/litellm_provider/test_litellm_response_parsing.py
+++ b/tests/providers/litellm_provider/test_litellm_response_parsing.py
@@ -121,3 +121,22 @@ def test_missing_usage_does_not_break_the_response():
     assert result["prompt_tokens"] is None
     assert result["cost"] is None
     assert result["model"] == "local-model"
+
+
+def _empty_choices_response():
+    """Some OpenAI-compatible backends (e.g. Azure content filtering) return
+    HTTP 200 with an empty ``choices`` list. ``raise_for_status`` passes, so the
+    provider still has to read ``choices[0]``."""
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(return_value={"choices": []})
+    return response
+
+
+def test_empty_choices_does_not_crash():
+    # choices[0] on an empty list raises IndexError, which the old
+    # ``except KeyError`` did not catch, so the step died with an opaque
+    # traceback instead of an empty response.
+    provider = _build_provider()
+    with patch("requests.post", return_value=_empty_choices_response()):
+        assert provider._query(prompt="hi")["response"] == ""


### PR DESCRIPTION
Fixes #6706

The litellm and vllm providers read `result["choices"][0]` inside an `except KeyError`. An empty `choices` list raises IndexError, which that handler doesn't catch, so the workflow step dies with an opaque traceback instead of the empty-response fallback the code already has for a missing content key.

This shows up in normal operation. An OpenAI-compatible backend can return HTTP 200 with `{"choices": []}` (Azure OpenAI does this when a prompt trips its content filter), so `raise_for_status()` passes and then `choices[0]` throws.

Catches IndexError alongside KeyError in both providers, so an empty list falls back to `""` the same way a missing key does. Added a regression test for the litellm path.