### PR TITLE
fix(providers): don't crash on empty choices in grok

### DIFF
--- a/keep/providers/grok_provider/grok_provider.py
+++ b/keep/providers/grok_provider/grok_provider.py
@@ -71,7 +71,14 @@ class GrokProvider(BaseProvider):
                 json=payload
             )
             response.raise_for_status()
-            content = response.json()["choices"][0]["message"]["content"]
+            result = response.json()
+            # An OpenAI-compatible backend can return HTTP 200 with an empty
+            # choices list (e.g. a content-filter block), so raise_for_status
+            # passes but choices[0] would raise. Degrade to an empty string.
+            try:
+                content = result["choices"][0]["message"]["content"]
+            except (KeyError, IndexError):
+                content = ""
 
             # Try to parse as JSON if structured output was requested
             if structured_output_format:

--- a/tests/providers/grok_provider/test_grok_response_parsing.py
+++ b/tests/providers/grok_provider/test_grok_response_parsing.py
@@ -1,0 +1,46 @@
+"""Tests for how the Grok provider parses a chat completion response.
+
+The xAI API is OpenAI-compatible, and OpenAI-compatible backends return HTTP 200
+with an empty ``choices`` list on a content-filter block. ``raise_for_status``
+passes, so the provider still has to read ``choices[0]`` and must not crash.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.grok_provider.grok_provider import GrokProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+
+def _build_provider() -> GrokProvider:
+    config = ProviderConfig(
+        description="Grok Provider",
+        authentication={"api_key": "test-key"},
+    )
+    return GrokProvider(ContextManager(tenant_id="test"), "grok-test", config)
+
+
+def _response(payload) -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(return_value=payload)
+    return response
+
+
+def test_empty_choices_does_not_crash():
+    provider = _build_provider()
+    with patch("requests.post", return_value=_response({"choices": []})):
+        assert provider._query(prompt="hi")["response"] == ""
+
+
+def test_missing_keys_do_not_crash():
+    provider = _build_provider()
+    with patch("requests.post", return_value=_response({})):
+        assert provider._query(prompt="hi")["response"] == ""
+
+
+def test_normal_response_is_returned():
+    provider = _build_provider()
+    payload = {"choices": [{"message": {"content": "hello"}}]}
+    with patch("requests.post", return_value=_response(payload)):
+        assert provider._query(prompt="hi")["response"] == "hello"


### PR DESCRIPTION
Fixes #6708

GrokProvider._query indexed ["choices"][0] right after raise_for_status. An OpenAI-compatible backend can return HTTP 200 with an empty choices list, so the index threw IndexError, which the existing except requests.exceptions.RequestException did not catch.

Guards the parse the same way #6705 did for litellm and vllm: fall back to an empty string when choices is empty or the keys are missing. Adds a test.