### PR TITLE
fix: Preserve column configuration when saving a preset

### DIFF
--- a/keep/api/routes/preset.py
+++ b/keep/api/routes/preset.py
@@ -44,6 +44,14 @@ from keep.searchengine.searchengine import SearchEngine
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+COLUMN_CONFIG_OPTION_LABELS = {
+    "column_visibility",
+    "column_order",
+    "column_rename_mapping",
+    "column_time_formats",
+    "column_list_formats",
+}
+
 
 # SHAHAR: this function runs as background tasks as a seperate thread
 #         DO NOT ADD async HERE as it will run in the main thread and block the whole server
@@ -378,7 +386,17 @@ def update_preset(
     options_dict = [option.dict() for option in body.options]
     if not options_dict:
         raise HTTPException(400, "Options cannot be empty")
-    preset.options = options_dict
+    options_dict = [
+        option
+        for option in options_dict
+        if option.get("label", "").lower() not in COLUMN_CONFIG_OPTION_LABELS
+    ]
+    column_config_options = [
+        option
+        for option in preset.options
+        if option.get("label", "").lower() in COLUMN_CONFIG_OPTION_LABELS
+    ]
+    preset.options = options_dict + column_config_options
 
     # Handle tags
     tags = []
@@ -621,14 +639,9 @@ def update_preset_column_config(
 
     # Get current options and remove any existing column config options
     current_options = [
-        option for option in preset.options 
-        if option.get("label", "").lower() not in [
-            "column_visibility", 
-            "column_order", 
-            "column_rename_mapping", 
-            "column_time_formats", 
-            "column_list_formats"
-        ]
+        option
+        for option in preset.options
+        if option.get("label", "").lower() not in COLUMN_CONFIG_OPTION_LABELS
     ]
 
     # Add new column configuration options

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -1,0 +1,129 @@
+import pytest
+from sqlmodel import select
+
+from keep.api.core.dependencies import SINGLE_TENANT_UUID
+from keep.api.models.db.preset import Preset
+from tests.fixtures.client import client, test_app  # noqa: F401
+
+COLUMN_OPTIONS = [
+    {"label": "column_visibility", "value": {"severity": True, "source": False}},
+    {"label": "column_order", "value": ["severity", "source"]},
+    {
+        "label": "column_rename_mapping",
+        "value": {"severity": "Priority"},
+    },
+    {
+        "label": "column_time_formats",
+        "value": {"lastReceived": "relative"},
+    },
+    {"label": "column_list_formats", "value": {"labels": "comma-separated"}},
+]
+
+
+def _query_options(suffix):
+    return [
+        {"label": "CEL", "value": f'severity == "{suffix}"'},
+        {
+            "label": "SQL",
+            "value": {"sql": "severity = :severity", "params": {"severity": suffix}},
+        },
+    ]
+
+
+def _create_preset(db_session, options):
+    preset = Preset(
+        tenant_id=SINGLE_TENANT_UUID,
+        created_by="test@keephq.dev",
+        name="Custom preset",
+        options=options,
+    )
+    db_session.add(preset)
+    db_session.commit()
+    db_session.refresh(preset)
+    return preset
+
+
+def _update_preset(client, preset, options):
+    return client.put(
+        f"/preset/{preset.id}",
+        json={
+            "name": preset.name,
+            "options": options,
+            "is_private": False,
+            "is_noisy": False,
+            "tags": [],
+            "counter_shows_firing_only": True,
+        },
+    )
+
+
+def _options_by_label(options):
+    return {option["label"].lower(): option["value"] for option in options}
+
+
+@pytest.mark.parametrize("test_app", ["NO_AUTH"], indirect=True)
+def test_update_preset_preserves_column_configuration(db_session, client, test_app):
+    preset = _create_preset(db_session, _query_options("warning") + COLUMN_OPTIONS)
+
+    response = _update_preset(client, preset, _query_options("critical"))
+
+    assert response.status_code == 200
+    returned_options = _options_by_label(response.json()["options"])
+    stored_preset = db_session.exec(
+        select(Preset).where(Preset.id == preset.id)
+    ).first()
+    db_session.refresh(stored_preset)
+    stored_options = _options_by_label(stored_preset.options)
+
+    assert returned_options == stored_options
+    assert returned_options == _options_by_label(
+        _query_options("critical") + COLUMN_OPTIONS
+    )
+
+
+@pytest.mark.parametrize("test_app", ["NO_AUTH"], indirect=True)
+def test_update_preset_without_column_configuration_updates_query_only(
+    db_session, client, test_app
+):
+    preset = _create_preset(db_session, _query_options("warning"))
+
+    response = _update_preset(client, preset, _query_options("critical"))
+
+    assert response.status_code == 200
+    assert response.json()["options"] == _query_options("critical")
+
+    db_session.refresh(preset)
+    assert preset.options == _query_options("critical")
+
+
+@pytest.mark.parametrize("test_app", ["NO_AUTH"], indirect=True)
+def test_repeated_preset_updates_replace_queries_without_duplicate_options(
+    db_session, client, test_app
+):
+    preset = _create_preset(db_session, _query_options("info") + COLUMN_OPTIONS)
+    submitted_column_option = {
+        "label": "column_visibility",
+        "value": {"severity": False},
+    }
+
+    first_response = _update_preset(
+        client, preset, _query_options("warning") + [submitted_column_option]
+    )
+    second_response = _update_preset(client, preset, _query_options("critical"))
+
+    assert first_response.status_code == 200
+    first_options = first_response.json()["options"]
+    assert _options_by_label(first_options) == _options_by_label(
+        _query_options("warning") + COLUMN_OPTIONS
+    )
+    assert len(first_options) == len(_query_options("warning") + COLUMN_OPTIONS)
+
+    assert second_response.status_code == 200
+    returned_options = second_response.json()["options"]
+    assert _options_by_label(returned_options) == _options_by_label(
+        _query_options("critical") + COLUMN_OPTIONS
+    )
+    assert len(returned_options) == len(_query_options("critical") + COLUMN_OPTIONS)
+
+    db_session.refresh(preset)
+    assert preset.options == returned_options

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"


### PR DESCRIPTION
Closes #

## 📑 Description

Update the preset route so a general preset save replaces the submitted query options while retaining the existing column-configuration entries (`column_visibility`, `column_order`, rename mappings, and time/list formats) before committing the model. Keep the preservation logic in the production route path and align its recognized labels with the dedicated column-config endpoint, without adding a test-only seam or changing the request contract. Add focused route-level regression coverage that seeds a preset with query and column options, performs the same general update used by the edit form, and verifies both the new query values and every saved column setting.

Custom alert presets lose their selected column visibility and ordering after the user opens the preset editor and saves the preset. The column-configuration endpoint stores those values as entries in the preset's shared `options` list, while the general `PUT /preset/{preset_id}` handler replaces that list with the editor's CEL and SQL entries. As a result, saving otherwise unrelated preset fields deletes all column configuration and the next read falls back to the default columns. The issue remains reproducible after the frontend cache and full-column-payload changes merged in #6537 because that change did not protect the backend's general update path.

Closes #6685

## ✅ Checks

- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] All the tests have passed

## ℹ Additional Information

Nothing beyond what is described above.
