### PR TITLE
fix(providers): don't crash on empty choices in openai and deepseek

### DIFF
--- a/keep/providers/deepseek_provider/deepseek_provider.py
+++ b/keep/providers/deepseek_provider/deepseek_provider.py
@@ -80,7 +80,13 @@ class DeepseekProvider(BaseProvider):
             max_tokens=max_tokens,
             response_format=structured_output_format,
         )
-        response = response.choices[0].message.content
+        # An OpenAI-compatible backend can return HTTP 200 with an empty
+        # choices list (for example a content-filter block), so choices[0]
+        # would raise. Degrade to an empty string instead of crashing the step.
+        try:
+            response = response.choices[0].message.content
+        except IndexError:
+            response = ""
         try:
             response = json.loads(response)
         except Exception:

--- a/keep/providers/openai_provider/openai_provider.py
+++ b/keep/providers/openai_provider/openai_provider.py
@@ -66,7 +66,13 @@ class OpenaiProvider(BaseProvider):
             max_tokens=max_tokens,
             response_format=structured_output_format,
         )
-        response = response.choices[0].message.content
+        # An OpenAI-compatible backend can return HTTP 200 with an empty
+        # choices list (for example a content-filter block), so choices[0]
+        # would raise. Degrade to an empty string instead of crashing the step.
+        try:
+            response = response.choices[0].message.content
+        except IndexError:
+            response = ""
         try:
             response = json.loads(response)
         except Exception:

--- a/tests/providers/deepseek_provider/test_deepseek_empty_choices.py
+++ b/tests/providers/deepseek_provider/test_deepseek_empty_choices.py
@@ -1,0 +1,37 @@
+"""The DeepSeek provider must not crash on an empty choices list.
+
+DeepSeek is reached through the OpenAI client against a different base URL, so
+it shares the same failure mode: an HTTP 200 with an empty ``choices`` list
+(for example a content-filter block) makes ``choices[0]`` raise IndexError and
+kills the workflow step. The provider degrades to an empty string instead.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.deepseek_provider.deepseek_provider import DeepseekProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+
+def _build_provider() -> DeepseekProvider:
+    config = ProviderConfig(
+        description="DeepSeek Provider",
+        authentication={"api_key": "test-key"},
+    )
+    return DeepseekProvider(ContextManager(tenant_id="test"), "deepseek-test", config)
+
+
+def _client_returning_no_choices():
+    client = MagicMock()
+    client.chat.completions.create.return_value.choices = []
+    return patch(
+        "keep.providers.deepseek_provider.deepseek_provider.OpenAI",
+        return_value=client,
+    )
+
+
+def test_empty_choices_returns_empty_string_instead_of_crashing():
+    provider = _build_provider()
+    with _client_returning_no_choices():
+        result = provider._query(prompt="hi")
+    assert result == {"response": ""}

--- a/tests/providers/openai_provider/test_openai_empty_choices.py
+++ b/tests/providers/openai_provider/test_openai_empty_choices.py
@@ -1,0 +1,37 @@
+"""The OpenAI provider must not crash on an empty choices list.
+
+An OpenAI-compatible backend can return HTTP 200 with an empty ``choices``
+list (for example a content-filter block). Reading ``choices[0]`` then raises
+IndexError and takes down the whole workflow step, so the provider degrades to
+an empty string instead.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.models.provider_config import ProviderConfig
+from keep.providers.openai_provider.openai_provider import OpenaiProvider
+
+
+def _build_provider() -> OpenaiProvider:
+    config = ProviderConfig(
+        description="OpenAI Provider",
+        authentication={"api_key": "test-key"},
+    )
+    return OpenaiProvider(ContextManager(tenant_id="test"), "openai-test", config)
+
+
+def _client_returning_no_choices():
+    client = MagicMock()
+    client.chat.completions.create.return_value.choices = []
+    return patch(
+        "keep.providers.openai_provider.openai_provider.OpenAI",
+        return_value=client,
+    )
+
+
+def test_empty_choices_returns_empty_string_instead_of_crashing():
+    provider = _build_provider()
+    with _client_returning_no_choices():
+        result = provider._query(prompt="hi")
+    assert result == {"response": ""}


### PR DESCRIPTION
Fixes #6715.

The OpenAI and DeepSeek providers read `response.choices[0].message.content` with no guard. An OpenAI-compatible backend can return HTTP 200 with an empty `choices` list (for example a content-filter block), so `choices[0]` raises `IndexError` and the workflow step crashes.

The same fix already landed for litellm/vllm (#6705) and grok (#6710); this covers the two remaining OpenAI-compatible providers.

### Change
- Guard `choices[0]` in both providers and degrade to an empty string, matching the grok and litellm behavior.
- Add a test for each provider that patches the client to return empty choices and asserts `_query` returns `{"response": ""}` instead of raising.

### Validation
```
poetry run pytest tests/providers/openai_provider/test_openai_empty_choices.py \
  tests/providers/deepseek_provider/test_deepseek_empty_choices.py
poetry run ruff check keep/providers/openai_provider keep/providers/deepseek_provider
```
Both tests pass on this change and fail with `IndexError` on the current code (openai_provider.py:69, deepseek_provider.py:83), so they pin the regression. ruff clean.