### PR TITLE
fix: extraction rule executions route to mapping execution pages

### DIFF
--- a/keep-ui/app/(keep)/extraction/[rule_id]/executions/[execution_id]/page.tsx
+++ b/keep-ui/app/(keep)/extraction/[rule_id]/executions/[execution_id]/page.tsx
@@ -17,6 +17,7 @@ export default function ExtractionExecutionDetailsPage(props: {
   const { execution, isLoading } = useEnrichmentEvent({
     ruleId: params.rule_id,
     executionId: params.execution_id,
+    type: "extraction",
   });
 
   const { data: extractions } = useExtractions();

--- a/keep-ui/app/(keep)/extraction/[rule_id]/executions/page.tsx
+++ b/keep-ui/app/(keep)/extraction/[rule_id]/executions/page.tsx
@@ -57,6 +57,7 @@ export default function ExtractionExecutionsPage(props: {
             offset: pagination.offset,
           }}
           setPagination={setPagination}
+          basePath="extraction"
         />
       </Card>
     </div>

--- a/keep-ui/components/table/ExecutionsTable.tsx
+++ b/keep-ui/components/table/ExecutionsTable.tsx
@@ -18,9 +18,14 @@ interface Pagination {
 interface Props {
   executions: PaginatedEnrichmentExecutionDto;
   setPagination: Dispatch<SetStateAction<Pagination>>;
+  basePath?: "mapping" | "extraction";
 }
 
-export function ExecutionsTable({ executions, setPagination }: Props) {
+export function ExecutionsTable({
+  executions,
+  setPagination,
+  basePath = "mapping",
+}: Props) {
   const columnHelper = createColumnHelper<EnrichmentEvent>();
   const router = useRouter();
 
@@ -86,7 +91,7 @@ export function ExecutionsTable({ executions, setPagination }: Props) {
         setPagination({ limit: newLimit, offset: newOffset })
       }
       onRowClick={(row: EnrichmentEvent) => {
-        router.push(`/mapping/${row.rule_id}/executions/${row.id}`);
+        router.push(`/${basePath}/${row.rule_id}/executions/${row.id}`);
       }}
     />
   );

--- a/keep-ui/components/table/__tests__/ExecutionsTable.test.tsx
+++ b/keep-ui/components/table/__tests__/ExecutionsTable.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useRouter } from "next/navigation";
+import { ExecutionsTable } from "../ExecutionsTable";
+import { PaginatedEnrichmentExecutionDto } from "@/shared/api/enrichment-events";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+const executions: PaginatedEnrichmentExecutionDto = {
+  items: [
+    {
+      id: "exec-1",
+      rule_id: 42,
+      status: "success",
+      timestamp: "2026-08-17T10:00:00",
+      alert_id: "alert-1",
+    } as any,
+  ],
+  count: 1,
+  limit: 20,
+  offset: 0,
+};
+
+describe("ExecutionsTable", () => {
+  const mockPush = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+  });
+
+  it("routes to the mapping execution page by default", () => {
+    render(
+      <ExecutionsTable executions={executions} setPagination={jest.fn()} />
+    );
+
+    fireEvent.click(screen.getByText("exec-1"));
+
+    expect(mockPush).toHaveBeenCalledWith("/mapping/42/executions/exec-1");
+  });
+
+  it("routes to the extraction execution page when basePath is extraction", () => {
+    render(
+      <ExecutionsTable
+        executions={executions}
+        setPagination={jest.fn()}
+        basePath="extraction"
+      />
+    );
+
+    fireEvent.click(screen.getByText("exec-1"));
+
+    expect(mockPush).toHaveBeenCalledWith("/extraction/42/executions/exec-1");
+  });
+});


### PR DESCRIPTION
## What
Fixes #6703.

Clicking an execution row on the **extraction rule executions** page opened the *mapping* rule execution detail page instead. Even navigating directly to the extraction execution URL fetched mapping data.

## Root cause
- `ExecutionsTable`'s row click handler hard-coded `/mapping/${row.rule_id}/executions/${row.id}`, with no way for a caller to route elsewhere.
- The extraction execution detail page called `useEnrichmentEvent({ ruleId, executionId })` without `type: "extraction"`, and that hook defaults `type` to `"mapping"`, so it hit the `/mapping/...` API endpoint regardless of the URL.

## Fix
- Added an optional `basePath` prop to `ExecutionsTable` (`"mapping" | "extraction"`, defaults to `"mapping"` so the existing mapping pages are unaffected) and used it in the row-click navigation instead of the hard-coded path.
- Passed `basePath="extraction"` from the extraction executions list page.
- Passed `type: "extraction"` explicitly from the extraction execution detail page so it fetches from the correct endpoint.

## Testing
- Added `components/table/__tests__/ExecutionsTable.test.tsx` covering both the default (mapping) and `basePath="extraction"` row-click routing.
- `npx jest` — full suite: 52 suites / 468 tests pass.
- `npx eslint` on all changed files — clean.
- `npx tsc --noEmit` — no new errors (18 pre-existing errors on `main`, unrelated to these files, unchanged).