### PR TITLE
fix(keep-provider): don't mutate the shared fingerprint_fields list

### DIFF
--- a/keep/providers/keep_provider/keep_provider.py
+++ b/keep/providers/keep_provider/keep_provider.py
@@ -136,7 +136,7 @@ class KeepProvider(BaseProvider):
         self.logger.info("Got alerts from Keep", extra={"num_of_alerts": len(alerts)})
         return alerts
 
-    def _build_alert(self, alert_data, fingerprint_fields=[], **kwargs):
+    def _build_alert(self, alert_data, fingerprint_fields=None, **kwargs):
         """
         Build alerts from Keep.
         """
@@ -174,7 +174,9 @@ class KeepProvider(BaseProvider):
             fingerprint_fields = ["labels." + label for label in list(labels.keys())]
 
         # workflowId is used as the "rule id" - it's used to identify the rule that created the alert
-        fingerprint_fields.append("workflowId")
+        # build a new list instead of appending in place, since fingerprint_fields may be a
+        # list the caller (e.g. _notify_alert's per-alert loop) reuses across multiple alerts
+        fingerprint_fields = fingerprint_fields + ["workflowId"]
         alert.fingerprint = self.get_alert_fingerprint(alert, fingerprint_fields)
         return alert
 

--- a/tests/test_keep_provider_fingerprint_fields_mutation.py
+++ b/tests/test_keep_provider_fingerprint_fields_mutation.py
@@ -1,0 +1,86 @@
+"""
+Test for KeepProvider._build_alert mutating the caller's fingerprint_fields list.
+
+This reproduces the issue described in https://github.com/keephq/keep/issues/6719
+where _build_alert calls fingerprint_fields.append("workflowId") on whatever list
+was passed in. _notify_alert's per-alert loop passes the same fingerprint_fields
+object into _build_alert on every iteration of a foreach batch, so each alert
+after the first accumulates one more duplicate "workflowId" entry, which changes
+its computed fingerprint.
+"""
+
+import uuid
+
+from keep.api.core.dependencies import SINGLE_TENANT_UUID
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.keep_provider.keep_provider import KeepProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+
+def _make_provider():
+    context_manager = ContextManager(
+        tenant_id=SINGLE_TENANT_UUID,
+        workflow_id=str(uuid.uuid4()),
+    )
+    provider_config = ProviderConfig(authentication={})
+    return KeepProvider(
+        context_manager=context_manager,
+        provider_id="test-keep",
+        config=provider_config,
+    )
+
+
+def test_build_alert_does_not_mutate_caller_fingerprint_fields():
+    """
+    Calling _build_alert repeatedly with the same fingerprint_fields list -
+    exactly what _notify_alert's per-alert loop does for a foreach batch -
+    must not grow or otherwise mutate that list between calls.
+    """
+    provider = _make_provider()
+    fingerprint_fields = ["labels.service"]
+
+    for _ in range(3):
+        provider._build_alert(
+            {},
+            fingerprint_fields,
+            name="disk full",
+            labels={"service": "db-primary"},
+        )
+
+    assert fingerprint_fields == ["labels.service"]
+
+
+def test_build_alert_produces_consistent_fingerprints_across_a_batch():
+    """
+    Alerts that only differ in the value of the fingerprinted field should get
+    fingerprints computed the same way, regardless of how many other alerts
+    were built earlier in the same batch (same fingerprint_fields object reused,
+    as _notify_alert does).
+    """
+    provider = _make_provider()
+    fingerprint_fields = ["labels.service"]
+
+    services = ["db-primary", "db-replica", "cache"]
+    fingerprints = []
+    for service in services:
+        alert = provider._build_alert(
+            {},
+            fingerprint_fields,
+            name="disk full",
+            labels={"service": service},
+        )
+        fingerprints.append(alert.fingerprint)
+
+    # Building the alert for "cache" independently (fresh fingerprint_fields,
+    # as if it were the only/first alert in its own batch) must produce the
+    # exact same fingerprint as when it was the 3rd alert in the loop above.
+    standalone_alert = provider._build_alert(
+        {},
+        ["labels.service"],
+        name="disk full",
+        labels={"service": "cache"},
+    )
+
+    assert fingerprints[2] == standalone_alert.fingerprint
+    # sanity: different services still produce different fingerprints
+    assert len(set(fingerprints)) == len(services)


### PR DESCRIPTION
## What
Fixes #6719.

`KeepProvider._build_alert` did `fingerprint_fields.append("workflowId")` on whatever list was passed in. `_notify_alert`'s per-alert loop passes that same list object into `_build_alert` on every iteration of a `foreach` batch, so each alert after the first accumulated one more duplicate `"workflowId"` entry, which changes its computed SHA-256 fingerprint.

## Fix
- `keep_provider.py:177` - build a new list (`fingerprint_fields + ["workflowId"]`) instead of mutating the caller's list with `.append`.
- `keep_provider.py:139` - switched the mutable default argument (`fingerprint_fields=[]`) to `None` while touching this line, since `if not fingerprint_fields:` already treats `None`/`[]` identically, so this is a no-op behaviorally but removes the classic mutable-default footgun flagged alongside the main bug.

## Testing
Added `tests/test_keep_provider_fingerprint_fields_mutation.py`:
- `test_build_alert_does_not_mutate_caller_fingerprint_fields` - calls `_build_alert` 3x with the same `fingerprint_fields` list (mirroring `_notify_alert`'s loop) and asserts the list is unchanged afterward.
- `test_build_alert_produces_consistent_fingerprints_across_a_batch` - asserts an alert's fingerprint is identical whether it's built standalone or as the 3rd alert in a batch that reused the same `fingerprint_fields` object.

I wasn't able to run the full suite in my sandbox - `pip install -e .` fails on this platform because `uvloop` doesn't support Windows (a pyproject dependency), and `tests/conftest.py` needs Docker/MySQL fixtures at collection time regardless of which test is targeted. I verified both the bug and the fix by extracting the exact control flow (`_build_alert`'s fingerprint-fields handling and the real `BaseProvider.get_alert_fingerprint` hashing algorithm) into a standalone script and running it directly - before the fix, a 3-alert batch left `fingerprint_fields` as `['labels.service', 'workflowId', 'workflowId', 'workflowId']` and alert 3's fingerprint didn't match the correct value; after the fix, the list stays `['labels.service']` and the fingerprint matches. `python -m py_compile` and `black --check` / `isort --check` pass on both changed files.