### PR TITLE
fix(step): iterate a scalar foreach value once instead of crashing on falsy values

### DIFF
--- a/keep/step/step.py
+++ b/keep/step/step.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterable
 import time
 from enum import Enum
 
@@ -127,7 +128,17 @@ class Step:
             foreach_items.append(items)
         if not foreach_items:
             return []
-        return len(foreach_items) == 1 and foreach_items[0] or zip(*foreach_items)
+        if len(foreach_items) == 1:
+            # A single reference resolves to whatever it points at: normally
+            # the list to iterate, but also legitimately a scalar such as a
+            # count of 0. The old `X and Y or Z` idiom routed falsy values
+            # into zip(), which raised TypeError on non-iterables; a scalar
+            # (falsy or not) is instead iterated once.
+            value = foreach_items[0]
+            if isinstance(value, Iterable):
+                return value
+            return [value]
+        return zip(*foreach_items)
 
     def _run_foreach(self):
         """Evaluate the action for each item, when using the `foreach` attribute (see foreach.md)"""

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -145,3 +145,33 @@ def test_continue_on_error_explicit_false():
         {},
     )
     assert step.continue_on_error is False
+
+
+@pytest.mark.parametrize(
+    "resolved,expected",
+    [
+        (0, [0]),  # falsy scalar: used to hit zip(0) -> TypeError (#6721)
+        (False, [False]),
+        (None, [None]),
+        (5, [5]),  # truthy non-iterable also crashed before via for-loop
+        ([1, 2], [1, 2]),  # iterables keep their semantics
+        (["a", "b"], ["a", "b"]),
+        ([], []),
+    ],
+)
+def test_get_foreach_items_single_reference(sample_step, resolved, expected):
+    sample_step.config["foreach"] = "{{ steps.check-count.results }}"
+    sample_step.context_manager.get_full_context = Mock(
+        return_value={"steps": {"check-count": {"results": resolved}}}
+    )
+
+    assert sample_step._get_foreach_items() == expected
+
+
+def test_get_foreach_items_multiple_references_zip(sample_step):
+    sample_step.config["foreach"] = "{{ steps.a.results }} && {{ steps.b.results }}"
+    sample_step.context_manager.get_full_context = Mock(
+        return_value={"steps": {"a": {"results": [1, 2]}, "b": {"results": ["x", "y"]}}}
+    )
+
+    assert list(sample_step._get_foreach_items()) == [(1, "x"), (2, "y")]


### PR DESCRIPTION
Fixes #6721.

## Summary

`Step._get_foreach_items` decided between "iterate a single resolved reference" and "`zip()` multiple `&&`-combined references" with the classic `X and Y or Z` idiom:

```python
return len(foreach_items) == 1 and foreach_items[0] or zip(*foreach_items)
```

The idiom is only safe when `Y` is never falsy. A single reference that resolves to `0`, `False` or `None` — e.g. `foreach: "{{ steps.check-count.results }}"` where the count is zero — fell through to `zip(*foreach_items)` = `zip(0)`, raising `TypeError: 'int' object is not iterable`. A *truthy* non-iterable scalar was returned bare and crashed the same way one line later in `_run_foreach`'s `for item in items`.

The fix wraps a non-iterable single value in a list so the action runs exactly once with the resolved value:

```python
if len(foreach_items) == 1:
    value = foreach_items[0]
    if isinstance(value, Iterable):
        return value
    return [value]
return zip(*foreach_items)
```

Iterables (lists, dicts, strings) keep their existing semantics and the multi-reference `zip` path is untouched.

## Testing

Added `test_get_foreach_items_single_reference` (parametrized over `0`, `False`, `None`, `5`, lists and the empty list) and `test_get_foreach_items_multiple_references_zip` to `tests/test_steps.py`, next to the existing `Step` unit tests with a mocked context manager.

Behavior differential of the expression (old vs new, values materialized):

| single resolved value | old | new |
|---|---|---|
| `0` / `False` / `None` | `TypeError` from `zip(...)` | `[value]` (one iteration) |
| `5` | `5` (then `TypeError` in the consumer's for-loop) | `[5]` (one iteration) |
| `[1, 2]`, `[]`, other iterables | unchanged | unchanged |
| multiple refs | `zip(...)` | unchanged |

Note: I could not run the full `tests/test_steps.py` suite locally — the project requires Python ≥ 3.11 (local interpreter is 3.10) and the conftest import chain needs the full API environment. The added tests follow the existing unit-test pattern in the same file and run under the project's CI.
