### PR TITLE
fix(topology): raise incidents for standalone services with no application

### DIFF
--- a/keep/topologies/topology_processor.py
+++ b/keep/topologies/topology_processor.py
@@ -142,13 +142,6 @@ class TopologyProcessor:
             self.logger.info(f"No topology data found for tenant {tenant_id}")
             return
 
-        # Currently topology-based incidents are created for applications only
-        # SHAHAR: this is harder to implement service-related incidents without applications
-        # TODO: add support for service-related incidents
-        if not applications:
-            self.logger.info(f"No applications found for tenant {tenant_id}")
-            return
-
         # TODO: get only alerts with service ( if lot of alerts it will be hidden)
         db_last_alerts = get_last_alerts(tenant_id, with_incidents=True)
         last_alerts = convert_db_alerts_to_dto_alerts(db_last_alerts)
@@ -165,10 +158,15 @@ class TopologyProcessor:
                     continue
                 services_to_alerts[alert.service].append(alert)
 
+        # track every service that belongs to some application, so alerts on the
+        # remaining ("standalone") services can still get an incident below
+        services_in_applications: Set[str] = set()
+
         for application in applications:
             # check if there is an incident for the application
             incident = self._get_application_based_incident(tenant_id, application)
             application_services = [t.service for t in application.services]
+            services_in_applications.update(application_services)
             services_with_alerts = [
                 service
                 for service in application_services
@@ -203,6 +201,30 @@ class TopologyProcessor:
                 self._create_application_based_incident(
                     tenant_id, application, services_to_alerts
                 )
+
+        # Services with alerts that aren't part of any application would otherwise
+        # never get an incident at all - handle those on their own, keyed by service
+        # rather than application.
+        standalone_services_with_alerts = [
+            service
+            for service in services_to_alerts
+            if service not in services_in_applications
+        ]
+        for service in standalone_services_with_alerts:
+            alerts = services_to_alerts[service]
+            incident = self._get_service_based_incident(tenant_id, service)
+            if incident:
+                self.logger.info(
+                    f"Found existing incident for standalone service {service}"
+                )
+                self._update_service_based_incident(
+                    tenant_id, service, incident, alerts
+                )
+            else:
+                self.logger.info(
+                    f"No existing incident found for standalone service {service}, creating"
+                )
+                self._create_service_based_incident(tenant_id, service, alerts)
 
     def _get_topology_based_incidents(self, tenant_id: str) -> Dict[str, Incident]:
         """Get all topology-based incidents for a tenant"""
@@ -247,8 +269,11 @@ class TopologyProcessor:
     def _get_topology_data(self, tenant_id: str):
         """Get topology data for a tenant"""
         with existed_or_new_session() as session:
+            # include_empty_deps=True: a service with no dependency edges at all
+            # is exactly the "standalone service" case (#6702) this processor
+            # needs to raise incidents for, so it can't be filtered out here.
             topology_data = TopologiesService.get_all_topology_data(
-                tenant_id=tenant_id, session=session
+                tenant_id=tenant_id, session=session, include_empty_deps=True
             )
             return topology_data
 
@@ -391,3 +416,120 @@ class TopologyProcessor:
             # Trigger the workflow event
             RulesEngine.send_workflow_event(tenant_id, session, incident_dto, "created")
             self.logger.info(f"Created new incident for application {application.name}")
+
+    def _get_service_based_incident(
+        self, tenant_id: str, service: str
+    ) -> Optional[Incident]:
+        """Get the standalone topology incident for a service that isn't part of
+        any application, if one already exists"""
+        with existed_or_new_session() as session:
+            # incident_application is None here, same reasoning as
+            # _get_application_based_incident applies to excluding deleted incidents
+            incident = session.exec(
+                select(Incident).where(
+                    Incident.tenant_id == tenant_id,
+                    Incident.incident_type == "topology",
+                    Incident.incident_application.is_(None),
+                    Incident.user_generated_name == f"Service incident: {service}",
+                    Incident.status != IncidentStatus.DELETED.value,
+                )
+            ).first()
+            return incident
+
+    def _update_service_based_incident(
+        self,
+        tenant_id: str,
+        service: str,
+        incident: Incident,
+        alerts: list[AlertDto],
+    ) -> None:
+        """Update an existing standalone service incident with new alerts and status"""
+        self.logger.info(f"Updating incident for standalone service {service}")
+
+        with existed_or_new_session() as session:
+            # Assign all alerts to the incident if they're not already assigned
+            add_alerts_to_incident(
+                tenant_id=tenant_id,
+                incident=incident,
+                fingerprints=[alert.fingerprint for alert in alerts],
+                session=session,
+                exclude_unlinked_alerts=True,
+            )
+
+            # Check if incident should be resolved
+            if incident.resolve_on == "all_resolved":
+                self.logger.info("Checking if incident should be resolved")
+                incident = enrich_incidents_with_alerts(tenant_id, [incident], session)[
+                    0
+                ]
+                alert_dtos = convert_db_alerts_to_dto_alerts(incident.alerts)
+                statuses = []
+                for alert in alert_dtos:
+                    if isinstance(alert.status, str):
+                        statuses.append(alert.status)
+                    else:
+                        statuses.append(alert.status.value)
+                all_resolved = all(
+                    [
+                        s == AlertStatus.RESOLVED.value
+                        or s == AlertStatus.SUPPRESSED.value
+                        for s in statuses
+                    ]
+                )
+                if all_resolved and incident.status != IncidentStatus.RESOLVED.value:
+                    self.logger.info(
+                        "All alerts are resolved, updating incident status to resolved"
+                    )
+                    incident.status = IncidentStatus.RESOLVED.value
+                    session.add(incident)
+                    session.commit()
+                elif (
+                    incident.status == IncidentStatus.RESOLVED.value
+                    and not all_resolved
+                ):
+                    self.logger.info(
+                        "Alerts are not resolved, updating incident status to updated"
+                    )
+                    incident.status = IncidentStatus.FIRING.value
+                    session.add(incident)
+                    session.commit()
+
+            incident_dto = IncidentDto.from_db_incident(incident)
+            RulesEngine.send_workflow_event(tenant_id, session, incident_dto, "updated")
+            self.logger.info(f"Updated incident for standalone service {service}")
+
+    def _create_service_based_incident(
+        self, tenant_id: str, service: str, alerts: list[AlertDto]
+    ) -> None:
+        """Create a new topology incident for a service that isn't part of any
+        application"""
+        self.logger.info(f"Creating new incident for standalone service {service}")
+
+        with existed_or_new_session() as session:
+            incident = Incident(
+                tenant_id=tenant_id,
+                user_generated_name=f"Service incident: {service}",
+                user_summary=f"Service {service} is experiencing issues",
+                incident_type="topology",
+                incident_application=None,
+                is_candidate=False,  # Topology-based incidents are always confirmed
+                is_visible=True,  # Topology-based incidents are always confirmed
+                is_predicted=True,  # Topology-based incidents are algorithmically generated
+            )
+
+            # Persist incident to database before adding alerts, same reasoning as
+            # _create_application_based_incident
+            session.add(incident)
+            session.flush()
+
+            for alert in alerts:
+                incident = assign_alert_to_incident(
+                    fingerprint=alert.fingerprint,
+                    incident=incident,
+                    tenant_id=tenant_id,
+                    session=session,
+                )
+
+            incident_dto = IncidentDto.from_db_incident(incident)
+            RulesEngine.send_workflow_event(tenant_id, session, incident_dto, "created")
+            self.logger.info(f"Created new incident for standalone service {service}")

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,9 +1,11 @@
 from datetime import datetime
+from unittest.mock import patch
 import uuid
 import pytest
 from sqlmodel import select
 
 from keep.api.core.dependencies import SINGLE_TENANT_UUID
+from keep.api.models.alert import AlertDto, AlertStatus, AlertSeverity
 from keep.api.models.db.topology import (
     TopologyApplication,
     TopologyApplicationDtoIn,
@@ -451,3 +453,153 @@ def test_get_application_based_incident_skips_deleted_incident(db_session):
         processor._get_application_based_incident(SINGLE_TENANT_UUID, application)
         is None
     )
+
+
+def test_create_service_based_incident_sets_is_predicted(db_session):
+    service = create_service(db_session, SINGLE_TENANT_UUID, "1")
+
+    processor = TopologyProcessor()
+    processor._create_service_based_incident(SINGLE_TENANT_UUID, service.service, [])
+
+    incident = db_session.exec(
+        select(Incident).where(
+            Incident.user_generated_name == f"Service incident: {service.service}"
+        )
+    ).first()
+
+    assert incident is not None
+    assert incident.incident_type == "topology"
+    assert incident.incident_application is None
+    assert incident.is_predicted is True
+    assert incident.is_visible is True
+    assert incident.is_candidate is False
+
+
+def test_get_service_based_incident_skips_deleted_incident(db_session):
+    """Same reasoning as test_get_application_based_incident_skips_deleted_incident,
+    for the standalone-service incident path."""
+    service = create_service(db_session, SINGLE_TENANT_UUID, "1")
+
+    processor = TopologyProcessor()
+    processor._create_service_based_incident(SINGLE_TENANT_UUID, service.service, [])
+
+    incident = db_session.exec(
+        select(Incident).where(
+            Incident.user_generated_name == f"Service incident: {service.service}"
+        )
+    ).first()
+    assert incident is not None
+
+    incident.status = IncidentStatus.DELETED.value
+    db_session.add(incident)
+    db_session.commit()
+
+    assert (
+        processor._get_service_based_incident(SINGLE_TENANT_UUID, service.service)
+        is None
+    )
+
+
+def test_get_service_based_incident_ignores_application_based_incident(db_session):
+    """An application-based incident (incident_application set) must never be
+    picked up by the service-based lookup, even for a service that's also a
+    member of that application - the two incident kinds are keyed differently
+    on purpose."""
+    service = create_service(db_session, SINGLE_TENANT_UUID, "1")
+    application = TopologyApplication(
+        tenant_id=SINGLE_TENANT_UUID,
+        name="Test App",
+        services=[service],
+    )
+    db_session.add(application)
+    db_session.commit()
+
+    processor = TopologyProcessor()
+    processor._create_application_based_incident(SINGLE_TENANT_UUID, application, {})
+
+    assert (
+        processor._get_service_based_incident(SINGLE_TENANT_UUID, service.service)
+        is None
+    )
+
+
+def _alert_for_service(service: str) -> AlertDto:
+    return AlertDto(
+        name=f"alert for {service}",
+        status=AlertStatus.FIRING,
+        severity=AlertSeverity.CRITICAL,
+        lastReceived=datetime.now().isoformat(),
+        service=service,
+        fingerprint=f"fingerprint-{service}",
+    )
+
+
+def test_process_tenant_creates_incident_for_standalone_service(db_session):
+    """Regression test for #6702: a service with no dependency edges and no
+    application still needs an incident when it has a firing alert - previously
+    _process_tenant returned immediately whenever the tenant had no applications
+    at all, so this alert would never produce an incident."""
+    service = create_service(db_session, SINGLE_TENANT_UUID, "1")
+    alert = _alert_for_service(service.service)
+
+    processor = TopologyProcessor()
+    with patch(
+        "keep.topologies.topology_processor.get_last_alerts", return_value=[]
+    ), patch(
+        "keep.topologies.topology_processor.convert_db_alerts_to_dto_alerts",
+        return_value=[alert],
+    ):
+        processor._process_tenant(SINGLE_TENANT_UUID)
+
+    incident = db_session.exec(
+        select(Incident).where(
+            Incident.user_generated_name == f"Service incident: {service.service}"
+        )
+    ).first()
+    assert incident is not None
+    assert incident.incident_application is None
+
+
+def test_process_tenant_handles_application_and_standalone_services_independently(
+    db_session,
+):
+    """An application-scoped alert and a standalone-service alert firing in the
+    same processing pass must each get their own incident, and neither path
+    should interfere with the other."""
+    app_service = create_service(db_session, SINGLE_TENANT_UUID, "1")
+    standalone_service = create_service(db_session, SINGLE_TENANT_UUID, "2")
+    application = TopologyApplication(
+        tenant_id=SINGLE_TENANT_UUID,
+        name="Test App",
+        services=[app_service],
+    )
+    db_session.add(application)
+    db_session.commit()
+
+    alerts = [
+        _alert_for_service(app_service.service),
+        _alert_for_service(standalone_service.service),
+    ]
+
+    processor = TopologyProcessor()
+    with patch(
+        "keep.topologies.topology_processor.get_last_alerts", return_value=[]
+    ), patch(
+        "keep.topologies.topology_processor.convert_db_alerts_to_dto_alerts",
+        return_value=alerts,
+    ):
+        processor._process_tenant(SINGLE_TENANT_UUID)
+
+    app_incident = processor._get_application_based_incident(
+        SINGLE_TENANT_UUID, application
+    )
+    assert app_incident is not None
+
+    service_incident = db_session.exec(
+        select(Incident).where(
+            Incident.user_generated_name
+            == f"Service incident: {standalone_service.service}"
+        )
+    ).first()
+    assert service_incident is not None
+    assert service_incident.id != app_incident.id


### PR DESCRIPTION
## What's changed?

`_process_tenant` returned immediately whenever a tenant had no topology applications at all (`if not applications: return`), so a service with an active alert never got an incident unless it happened to belong to an application. Separately, `_get_topology_data` called `get_all_topology_data` without `include_empty_deps=True`, so a service with zero dependency edges - the literal "standalone service" from the issue title - was filtered out of the topology data before the processor ever saw it, even once the early-return above is removed.

Fixed both:
- `_get_topology_data` now passes `include_empty_deps=True`.
- The application loop no longer gates the rest of the function. After it runs, any service that has an alert but isn't part of any application gets its own topology incident via new `_get_service_based_incident` / `_create_service_based_incident` / `_update_service_based_incident` methods - keyed by service name with `incident_application` left `None`, instead of an application id. These are additive; the existing application-based methods and their callers are untouched.

Closes #6702

## How was this patch tested?

- Added tests to `tests/test_topology.py` following its existing style (real `TopologyProcessor()` against the sqlite `db_session` fixture, not mocks): incident-creation defaults for the new service-based path, the same deleted-incident-is-skipped guard the application path already has, a check that the service-based lookup never picks up an application-based incident, and two `_process_tenant`-level tests (a standalone service alone, and an application + an unrelated standalone service together) proving the actual bug is fixed end to end.
- Couldn't run these locally - same `poetry install`/Windows blocker as my other PRs in this repo, this time compounded by `keep.api.core.db` unconditionally importing most of the optional integrations (GCP/AWS/Azure SDKs, several message queues, etc.) at module scope, which pip's resolver couldn't reconcile in one shot on this platform. So instead I extracted the two actual pieces of changed control flow (the `include_empty_deps` gate and the application-vs-standalone routing in `_process_tenant`) into a standalone script using plain Python objects and confirmed old-vs-new behavior objectively - happy to paste it here if useful.
- `python -m py_compile` and `black --check` pass on both changed files.
