### PR TITLE
fix(iohandler): don't drop empty list/dict/tuple and literal False args to keep.* functions

### DIFF
--- a/keep/iohandler/iohandler.py
+++ b/keep/iohandler/iohandler.py
@@ -331,15 +331,9 @@ class IOHandler:
                                 pass
                     else:
                         _arg = arg.id
-                    # if the value is empty '', we still need to pass it to the function
-                    # also, if the value is 0 or 0.0, we need to pass it to the function
-                    # 0 == False, so we need to check if the value is not False explicitly
-                    if (
-                        _arg
-                        or _arg == ""
-                        or (_arg == 0 or _arg == 0.0)
-                        and _arg is not False
-                    ):
+                    # _arg is None only when parsing produced no value (e.g. nested keep.* call returned nothing).
+                    # Keep all other values: "", 0, 0.0, False, [], {}, (), etc.
+                    if _arg is not None:
                         _args.append(_arg)
 
                 # Parse keyword args


### PR DESCRIPTION
Fixes #6728

## Problem
The argument-filtering guard in `_parse_token` was too complex and incorrectly dropped:
- Empty containers: `[]`, `{}`, `()` (falsy but not caught by special cases)
- Literal `False` (equals `0` in Python, so `_arg == 0` matched but then `_arg is not False` excluded it)

## Solution
Changed the guard to simply `if _arg is not None:` since `_arg` is initialized to `None` and only stays `None` when parsing produces no value (e.g., a nested `keep.*` call that returns nothing). This correctly preserves all legitimate argument values including empty strings, zero, false, and empty collections.
