### PR TITLE
docs: Add FluxCD to service topology supported providers list

### DIFF
--- a/docs/overview/servicetopology.mdx
+++ b/docs/overview/servicetopology.mdx
@@ -58,6 +58,13 @@ The Service Topology feature in Keep provides a visual representation of your se
       <img src="https://img.logo.dev/servicenow.com?token=pk_dfXfZBoKQMGDTIgqu7LvYg" />
     }
   ></Card>
+  <Card
+    title="FluxCD"
+    href="/providers/documentation/fluxcd-provider"
+    icon={
+      <img src="https://img.logo.dev/fluxcd.io?token=pk_dfXfZBoKQMGDTIgqu7LvYg" />
+    }
+  ></Card>
 </CardGroup>
 
 ## Features


### PR DESCRIPTION
Closes #5404

## Description

Adds FluxCD to the list of supported topology providers on the Service Topology documentation page.

The FluxCD provider's own documentation (`docs/providers/documentation/fluxcd-provider.mdx`) confirms it pulls topology data from GitRepositories, HelmRepositories, HelmCharts, OCIRepositories, Buckets, Kustomizations, and HelmReleases. The comparison table in that same doc also confirms topology support alongside ArgoCD, which is already listed.

## Changes
- [x] Added a FluxCD card to the "Supported Providers" section in `docs/overview/servicetopology.mdx`, matching the existing format used by other providers.