### PR TITLE
fix(topology): preserve incident continuity and application identity across topology re-imports

### DIFF
--- a/keep/topologies/topologies_service.py
+++ b/keep/topologies/topologies_service.py
@@ -746,6 +746,15 @@ class TopologiesService:
         all_applications: list[TopologyApplicationDtoIn] = []
         all_dependencies: list[TopologyServiceDependencyCreateRequestDto] = []
         try:
+            # Preserve existing application IDs across imports by name so UUIDs
+            # remain stable and don't orphan topology incidents.
+            existing_applications = {
+                app.name: app.id
+                for app in session.query(TopologyApplication)
+                .filter(TopologyApplication.tenant_id == tenant_id)
+                .all()
+            }
+
             # Clean existing data for the tenant before import
             TopologiesService.clean_before_import(tenant_id=tenant_id, session=session)
 
@@ -756,6 +765,11 @@ class TopologiesService:
                 application["services"] = [
                     {"id": _id} for _id in application["services"]
                 ]
+                if (
+                    not application.get("id")
+                    and application.get("name") in existing_applications
+                ):
+                    application["id"] = existing_applications[application["name"]]
                 all_applications.append(TopologyApplicationDtoIn(**application))
 
             for dependency in topology_data["dependencies"]:

--- a/keep/topologies/topology_processor.py
+++ b/keep/topologies/topology_processor.py
@@ -242,6 +242,22 @@ class TopologyProcessor:
                     Incident.status != IncidentStatus.DELETED.value,
                 )
             ).first()
+            # If application ID changed or is not linked (e.g. historical data or manual topology sync),
+            # fall back to matching an active incident by application name to prevent duplicate incidents.
+            if not incident and application.name:
+                app_incident_name = f"Application incident: {application.name}"
+                incident = session.exec(
+                    select(Incident).where(
+                        Incident.tenant_id == tenant_id,
+                        Incident.user_generated_name == app_incident_name,
+                        Incident.incident_type == "topology",
+                        Incident.status != IncidentStatus.DELETED.value,
+                    )
+                ).first()
+                if incident:
+                    incident.incident_application = application.id
+                    session.add(incident)
+                    session.commit()
             return incident
 
     def _get_topology_data(self, tenant_id: str):

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -386,10 +386,54 @@ def test_import_to_db(db_session):
         assert applications[0].name == "Test Application 1"
         assert applications[1].name == "Test Application 2"
 
+        if i == 0:
+            first_run_app_ids = {app.name: app.id for app in applications}
+        else:
+            # Verify application IDs are preserved across re-imports to prevent duplicate incidents
+            for app in applications:
+                assert app.id == first_run_app_ids[app.name]
+
         dependencies = db_session.exec(select(TopologyServiceDependency)).all()
         assert len(dependencies) == 1
         assert dependencies[0].service_id == 1
         assert dependencies[0].depends_on_service_id == 2
+
+
+def test_get_application_based_incident_fallback_by_name(db_session):
+    from unittest.mock import patch
+
+    tenant_id = SINGLE_TENANT_UUID
+    old_app_id = uuid.uuid4()
+    new_app_id = uuid.uuid4()
+
+    # Existing active incident created under an old application UUID
+    incident = Incident(
+        tenant_id=tenant_id,
+        user_generated_name="Application incident: Test App",
+        user_summary="Test summary",
+        incident_type="topology",
+        incident_application=old_app_id,
+        status=IncidentStatus.FIRING.value,
+        is_candidate=False,
+        is_visible=True,
+        is_predicted=True,
+    )
+    db_session.add(incident)
+    db_session.commit()
+
+    processor = object.__new__(TopologyProcessor)
+    app = TopologyApplication(id=new_app_id, tenant_id=tenant_id, name="Test App")
+
+    with patch(
+        "keep.topologies.topology_processor.existed_or_new_session"
+    ) as mock_session:
+        mock_session.return_value.__enter__.return_value = db_session
+        mock_session.return_value.__exit__.return_value = None
+        found_incident = processor._get_application_based_incident(tenant_id, app)
+
+    assert found_incident is not None
+    assert found_incident.id == incident.id
+    assert found_incident.incident_application == new_app_id
 
 
 def test_create_application_based_incident_sets_is_predicted(db_session):


### PR DESCRIPTION
## What

Fixes #6731.

When importing or re-importing topology YAML, TopologiesService.clean_before_import deletes all existing TopologyApplication records for the tenant. On recreation, create_applications_by_tenant_id assigns brand new internal UUIDs to applications that do not specify explicit IDs in YAML.

Because topology incidents link to applications via Incident.incident_application == application.id, TopologyProcessor._get_application_based_incident fails to locate the active incident for the recreated application and creates a duplicate incident when subsequent alerts fire.

## Fix

1. In TopologiesService.import_to_db, query existing application IDs by (tenant_id, name) before cleanup, and preserve the existing UUID for matching applications.
2. In TopologyProcessor._get_application_based_incident, if lookup by application.id misses, fall back to looking up an active non-deleted topology incident by application name (Application incident: {application.name}) and re-link incident.incident_application = application.id.

## Testing

- Updated tests/test_topology.py::test_import_to_db to assert that application IDs remain stable across successive imports.
- Added test_get_application_based_incident_fallback_by_name to assert that an existing active incident created under a prior application UUID is found and reconnected to the new application ID.
- python -m py_compile passes cleanly on all changed files.

## Checklist

- [x] I have read the Contributing Guide
- [x] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints (black/isort)