### PR TITLE
fix: Enable Zabbix ID deduplication

### DIFF
--- a/keep/providers/zabbix_provider/zabbix_provider.py
+++ b/keep/providers/zabbix_provider/zabbix_provider.py
@@ -63,6 +63,7 @@ class ZabbixProvider(BaseProvider):
     """
 
     PROVIDER_CATEGORY = ["Monitoring"]
+    FINGERPRINT_FIELDS = ["id"]
     KEEP_ZABBIX_WEBHOOK_INTEGRATION_NAME = "keep"  # keep-zabbix
     KEEP_ZABBIX_WEBHOOK_SCRIPT_FILENAME = (
         "zabbix_provider_script.js"  # zabbix mediatype script file

--- a/tests/test_provider_factory.py
+++ b/tests/test_provider_factory.py
@@ -1,11 +1,19 @@
-from datetime import datetime
 import inspect
+from datetime import datetime
 from typing import Optional, Union
+from unittest.mock import patch
+
+import pytest
 
 from keep.api.core.dependencies import SINGLE_TENANT_UUID
 from keep.api.models.db.provider import Provider
 from keep.providers.providers_factory import ProvidersFactory
-from unittest.mock import patch
+
+
+@pytest.fixture
+def isolated_provider_factory_caches(monkeypatch):
+    monkeypatch.setattr(ProvidersFactory, "_loaded_providers_cache", None)
+    monkeypatch.setattr(ProvidersFactory, "_loaded_deduplication_rules_cache", None)
 
 
 class TestProviderFactoryMethodParam:
@@ -65,3 +73,19 @@ def test_provider_factory_is_using_config_key_from_db(db_session):
         ProvidersFactory.get_installed_providers(tenant_id=SINGLE_TENANT_UUID)
         assert mock_secret_manager.return_value.read_secret.call_args[1]['secret_name'] == custom_configuration_key
 
+
+def test_zabbix_default_fingerprint_fields_and_rule(isolated_provider_factory_caches):
+    assert ProvidersFactory._loaded_providers_cache is None
+    assert ProvidersFactory._loaded_deduplication_rules_cache is None
+
+    providers = ProvidersFactory.get_all_providers(ignore_cache_file=True)
+    zabbix_provider = next(
+        provider for provider in providers if provider.type == "zabbix"
+    )
+
+    assert zabbix_provider.default_fingerprint_fields == ["id"]
+
+    default_rules = ProvidersFactory.get_default_deduplication_rules()
+    zabbix_rule = next(rule for rule in default_rules if rule.provider_type == "zabbix")
+
+    assert zabbix_rule.fingerprint_fields == ["id"]


### PR DESCRIPTION
Closes #4767

## 📑 Description

Declare `id` as `ZabbixProvider`'s default fingerprint field, following the existing Graylog, Wazuh, Checkmk, and Dynatrace provider pattern. Keep the change at the provider contract boundary: `ProvidersFactory.get_all_providers()` already copies this declaration into `default_fingerprint_fields`, and `get_default_deduplication_rules()` already turns non-empty values into enabled provider defaults. Add factory-level regression coverage that verifies Zabbix metadata exposes `id` and that the generated Zabbix default rule uses it, while isolating the factory caches so the assertions cannot pass because of earlier test state.

Zabbix alerts carry their problem occurrence identifier in the normalized alert `id`, but `ZabbixProvider` does not declare a default fingerprint field. Provider discovery therefore publishes no default fingerprint fields for Zabbix, so the deduplication service omits the provider's default rule and a Zabbix-only installation can show an empty deduplication page. Graylog already declares `FINGERPRINT_FIELDS = ["id"]` in the current tree, leaving Zabbix as the concrete unresolved case described by the latest human report. The existing custom-rule API workaround confirms that `id` is accepted by the deduplication path once supplied.

## ✅ Checks

- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] All the tests have passed

## ℹ Additional Information

Nothing beyond what is described above.
