### PR TITLE
fix(google_chat): report why a send failed

### DIFF
--- a/keep/providers/google_chat_provider/google_chat_provider.py
+++ b/keep/providers/google_chat_provider/google_chat_provider.py
@@ -1,6 +1,7 @@
 import dataclasses
 import http
 import os
+import re
 import time
 
 import pydantic
@@ -35,6 +36,11 @@ class GoogleChatProvider(BaseProvider):
     PROVIDER_TAGS = ["messaging"]
     PROVIDER_CATEGORY = ["Collaboration"]
 
+    # A webhook URL carries "key" and "token" in its query string, and Google
+    # quotes the request URL in some of its errors, so anything coming back from
+    # the API goes through __redact before it is logged or raised.
+    SENSITIVE_QUERY_PARAMS = ("key", "token")
+
     def __init__(
         self, context_manager: ContextManager, provider_id: str, config: ProviderConfig
     ):
@@ -50,6 +56,12 @@ class GoogleChatProvider(BaseProvider):
         No need to dispose of anything, so just do nothing.
         """
         pass
+
+    @classmethod
+    def __redact(cls, text: str) -> str:
+        """Redact webhook credentials from a text before it is reported."""
+        params = "|".join(cls.SENSITIVE_QUERY_PARAMS)
+        return re.sub(rf"([?&](?:{params})=)[^&\s\"']+", r"\1<redacted>", text)
 
     def _notify(self, message="", **kwargs: dict):
         """
@@ -68,24 +80,29 @@ class GoogleChatProvider(BaseProvider):
             raise ProviderException("Message is required")
 
         def __send_message(url, body, headers, retries=3):
+            last_error = ""
             for attempt in range(retries):
                 try:
                     resp = requests.post(url, json=body, headers=headers)
                     if resp.status_code == http.HTTPStatus.OK:
                         return resp
 
+                    last_error = (
+                        f"status code {resp.status_code}: {self.__redact(resp.text)}"
+                    )
                     self.logger.warning(
-                        f"Attempt {attempt + 1} failed with status code {resp.status_code}"
+                        f"Attempt {attempt + 1} failed with {last_error}"
                     )
 
                 except requests.exceptions.RequestException as e:
-                    self.logger.error(f"Attempt {attempt + 1} failed: {e}")
+                    last_error = self.__redact(str(e))
+                    self.logger.error(f"Attempt {attempt + 1} failed: {last_error}")
 
                 if attempt < retries - 1:
                     time.sleep(1)
 
             raise requests.exceptions.RequestException(
-                f"Failed to notify message after {retries} attempts"
+                f"Failed to notify message after {retries} attempts, last error: {last_error}"
             )
 
         payload = {
@@ -94,11 +111,7 @@ class GoogleChatProvider(BaseProvider):
 
         request_headers = {"Content-Type": "application/json; charset=UTF-8"}
 
-        response = __send_message(webhook_url, body=payload, headers=request_headers)
-        if response.status_code != http.HTTPStatus.OK:
-            raise ProviderException(
-                f"Failed to notify message to Google Chat: {response.text}"
-            )
+        __send_message(webhook_url, body=payload, headers=request_headers)
 
         self.logger.debug("Alert message sent to Google Chat successfully")
         return "Alert message sent to Google Chat successfully"

--- a/tests/providers/google_chat_provider/test_google_chat_provider.py
+++ b/tests/providers/google_chat_provider/test_google_chat_provider.py
@@ -1,0 +1,120 @@
+"""
+Tests for the send path of the Google Chat provider.
+
+The retry loop had no coverage, and covering it is what surfaced the failure
+path: the provider gave up with "Failed to notify message after 3 attempts" and
+dropped whatever Google said about the rejection.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from keep.contextmanager.contextmanager import ContextManager
+from keep.providers.google_chat_provider.google_chat_provider import GoogleChatProvider
+from keep.providers.models.provider_config import ProviderConfig
+
+DEFAULT_WEBHOOK = "https://chat.googleapis.com/v1/spaces/AAAADefault/messages?key=default-key&token=default-token"
+
+
+def _build_provider(**authentication) -> GoogleChatProvider:
+    config = ProviderConfig(
+        name="google-chat",
+        description="Google Chat Output Provider",
+        authentication=authentication,
+    )
+    return GoogleChatProvider(
+        ContextManager(tenant_id="test", workflow_id="test"),
+        provider_id="google-chat",
+        config=config,
+    )
+
+
+@pytest.fixture
+def sleep():
+    with patch("time.sleep") as mocked_sleep:
+        yield mocked_sleep
+
+
+@pytest.fixture
+def post():
+    with patch("requests.post") as mocked_post:
+        mocked_post.return_value = MagicMock(status_code=200, text="{}")
+        yield mocked_post
+
+
+class TestSendingAndRetries:
+    def test_a_successful_send_posts_once(self, post):
+        _build_provider(webhook_url=DEFAULT_WEBHOOK).notify(message="hello")
+
+        assert post.call_count == 1
+
+    def test_a_transient_failure_is_retried_and_then_succeeds(self, post, sleep):
+        post.side_effect = [
+            requests.exceptions.ConnectionError("connection reset"),
+            MagicMock(status_code=200, text="{}"),
+        ]
+
+        _build_provider(webhook_url=DEFAULT_WEBHOOK).notify(message="hello")
+
+        assert post.call_count == 2
+        assert sleep.call_count == 1
+
+    def test_a_persistent_failure_gives_up_after_three_attempts(self, post, sleep):
+        post.return_value = MagicMock(status_code=503, text="service unavailable")
+
+        with pytest.raises(
+            requests.exceptions.RequestException, match="after 3 attempts"
+        ):
+            _build_provider(webhook_url=DEFAULT_WEBHOOK).notify(message="hello")
+
+        assert post.call_count == 3
+        assert sleep.call_count == 2
+
+    def test_the_failing_response_body_reaches_the_caller(self, post, sleep):
+        post.return_value = MagicMock(status_code=400, text="Invalid thread key")
+
+        with pytest.raises(requests.exceptions.RequestException) as exc_info:
+            _build_provider(webhook_url=DEFAULT_WEBHOOK).notify(message="hello")
+
+        assert "status code 400" in str(exc_info.value)
+        assert "Invalid thread key" in str(exc_info.value)
+
+    def test_a_failing_response_body_is_redacted(self, post, sleep):
+        post.return_value = MagicMock(
+            status_code=403, text=f"forbidden for {DEFAULT_WEBHOOK}"
+        )
+
+        with pytest.raises(requests.exceptions.RequestException) as exc_info:
+            _build_provider(webhook_url=DEFAULT_WEBHOOK).notify(message="hello")
+
+        assert "default-key" not in str(exc_info.value)
+        assert "default-token" not in str(exc_info.value)
+        assert "key=<redacted>" in str(exc_info.value)
+
+    def test_a_failing_connection_message_is_redacted(self, post, sleep):
+        post.side_effect = requests.exceptions.ConnectionError(
+            f"cannot connect to {DEFAULT_WEBHOOK}"
+        )
+
+        with pytest.raises(requests.exceptions.RequestException) as exc_info:
+            _build_provider(webhook_url=DEFAULT_WEBHOOK).notify(message="hello")
+
+        assert "default-token" not in str(exc_info.value)
+        assert "token=<redacted>" in str(exc_info.value)
+
+    def test_the_content_type_header_is_sent(self, post):
+        _build_provider(webhook_url=DEFAULT_WEBHOOK).notify(message="hello")
+
+        assert (
+            post.call_args.kwargs["headers"]["Content-Type"]
+            == "application/json; charset=UTF-8"
+        )
+
+    def test_unrelated_workflow_parameters_are_ignored(self, post):
+        _build_provider(webhook_url=DEFAULT_WEBHOOK).notify(
+            message="hello", severity="critical", fingerprint="abc123"
+        )
+
+        assert post.call_args.kwargs["json"] == {"text": "hello"}


### PR DESCRIPTION
## Problem

See #6746. `__send_message` inside `GoogleChatProvider._notify` returns only on 200
and raises otherwise, so the `response.status_code != http.HTTPStatus.OK` check
after the call can never fire and the `ProviderException` under it, the one
carrying `response.text`, is unreachable. A rejected message surfaces as
`Failed to notify message after 3 attempts` with Google's explanation discarded,
so a malformed payload and a revoked key look the same from the workflow.

## Fix

- The dead check is gone, and the last error from the retry loop — status code
  plus response body, or the connection error — now travels with the exception.
- Errors are redacted on the way out. Google quotes the request URL in some of
  its errors, and a Chat webhook URL carries `key` and `token` in its query
  string. The connection errors already being logged went out with the URL
  intact; they go through the same redaction now.

Behaviour on success is unchanged.

## Tests

The retry loop had no coverage at all, which is what hid this.
`tests/providers/google_chat_provider/test_google_chat_provider.py` is new and
covers one attempt on success, a transient failure retried and then succeeding,
three attempts before giving up, the body reaching the caller, redaction of both
a response body and a connection error, the content type header, and unrelated
workflow parameters being ignored. 8 tests, all passing.

Fixes #6746
