### PR TITLE
fix(jiraonprem): stop resetting the priority on every update

### DIFF
--- a/keep/providers/jiraonprem_provider/jiraonprem_provider.py
+++ b/keep/providers/jiraonprem_provider/jiraonprem_provider.py
@@ -521,7 +521,7 @@ class JiraonpremProvider(BaseProvider):
         labels: List[str] = None,
         components: List[str] = None,
         custom_fields: dict = None,
-        priority: str = "Medium",
+        priority: str = None,
         **kwargs: dict,
     ):
         """
@@ -548,6 +548,9 @@ class JiraonpremProvider(BaseProvider):
                     labels=labels,
                     components=components,
                     custom_fields=custom_fields,
+                    # __update_issue writes whatever priority it is handed, so the
+                    # workflow's value goes through as it is: None leaves the ticket
+                    # with the priority it already has
                     priority=priority,
                     **kwargs,
                 )
@@ -574,7 +577,9 @@ class JiraonpremProvider(BaseProvider):
                 labels=labels,
                 components=components,
                 custom_fields=custom_fields,
-                priority=priority,
+                # the create screen always carries a priority field, so a new issue
+                # falls back to Medium when the workflow names none
+                priority=priority or "Medium",
                 **kwargs,
             )
             result["ticket_url"] = f"{self.jira_host}/browse/{result['issue']['key']}"

--- a/tests/test_jira_provider.py
+++ b/tests/test_jira_provider.py
@@ -355,3 +355,54 @@ class TestJiraProvider:
 
                 # If we get here without the "string indices must be integers" error, the fix worked
                 assert result is not None
+
+    @patch("requests.put")
+    @patch("requests.get")
+    def test_jiraonprem_notify_update_leaves_priority_alone(
+        self, mock_get, mock_put, jiraonprem_provider
+    ):
+        """Test that an update that never mentioned priority does not set it"""
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"key": "TEST-1"}
+        mock_put.return_value.status_code = 204
+
+        jiraonprem_provider._notify(summary="Updated", issue_id="TEST-1")
+
+        update = mock_put.call_args[1]["json"]["update"]
+        assert "priority" not in update
+        assert update["summary"] == [{"set": "Updated"}]
+
+    @patch("requests.put")
+    @patch("requests.get")
+    def test_jiraonprem_notify_update_sets_priority_when_asked(
+        self, mock_get, mock_put, jiraonprem_provider
+    ):
+        """Test that an update sets the priority the workflow named"""
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"key": "TEST-1"}
+        mock_put.return_value.status_code = 204
+
+        jiraonprem_provider._notify(
+            summary="Updated", issue_id="TEST-1", priority="High"
+        )
+
+        update = mock_put.call_args[1]["json"]["update"]
+        assert update["priority"] == [{"set": {"name": "High"}}]
+
+    @patch("requests.post")
+    def test_jiraonprem_notify_create_defaults_to_medium(
+        self, mock_post, jiraonprem_provider
+    ):
+        """Test that a created issue gets Medium when the workflow names no priority"""
+        mock_post.return_value.status_code = 201
+        mock_post.return_value.json.return_value = {"key": "TEST-2", "id": "2"}
+
+        jiraonprem_provider._notify(
+            summary="Created",
+            description="Created by Keep",
+            issue_type="Task",
+            project_key="TEST",
+        )
+
+        fields = mock_post.call_args[1]["json"]["fields"]
+        assert fields["priority"] == {"name": "Medium"}


### PR DESCRIPTION
## Problem

See #6751. `_notify` defaults `priority` to `"Medium"` and passes it to
`__update_issue`, which writes the field for any truthy value. An update about
the summary rewrites the priority of a ticket somebody escalated by hand.

## Fix

`priority` defaults to `None` and reaches `__update_issue` as it came, so the
update writes the field only for a value the workflow named. The create path
passes `priority or "Medium"`, so a new issue keeps the same default it has
today.

## Tests

`tests/test_jira_provider.py` grows to 12 tests, all passing: an update with no
priority leaves the field out of the request body, an update naming one sets it,
and a create with no priority still sends Medium.

## Note on the other Jira PRs

#6752, #6753 and #6754 report three more gaps in the same two providers, each
with a PR of its own. The on-prem transitions one edits the same `_notify`
signature line as this PR, so whichever of the two lands second needs a one line
resolution. Everything else between the four is additive.

Fixes #6751
