### PR TITLE
feat(jira): search issues by JQL from both providers

### DIFF
--- a/docs/snippets/providers/jira-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/jira-snippet-autogenerated.mdx
@@ -33,6 +33,9 @@ steps:
       with:
         ticket_id: {value}  # The ticket id of the issue, optional.
         board_id: {value}  # The board id of the issue.
+        jql: {value}  # A JQL query to search the issues with.
+        max_results: {value}  # How many issues to return alongside the total. Zero, the default, returns the total and an empty issues list.
+        fields: {value}  # Comma separated Jira fields to return for each issue, or a list of them. All fields when empty.
 ```
 
 
@@ -63,6 +66,7 @@ Check the following workflow examples:
 - [incident-enrich.yaml](https://github.com/keephq/keep/blob/main/examples/workflows/incident-enrich.yaml)
 - [jira-create-ticket-on-alert.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira-create-ticket-on-alert.yml)
 - [jira-transition-on-resolved.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira-transition-on-resolved.yml)
+- [jira_cloud_stale_issues.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira_cloud_stale_issues.yml)
 - [jira_on_prem.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira_on_prem.yml)
 - [jira_on_prem_stale_issues.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira_on_prem_stale_issues.yml)
 - [test_jira_create_with_custom_fields.yml](https://github.com/keephq/keep/blob/main/examples/workflows/test_jira_create_with_custom_fields.yml)

--- a/docs/snippets/providers/jira-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/jira-snippet-autogenerated.mdx
@@ -64,6 +64,7 @@ Check the following workflow examples:
 - [jira-create-ticket-on-alert.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira-create-ticket-on-alert.yml)
 - [jira-transition-on-resolved.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira-transition-on-resolved.yml)
 - [jira_on_prem.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira_on_prem.yml)
+- [jira_on_prem_stale_issues.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira_on_prem_stale_issues.yml)
 - [test_jira_create_with_custom_fields.yml](https://github.com/keephq/keep/blob/main/examples/workflows/test_jira_create_with_custom_fields.yml)
 - [test_jira_custom_fields_fix.yml](https://github.com/keephq/keep/blob/main/examples/workflows/test_jira_custom_fields_fix.yml)
 - [update_jira_ticket.yml](https://github.com/keephq/keep/blob/main/examples/workflows/update_jira_ticket.yml)

--- a/docs/snippets/providers/jiraonprem-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/jiraonprem-snippet-autogenerated.mdx
@@ -32,6 +32,9 @@ steps:
       with:
         ticket_id: {value}  # The ticket id.
         board_id: {value}  # The board id.
+        jql: {value}  # A JQL query to search the issues with.
+        max_results: {value}  # How many issues to return alongside the total. Zero, the default, returns the total and an empty issues list.
+        fields: {value}  # Comma separated Jira fields to return for each issue, or a list of them. All fields when empty.
 ```
 
 
@@ -57,5 +60,6 @@ actions:
 
 
 
-Check the following workflow example:
+Check the following workflow examples:
 - [jira_on_prem.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira_on_prem.yml)
+- [jira_on_prem_stale_issues.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira_on_prem_stale_issues.yml)

--- a/docs/snippets/providers/slack-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/slack-snippet-autogenerated.mdx
@@ -43,6 +43,7 @@ Check the following workflow examples:
 - [gcp_logging_open_ai.yaml](https://github.com/keephq/keep/blob/main/examples/workflows/gcp_logging_open_ai.yaml)
 - [ifelse.yml](https://github.com/keephq/keep/blob/main/examples/workflows/ifelse.yml)
 - [incident-tier-escalation.yml](https://github.com/keephq/keep/blob/main/examples/workflows/incident-tier-escalation.yml)
+- [jira_cloud_stale_issues.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira_cloud_stale_issues.yml)
 - [jira_on_prem_stale_issues.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira_on_prem_stale_issues.yml)
 - [new-auth0-users-monitor.yml](https://github.com/keephq/keep/blob/main/examples/workflows/new-auth0-users-monitor.yml)
 - [new_github_stars.yml](https://github.com/keephq/keep/blob/main/examples/workflows/new_github_stars.yml)

--- a/docs/snippets/providers/slack-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/slack-snippet-autogenerated.mdx
@@ -43,6 +43,7 @@ Check the following workflow examples:
 - [gcp_logging_open_ai.yaml](https://github.com/keephq/keep/blob/main/examples/workflows/gcp_logging_open_ai.yaml)
 - [ifelse.yml](https://github.com/keephq/keep/blob/main/examples/workflows/ifelse.yml)
 - [incident-tier-escalation.yml](https://github.com/keephq/keep/blob/main/examples/workflows/incident-tier-escalation.yml)
+- [jira_on_prem_stale_issues.yml](https://github.com/keephq/keep/blob/main/examples/workflows/jira_on_prem_stale_issues.yml)
 - [new-auth0-users-monitor.yml](https://github.com/keephq/keep/blob/main/examples/workflows/new-auth0-users-monitor.yml)
 - [new_github_stars.yml](https://github.com/keephq/keep/blob/main/examples/workflows/new_github_stars.yml)
 - [notify-new-trello-card.yml](https://github.com/keephq/keep/blob/main/examples/workflows/notify-new-trello-card.yml)

--- a/examples/workflows/jira_cloud_stale_issues.yml
+++ b/examples/workflows/jira_cloud_stale_issues.yml
@@ -1,0 +1,29 @@
+workflow:
+  id: jira-cloud-stale-issues
+  name: Jira Cloud Stale Issue Reporter
+  description: Searches Jira Cloud for issues left open past a threshold and posts one Slack message per issue.
+  triggers:
+    - type: interval
+      value: 3600
+  consts:
+    stale_after: "-3d"
+  owners: []
+  services: []
+  steps:
+    - name: search-stale-issues
+      provider:
+        config: "{{ providers.jira }}"
+        type: jira
+        with:
+          jql: "project = SA AND status = Open AND created <= {{ consts.stale_after }}"
+          max_results: 50
+          # Without this every issue arrives with all of its fields, custom ones included.
+          fields: summary,status,created,assignee
+  actions:
+    - name: report-stale-issue
+      foreach: "{{ steps.search-stale-issues.results.issues }}"
+      provider:
+        config: "{{ providers.slack }}"
+        type: slack
+        with:
+          message: "{{ foreach.value.key }} is open since {{ foreach.value.fields.created }}: {{ foreach.value.fields.summary }}"

--- a/examples/workflows/jira_on_prem_stale_issues.yml
+++ b/examples/workflows/jira_on_prem_stale_issues.yml
@@ -1,0 +1,29 @@
+workflow:
+  id: jira-onprem-stale-issues
+  name: Jira On-Prem Stale Issue Reporter
+  description: Searches on-premises Jira for issues left open past a threshold and posts one Slack message per issue.
+  triggers:
+    - type: interval
+      value: 3600
+  consts:
+    stale_after: "-3d"
+  owners: []
+  services: []
+  steps:
+    - name: search-stale-issues
+      provider:
+        config: "{{ providers.jira }}"
+        type: jiraonprem
+        with:
+          jql: "project = SA AND status = Open AND created <= {{ consts.stale_after }}"
+          max_results: 50
+          # Without this every issue arrives with all of its fields, custom ones included.
+          fields: summary,status,created,assignee
+  actions:
+    - name: report-stale-issue
+      foreach: "{{ steps.search-stale-issues.results.issues }}"
+      provider:
+        config: "{{ providers.slack }}"
+        type: slack
+        with:
+          message: "{{ foreach.value.key }} is open since {{ foreach.value.fields.created }}: {{ foreach.value.fields.summary }}"

--- a/keep/providers/jira_provider/jira_provider.py
+++ b/keep/providers/jira_provider/jira_provider.py
@@ -649,7 +649,15 @@ class JiraProvider(BaseProvider):
             }
             raise ProviderException(f"Failed to notify jira: {e} - Params: {context}")
 
-    def _query(self, ticket_id="", board_id="", **kwargs: dict):
+    def _query(
+        self,
+        ticket_id="",
+        board_id="",
+        jql="",
+        max_results=0,
+        fields="",
+        **kwargs: dict,
+    ):
         """
         API for fetching issues:
         https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-rest-agile-1-0-board-boardid-issue-get
@@ -657,8 +665,67 @@ class JiraProvider(BaseProvider):
         Args:
             ticket_id (str): The ticket id of the issue, optional.
             board_id (str): The board id of the issue.
+            jql (str): A JQL query to search the issues with.
+            max_results (int): How many issues to return alongside the total. Zero, the default, returns the total and an empty issues list.
+            fields (str): Comma separated Jira fields to return for each issue, or a list of them. All fields when empty.
         """
-        if not ticket_id:
+        if jql:
+            try:
+                max_results = int(max_results)
+            except (TypeError, ValueError):
+                raise ProviderException(
+                    f"{self.__class__.__name__} got a non-numeric max_results: {max_results!r}"
+                )
+
+            if isinstance(fields, list):
+                fields = ",".join(fields)
+
+            issues = []
+            total = None
+
+            if max_results:
+                query_params = {"jql": jql, "maxResults": max_results}
+                if fields:
+                    query_params["fields"] = fields
+
+                # /rest/api/2/search is on its way out on Cloud, search/jql replaces it
+                request_url = self.__get_url(
+                    paths=["search", "jql"], query_params=query_params
+                )
+                response = requests.get(
+                    request_url, auth=self.__get_auth(), verify=False
+                )
+                if not response.ok:
+                    raise ProviderException(
+                        f"{self.__class__.__name__} failed to fetch data from Jira: {response.text}"
+                    )
+                page = response.json()
+                issues = page.get("issues", [])
+                # A page Jira did not truncate is the whole answer, and its length
+                # is the total. Jira marks a truncated page with a nextPageToken; a
+                # page filled to max_results counts as truncated too, since a
+                # deployment that omits the token would otherwise pass a capped
+                # number off as the total.
+                if not page.get("nextPageToken") and len(issues) < max_results:
+                    total = len(issues)
+
+            if total is None:
+                # search/jql reports no total of its own, so the count comes from
+                # the endpoint next to it
+                count_response = requests.post(
+                    self.__get_url(paths=["search", "approximate-count"]),
+                    json={"jql": jql},
+                    auth=self.__get_auth(),
+                    verify=False,
+                )
+                if not count_response.ok:
+                    raise ProviderException(
+                        f"{self.__class__.__name__} failed to fetch data from Jira: {count_response.text}"
+                    )
+                total = count_response.json().get("count", 0)
+
+            return {"total": total, "jql": jql, "issues": issues}
+        elif not ticket_id:
             request_url = f"{self.jira_host}/rest/agile/1.0/board/{board_id}/issue"
             response = requests.get(request_url, auth=self.__get_auth(), verify=False)
             if not response.ok:

--- a/keep/providers/jiraonprem_provider/jiraonprem_provider.py
+++ b/keep/providers/jiraonprem_provider/jiraonprem_provider.py
@@ -590,7 +590,15 @@ class JiraonpremProvider(BaseProvider):
             }
             raise ProviderException(f"Failed to notify jira: {e} - Params: {context}")
 
-    def _query(self, ticket_id="", board_id="", **kwargs: dict):
+    def _query(
+        self,
+        ticket_id="",
+        board_id="",
+        jql="",
+        max_results=0,
+        fields="",
+        **kwargs: dict,
+    ):
         """
         API for fetching issues:
         https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-rest-agile-1-0-board-boardid-issue-get
@@ -598,8 +606,47 @@ class JiraonpremProvider(BaseProvider):
         Args:
             ticket_id (str): The ticket id.
             board_id (str): The board id.
+            jql (str): A JQL query to search the issues with.
+            max_results (int): How many issues to return alongside the total. Zero, the default, returns the total and an empty issues list.
+            fields (str): Comma separated Jira fields to return for each issue, or a list of them. All fields when empty.
         """
-        if not ticket_id:
+        if jql:
+            try:
+                max_results = int(max_results)
+            except (TypeError, ValueError):
+                raise ProviderException(
+                    f"{self.__class__.__name__} got a non-numeric max_results: {max_results!r}"
+                )
+
+            if isinstance(fields, list):
+                fields = ",".join(fields)
+
+            # Jira returns the total whatever maxResults is, and no issues at all
+            # when it is zero.
+            query_params = {"jql": jql, "maxResults": max_results}
+            if fields:
+                query_params["fields"] = fields
+
+            request_url = self.__get_url(paths=["search"], query_params=query_params)
+            response = requests.get(
+                request_url,
+                headers=self.__get_auth_header(),
+                verify=self.authentication_config.verify,
+                timeout=10,
+            )
+            if not response.ok:
+                raise ProviderException(
+                    f"{self.__class__.__name__} failed to fetch data from Jira: {response.text}"
+                )
+            search = response.json()
+            # issues is always a list, empty when max_results is zero, so a foreach
+            # over it in a workflow is a no-op and never a missing key
+            return {
+                "total": search.get("total", 0),
+                "jql": jql,
+                "issues": search.get("issues", []),
+            }
+        elif not ticket_id:
             request_url = (
                 f"https://{self.jira_host}/rest/agile/1.0/board/{board_id}/issue"
             )

--- a/tests/test_jira_provider.py
+++ b/tests/test_jira_provider.py
@@ -440,3 +440,150 @@ class TestJiraProvider:
             jiraonprem_provider.query(jql="status = Open", max_results="fifty")
 
         mock_get.assert_not_called()
+
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_jira_query_with_jql(self, mock_get, mock_post, jira_provider):
+        """Test that a jql query counts the matching issues without listing them"""
+        mock_post.return_value.ok = True
+        mock_post.return_value.json.return_value = {"count": 7}
+
+        jql = "project = TEST AND status = Open"
+        result = jira_provider.query(jql=jql)
+
+        assert result == {"total": 7, "jql": jql, "issues": []}
+
+        # the total comes from approximate-count, and with max_results at zero no
+        # issues are fetched at all
+        assert "/rest/api/2/search/approximate-count" in mock_post.call_args[0][0]
+        assert mock_post.call_args[1]["json"] == {"jql": jql}
+        mock_get.assert_not_called()
+
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_jira_query_with_jql_returning_issues(
+        self, mock_get, mock_post, jira_provider
+    ):
+        """Test that max_results asks Jira for the issues and returns them"""
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = {
+            "issues": [{"key": "TEST-1"}, {"key": "TEST-2"}]
+        }
+
+        result = jira_provider.query(jql="status = Open", max_results=50)
+
+        assert result["total"] == 2
+        assert [issue["key"] for issue in result["issues"]] == ["TEST-1", "TEST-2"]
+
+        request_url = mock_get.call_args[0][0]
+        # /rest/api/2/search is deprecated on Cloud, search/jql replaces it.
+        assert "/rest/api/2/search/jql" in request_url
+        assert "maxResults=50" in request_url
+        # Jira did not truncate the page, so it is the whole answer and counting it
+        # again over the network would be a wasted request.
+        mock_post.assert_not_called()
+
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_jira_query_with_jql_counts_a_truncated_page(
+        self, mock_get, mock_post, jira_provider
+    ):
+        """Test that the total of a truncated page comes from the count endpoint"""
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = {
+            "issues": [{"key": "TEST-1"}, {"key": "TEST-2"}],
+            "nextPageToken": "next-page",
+        }
+        mock_post.return_value.ok = True
+        mock_post.return_value.json.return_value = {"count": 91}
+
+        result = jira_provider.query(jql="status = Open", max_results=2)
+
+        assert result["total"] == 91
+        assert [issue["key"] for issue in result["issues"]] == ["TEST-1", "TEST-2"]
+        assert "/rest/api/2/search/approximate-count" in mock_post.call_args[0][0]
+
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_jira_query_with_jql_counts_a_page_filled_to_the_brim(
+        self, mock_get, mock_post, jira_provider
+    ):
+        """Test that a page as long as max_results is not taken for the total"""
+        mock_get.return_value.ok = True
+        # no nextPageToken, which a deployment may omit, so a full page is counted
+        # instead of being passed off as a total capped at max_results
+        mock_get.return_value.json.return_value = {"issues": [{"key": "TEST-1"}]}
+        mock_post.return_value.ok = True
+        mock_post.return_value.json.return_value = {"count": 12}
+
+        result = jira_provider.query(jql="status = Open", max_results=1)
+
+        assert result["total"] == 12
+        assert "/rest/api/2/search/approximate-count" in mock_post.call_args[0][0]
+
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_jira_query_with_jql_issue_fetch_failure(
+        self, mock_get, mock_post, jira_provider
+    ):
+        """Test that a failed search raises with Jira's error text"""
+        mock_get.return_value.ok = False
+        mock_get.return_value.text = "Error in the JQL Query"
+
+        with pytest.raises(ProviderException, match="Error in the JQL Query"):
+            jira_provider.query(jql="status = Nope", max_results=10)
+
+        mock_post.assert_not_called()
+
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_jira_query_with_jql_fields(self, mock_get, mock_post, jira_provider):
+        """Test that fields are passed through, as a string or as a list"""
+        mock_post.return_value.ok = True
+        mock_post.return_value.json.return_value = {"count": 1}
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = {"issues": [{}]}
+
+        jira_provider.query(jql="status = Open", max_results=2, fields="summary,status")
+        assert "fields=summary%2Cstatus" in mock_get.call_args[0][0]
+
+        jira_provider.query(
+            jql="status = Open", max_results=2, fields=["summary", "status"]
+        )
+        assert "fields=summary%2Cstatus" in mock_get.call_args[0][0]
+
+    @patch("requests.post")
+    def test_jira_query_with_jql_failure(self, mock_post, jira_provider):
+        """Test that a failed jql query raises with Jira's error text"""
+        mock_post.return_value.ok = False
+        mock_post.return_value.text = "Error in the JQL Query"
+
+        with pytest.raises(ProviderException, match="Error in the JQL Query"):
+            jira_provider.query(jql="status = Nope")
+
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_jira_query_with_ticket_id_fetches_the_issue(
+        self, mock_get, mock_post, jira_provider
+    ):
+        """Test that a ticket_id query fetches that issue by key"""
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = {"key": "TEST-1", "id": "1"}
+
+        result = jira_provider.query(ticket_id="TEST-1")
+
+        assert result == {"issue": {"key": "TEST-1", "id": "1"}}
+        assert "/rest/api/2/issue/TEST-1" in mock_get.call_args[0][0]
+        mock_post.assert_not_called()
+
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_jira_query_with_non_numeric_max_results(
+        self, mock_get, mock_post, jira_provider
+    ):
+        """Test that a max_results that is not a number is refused before the request"""
+        with pytest.raises(ProviderException, match="non-numeric max_results"):
+            jira_provider.query(jql="status = Open", max_results="fifty")
+
+        mock_get.assert_not_called()
+        mock_post.assert_not_called()

--- a/tests/test_jira_provider.py
+++ b/tests/test_jira_provider.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from keep.contextmanager.contextmanager import ContextManager
+from keep.exceptions.provider_exception import ProviderException
 from keep.providers.jira_provider.jira_provider import JiraProvider
 from keep.providers.jiraonprem_provider.jiraonprem_provider import JiraonpremProvider
 from keep.providers.models.provider_config import ProviderConfig
@@ -355,3 +356,87 @@ class TestJiraProvider:
 
                 # If we get here without the "string indices must be integers" error, the fix worked
                 assert result is not None
+
+    @patch("requests.get")
+    def test_jiraonprem_query_with_jql(self, mock_get, jiraonprem_provider):
+        """Test that a jql query returns only the count of matching issues"""
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = {"total": 7, "issues": []}
+
+        jql = "project = TEST AND status = Open"
+        result = jiraonprem_provider.query(jql=jql)
+
+        # issues is always present, empty here, so a foreach over it in a workflow
+        # that left max_results out iterates over nothing
+        assert result == {"total": 7, "jql": jql, "issues": []}
+
+        request_url = mock_get.call_args[0][0]
+        assert "/rest/api/2/search" in request_url
+        assert "maxResults=0" in request_url
+        assert "fields" not in request_url
+        assert mock_get.call_args[1]["verify"] is False
+
+    @patch("requests.get")
+    def test_jiraonprem_query_with_jql_failure(self, mock_get, jiraonprem_provider):
+        """Test that a failed jql query raises with Jira's error text"""
+        mock_get.return_value.ok = False
+        mock_get.return_value.text = "Error in the JQL Query"
+
+        with pytest.raises(ProviderException, match="Error in the JQL Query"):
+            jiraonprem_provider.query(jql="status = Nope")
+
+    @patch("requests.get")
+    def test_jiraonprem_query_with_ticket_id_fetches_the_issue(
+        self, mock_get, jiraonprem_provider
+    ):
+        """Test that a ticket_id query fetches that issue by key"""
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = {"key": "TEST-1", "id": "1"}
+
+        result = jiraonprem_provider.query(ticket_id="TEST-1")
+
+        assert result == {"issue": {"key": "TEST-1", "id": "1"}}
+        assert "/rest/api/2/issue/TEST-1" in mock_get.call_args[0][0]
+
+    @patch("requests.get")
+    def test_jiraonprem_query_with_jql_returning_issues(
+        self, mock_get, jiraonprem_provider
+    ):
+        """Test that max_results asks Jira for the issues and returns them"""
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = {
+            "total": 2,
+            "issues": [{"key": "TEST-1"}, {"key": "TEST-2"}],
+        }
+
+        result = jiraonprem_provider.query(jql="status = Open", max_results=50)
+
+        assert result["total"] == 2
+        assert [issue["key"] for issue in result["issues"]] == ["TEST-1", "TEST-2"]
+        assert "maxResults=50" in mock_get.call_args[0][0]
+
+    @patch("requests.get")
+    def test_jiraonprem_query_with_jql_fields(self, mock_get, jiraonprem_provider):
+        """Test that fields are passed through, as a string or as a list"""
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = {"total": 1, "issues": [{}]}
+
+        jiraonprem_provider.query(
+            jql="status = Open", max_results=1, fields="summary,status"
+        )
+        assert "fields=summary%2Cstatus" in mock_get.call_args[0][0]
+
+        jiraonprem_provider.query(
+            jql="status = Open", max_results=1, fields=["summary", "status"]
+        )
+        assert "fields=summary%2Cstatus" in mock_get.call_args[0][0]
+
+    @patch("requests.get")
+    def test_jiraonprem_query_with_non_numeric_max_results(
+        self, mock_get, jiraonprem_provider
+    ):
+        """Test that a max_results that is not a number is refused before the request"""
+        with pytest.raises(ProviderException, match="non-numeric max_results"):
+            jiraonprem_provider.query(jql="status = Open", max_results="fifty")
+
+        mock_get.assert_not_called()


### PR DESCRIPTION
## Problem

See #6753. `_query` can fetch one issue by key or count a board, and it drops the
issues it fetched. A workflow cannot ask a question narrower than "how many
issues does this board hold".

## Fix

Two commits, one per provider. `_query` takes `jql`, `max_results` and `fields`
and returns `{"total": ..., "jql": ..., "issues": [...]}`. The `ticket_id` and
`board_id` paths are untouched.

On Server and Data Center one GET to `/rest/api/2/search` carries `jql`,
`maxResults` and the optional `fields`, and the response holds the total and the
page together. `issues` is always a list, empty when `max_results` is zero, so a
`foreach` over it is a no-op rather than a missing key.

Cloud needs two endpoints and tries to spend one request. `search/jql` reports no
total, so the count comes from `search/approximate-count`; the search is skipped
when `max_results` is zero, and the count is skipped when the page Jira returned
is the whole answer. A page counts as whole when it carries no `nextPageToken`
and is shorter than `max_results`, so a deployment that omits the token cannot
pass a capped number off as the total.

In both providers `max_results` goes through `int()`, since a workflow hands over
strings, and a value that is not a number raises a `ProviderException` naming it.
`fields` takes a list or a comma separated string.

## Tests

`tests/test_jira_provider.py` grows to 24 tests, all passing: the count-only
default, a page of issues, `fields` reaching the request, a non-numeric
`max_results`, a failed request on either endpoint, and the `ticket_id` path
behaving as before. The Cloud tests also cover the request the provider does not
send, both for a whole page and for one filled to `max_results`.

## Docs

Two example workflows, `examples/workflows/jira_cloud_stale_issues.yml` and
`examples/workflows/jira_on_prem_stale_issues.yml`, and the snippets regenerated
from the new docstrings. Both examples post their results to Slack, which is why
the Slack snippet's example list picks them up as well.

## Note on the other Jira PRs

#6755, #6756 and #6757 cover the other three reports on these providers. This PR
shares only `tests/test_jira_provider.py` with them, where the blocks are added
side by side.

Fixes #6753
