### PR TITLE
fix: pass falsy args to keep.* template functions

### DIFF
--- a/keep/iohandler/iohandler.py
+++ b/keep/iohandler/iohandler.py
@@ -331,15 +331,10 @@ class IOHandler:
                                 pass
                     else:
                         _arg = arg.id
-                    # if the value is empty '', we still need to pass it to the function
-                    # also, if the value is 0 or 0.0, we need to pass it to the function
-                    # 0 == False, so we need to check if the value is not False explicitly
-                    if (
-                        _arg
-                        or _arg == ""
-                        or (_arg == 0 or _arg == 0.0)
-                        and _arg is not False
-                    ):
+                    # _arg is None only when no parsing branch matched (no real value produced)
+                    # All other values — including "", 0, False, [], {}, () — are valid
+                    # and must be passed to the function
+                    if _arg is not None:
                         _args.append(_arg)
 
                 # Parse keyword args


### PR DESCRIPTION
## Problem

`IOHandler._parse_token` silently drops falsy-but-valid arguments to `keep.*` template functions. When a function call resolves to `[]`, `{}`, `()`, `False`, or `0`, the argument is silently dropped instead of being passed to the function.

The current condition handles `""`, `0`, and `0.0` but still drops `[]`, `{}`, `()`, and `False` due to short-circuit evaluation.

## Fix

Replace the complex condition with `if _arg is not None:`.

`_arg` is initialized to `None` and stays `None` only when no parsing branch matched (no real value produced). All other values including `""`, `0`, `False`, `[]`, `{}`, `()` are valid parsed results that should be passed through.

## Testing

The edge cases that were previously dropped:
- Empty list
- Empty dict
- Empty tuple
- Boolean False
- Zero

Fixes #6728
