### PR TITLE
fix: use ternary for foreach single-item unwrap

### DIFF
--- a/keep/step/step.py
+++ b/keep/step/step.py
@@ -127,7 +127,7 @@ class Step:
             foreach_items.append(items)
         if not foreach_items:
             return []
-        return len(foreach_items) == 1 and foreach_items[0] or zip(*foreach_items)
+        return foreach_items[0] if len(foreach_items) == 1 else zip(*foreach_items)
 
     def _run_foreach(self):
         """Evaluate the action for each item, when using the `foreach` attribute (see foreach.md)"""


### PR DESCRIPTION
## Problem

`Step._get_foreach_items` uses the Python `and`/`or` idiom to unwrap a single-item list:

```python
return len(foreach_items) == 1 and foreach_items[0] or zip(*foreach_items)
```

When `foreach_items[0]` is a falsy value like `0`, `False`, `""`, `[]`, or `{}`, the `and` short-circuits to that falsy value, then `or` falls through to `zip(*foreach_items)`. This causes a `TypeError` because scalars are not iterable.

## Fix

Replace with a proper ternary expression:

```python
return foreach_items[0] if len(foreach_items) == 1 else zip(*foreach_items)
```

This branches solely on the count of foreach items, not on the truthiness of the resolved value.

Fixes #6721
