### PR TITLE
fix: record original sub_rule for null CEL correlation comparison

### DIFF
--- a/keep/rulesengine/rulesengine.py
+++ b/keep/rulesengine/rulesengine.py
@@ -480,6 +480,7 @@ class RulesEngine:
             #          So we need to replace "null" with ""
             #
             #          TODO: it works for strings now, but we need to add support on list/dict when needed
+            original_sub_rule = sub_rule
             if "null" in sub_rule:
                 sub_rule = sub_rule.replace("null", '""')
             ast = self.env.compile(sub_rule)
@@ -501,13 +502,13 @@ class RulesEngine:
                             sub_rule, prgm, activation, event
                         )
                         if coerced:
-                            sub_rules_matched.append(sub_rule)
+                            sub_rules_matched.append(original_sub_rule)
                             continue
                     except Exception:
                         pass
                 raise
             if r:
-                sub_rules_matched.append(sub_rule)
+                sub_rules_matched.append(original_sub_rule)
         # no subrules matched
         return sub_rules_matched
 


### PR DESCRIPTION
## Problem

Correlation rules with `create_on: all` never complete when the CEL definition contains `null`. The incident stays hidden regardless of how many alerts arrive.

Root cause: `_check_if_rule_apply` rewrites `null` to `""` for CEL evaluation, but records the rewritten version in `sub_rules_matched`. The comparison in `_process_event_for_history_based_rule` takes its expectations from `rule.definition_cel` which still contains `null`. The sets can never be equal:

```
all_sub_rules : {'service != null', 'source == "sentry"'}
matched       : {'service != ""',   'source == "sentry"'}
equal?        : False
```

## Fix

Save the original `sub_rule` before the null rewrite and use it when recording matches. The rewritten version is still used for CEL evaluation (which is necessary to avoid the `CELEvalError`), but the original expression is what gets recorded for comparison.

Fixes #6694
