### PR TITLE
fix: raise when all SignalFx incidents fail to format

### DIFF
--- a/keep/providers/signalfx_provider/signalfx_provider.py
+++ b/keep/providers/signalfx_provider/signalfx_provider.py
@@ -153,13 +153,20 @@ class SignalfxProvider(BaseProvider):
         incidents = response.json()
         # Map SignalFx alert data to AlertDto objects
         alerts = []
+        total = len(incidents)
+        failed = 0
         # TODO: incident may have more than one alert?
         for incident in incidents:
             try:
                 alerts.append(self._format_alert_get_alert(incident))
             except Exception as e:
+                failed += 1
                 self.logger.error(f"Failed to format SignalFx alert: {e}")
-                pass
+
+        if total > 0 and failed == total:
+            raise Exception(
+                f"Failed to format all {total} SignalFx incidents"
+            )
 
         return alerts
 

--- a/keep/rulesengine/rulesengine.py
+++ b/keep/rulesengine/rulesengine.py
@@ -480,6 +480,7 @@ class RulesEngine:
             #          So we need to replace "null" with ""
             #
             #          TODO: it works for strings now, but we need to add support on list/dict when needed
+            original_sub_rule = sub_rule
             if "null" in sub_rule:
                 sub_rule = sub_rule.replace("null", '""')
             ast = self.env.compile(sub_rule)
@@ -501,13 +502,13 @@ class RulesEngine:
                             sub_rule, prgm, activation, event
                         )
                         if coerced:
-                            sub_rules_matched.append(sub_rule)
+                            sub_rules_matched.append(original_sub_rule)
                             continue
                     except Exception:
                         pass
                 raise
             if r:
-                sub_rules_matched.append(sub_rule)
+                sub_rules_matched.append(original_sub_rule)
         # no subrules matched
         return sub_rules_matched
 


### PR DESCRIPTION
## Problem

SignalFx `_get_alerts` silently returns `[]` when every incident fails to format. This masks errors — callers get an empty list with no indication that something went wrong. Other providers (VictoriaMetrics, Prometheus, Dynatrace) raise on total failure.

## Fix

Track the total number of incidents and how many failed to format. If all incidents fail, raise an exception instead of silently returning an empty list. Partial failures still return successfully (matching the existing per-item skip pattern used by Datadog and others).

Fixes #6674
