### PR TITLE
fix(functions): refuse a time string add_time_to_date cannot read

### DIFF
--- a/keep/functions/__init__.py
+++ b/keep/functions/__init__.py
@@ -394,6 +394,15 @@ def add_time_to_date(date, date_format, time_str):
     time_dict = {unit: 0 for unit in time_units.values()}
 
     matches = re.findall(r"(\d+)([wdhms])", time_str)
+    if not matches:
+        # Returning the date unchanged made a typo look like a working
+        # workflow: "1y" or "3M" are not units this understands, and an SLA
+        # deadline computed from one silently came out as the start date.
+        raise ValueError(
+            f"add_time_to_date() could not read any time from {time_str!r}: "
+            "expected a number followed by w, d, h, m, or s, such as '1w' or "
+            "'2d 3h'"
+        )
     for value, unit in matches:
         time_dict[time_units[unit]] += int(value)
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -396,6 +396,36 @@ def test_add_time_to_date():
     assert functions.add_time_to_date(date_str, date_format, time_str) == expected_date
 
 
+@pytest.mark.parametrize(
+    "time_str",
+    ["1y", "3M", "10", "", "2 d", "next week"],
+    ids=["years", "months", "no-unit", "empty", "space-before-unit", "prose"],
+)
+def test_add_time_to_date_refuses_a_string_it_cannot_read(time_str):
+    """A string with no readable unit is a mistake, not a zero delta.
+
+    The regex matches a digit followed by w, d, h, m or s and nothing else,
+    so "1y" and "3M" matched nothing and the function returned the date it
+    was given. A workflow computing a deadline that way got the start date
+    and looked like it had worked.
+    """
+    with pytest.raises(ValueError, match="could not read any time"):
+        functions.add_time_to_date("2024-07-01", "%Y-%m-%d", time_str)
+
+
+@pytest.mark.parametrize(
+    ("time_str", "expected"),
+    [
+        ("1w", datetime.datetime(2024, 7, 8)),
+        ("45s", datetime.datetime(2024, 7, 1, 0, 0, 45)),
+        ("1w 2d 3h 30m", datetime.datetime(2024, 7, 10, 3, 30)),
+    ],
+)
+def test_add_time_to_date_still_reads_every_supported_spelling(time_str, expected):
+    """The guard fires on nothing that parsed before, spaces included."""
+    assert functions.add_time_to_date("2024-07-01", "%Y-%m-%d", time_str) == expected
+
+
 def test_add_time_to_date_with_datetime_string():
     """
     Test the add_time_to_date function with a specific datetime string input


### PR DESCRIPTION
Fixes #6778

`add_time_to_date` reads units with `re.findall(r"(\d+)([wdhms])", time_str)` and adds what it finds. When it finds nothing it adds nothing, so a string it cannot read returns the date unchanged and looks like it worked.

This raises instead. The message names the string it could not read and the units it understands.

Nothing that parsed before changes. `1w`, `2d`, `3h`, `30m`, `45s` and `1w 2d 3h 30m` all still work; the guard fires only when the regex matched nothing at all, which is why the spaced form is unaffected.

Tests cover six unreadable spellings, including `1y` and `3M`, which are the units people reach for and neither of which is supported. Three more pin the accepted forms as controls. The six fail on the commit before the fix and the three pass either way.

`tests/test_functions.py tests/test_iohandler.py`: 206 passed. `ruff check` clean.

I did not add month support. `m` already means minutes, so `3M` cannot be a month without making the unit ambiguous. This is about the silence, not the unit set.
