### PR TITLE
fix(tests): stop the auth0 fixture reaching the network

### DIFF
--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -37,13 +37,13 @@ def test_app(monkeypatch, request, db_session):
 
     try:
         monkeypatch.setenv("KEEP_USE_LIMITER", "false")
-        is_auth0 = False
+        uses_auth0 = False
         # Check if request.param is a dict or a string
         if isinstance(request.param, dict):
             # Set environment variables based on the provided dictionary
             for key, value in request.param.items():
                 monkeypatch.setenv(key, str(value))
-            is_auth0 = request.param.get("AUTH_TYPE") == "AUTH0"
+            uses_auth0 = request.param.get("AUTH_TYPE") == "AUTH0"
         else:
             # Old behavior for string parameters
             auth_type = request.param
@@ -51,13 +51,21 @@ def test_app(monkeypatch, request, db_session):
             monkeypatch.setenv("KEEP_JWT_SECRET", "somesecret")
 
             if auth_type == "MULTI_TENANT":
-                monkeypatch.setenv("AUTH0_DOMAIN", "https://auth0domain.com")
+                # A bare host, the way every other reader of this variable
+                # expects it. auth0_utils formats it into
+                # "https://{}/api/v2/" and the verifier builds its issuer the
+                # same way, so a value carrying its own scheme produced
+                # "https://https://auth0domain.com/".
+                monkeypatch.setenv("AUTH0_DOMAIN", "auth0domain.com")
+                # MULTI_TENANT loads the Auth0 verifier too, so it needs the
+                # same stub as the dict form below.
+                uses_auth0 = True
 
-        # When AUTH_TYPE=AUTH0, the authverifier module makes a real HTTP call
-        # at import time to fetch the OIDC discovery document. The mock must
-        # wrap the module reload as well, because deleted route modules get
-        # re-imported during reload and cascade into re-importing the verifier.
-        ctx = _mock_oidc_discovery() if is_auth0 else nullcontext()
+        # The authverifier module makes a real HTTP call at import time to
+        # fetch the OIDC discovery document. The mock must wrap the module
+        # reload as well, because deleted route modules get re-imported during
+        # reload and cascade into re-importing the verifier.
+        ctx = _mock_oidc_discovery() if uses_auth0 else nullcontext()
         with ctx:
             # Clear and reload modules to ensure environment changes are reflected
             for module in list(sys.modules):


### PR DESCRIPTION
Fixes #6816

`unit-tests` has been erroring on every PR with four setup timeouts in `tests/test_auth.py`:

```
ERROR at setup of test_api_key_with_header[MULTI_TENANT] - Failed: Timeout >20.0s
socket.gaierror: [Errno -3] Temporary failure in name resolution
Failed to fetch OpenID discovery document from
  https://https://auth0domain.com/.well-known/openid-configuration
```

Two things behind it. Both live in `tests/fixtures/client.py`.

The `MULTI_TENANT` branch sets `AUTH0_DOMAIN` to `https://auth0domain.com`. Every other reader of that variable takes a bare host: `auth0_utils` formats it into `"https://{}/api/v2/"`, the verifier builds `self.issuer` the same way, and `tests/test_auth_new.py` uses `test-domain.auth0.com`. With a scheme already on it the verifier asks the resolver for a host literally named `https`, which is the gaierror above.

The fixture also stubs OIDC discovery only for the dict form of the parameter, and `MULTI_TENANT` loads the same Auth0 verifier with no stub at all, so the call went out for real. On a runner without DNS that burns the whole 20 seconds before the test has started.

So: bare host, and the stub now covers both forms.

Verified by counting outbound DNS lookups during `test_api_key_with_header[MULTI_TENANT]`:

```
parent commit:  ['https']
this commit:    []
```

`tests/test_auth.py --non-integration`: 22 passed, 1 skipped, on both. The count is the evidence; the pass is not, since a resolver that answers quickly hides this.

Corroboration since this was opened: the four setup timeouts show up again on #6716, which touches none of this. Same four tests, same resolver error, on a PR that only changes provider code.