### PR TITLE
docs(providers): fix NewRelic _query docstring param name

### DIFF
--- a/keep/providers/newrelic_provider/newrelic_provider.py
+++ b/keep/providers/newrelic_provider/newrelic_provider.py
@@ -282,7 +282,7 @@ class NewrelicProvider(BaseProvider):
         Query New Relic account using the given NRQL
 
         Args:
-            query (str): query to execute
+            nrql (str): query to execute
 
         Returns:
             list[tuple] | list[dict]: results of the query


### PR DESCRIPTION
`NewRelicProvider._query(nrql='', **kwargs)`'s Args block documents `query (str)` — the parameter was renamed to `nrql`. One-line docstring fix.