### PR TITLE
docs(workflowstore): fix query_workflow_templates' copy-pasted docstring

### DIFF
--- a/keep/workflowmanager/workflowstore.py
+++ b/keep/workflowmanager/workflowstore.py
@@ -589,7 +589,7 @@ class WorkflowStore:
         Args:
             tenant_id (str): The tenant to which the workflows belong.
             workflows_dir (str): A directory containing workflows yamls.
-            limit (int): The number of workflows to return.
+            query (QueryDto): The query to filter workflows by.
 
         Returns:
             List[dict]: A list of workflows


### PR DESCRIPTION
`WorkflowStore.query_workflow_templates`'s docstring was copied verbatim from `get_random_workflow_templates`: the summary says "Get random workflows from a directory" and the Args block documents a `limit (int)` parameter. The real signature is `(tenant_id, workflows_dir, query: QueryDto)`. Docstring updated to match (the identical line in `get_random_workflow_templates` is legitimate and untouched). Docs-only.