### PR TITLE
docs: drop the empty link target in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
 
 ## Report bugs using Github's [issues](https://github.com/keephq/keep/issues)
-We use GitHub issues to track public bugs. Report a bug by [opening a new issue](); it's that easy!
+We use GitHub issues to track public bugs. Report a bug by opening a new issue; it's that easy!
 
 **Great Bug Reports** tend to have:
 


### PR DESCRIPTION
`CONTRIBUTING.md` rendered `[opening a new issue]()` — a markdown link with an empty target (clicking does nothing). Now plain text.