### PR TITLE
fix(alert-timeline): make timeline scrollable with mouse wheel/trackpad

### DIFF
--- a/keep-ui/features/alerts/alert-detail-sidebar/ui/alert-timeline.tsx
+++ b/keep-ui/features/alerts/alert-detail-sidebar/ui/alert-timeline.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { Subtitle, Button, Card, Title } from "@tremor/react";
 import { Chrono } from "react-chrono";
 import { ArrowPathIcon } from "@heroicons/react/24/outline";
@@ -26,6 +26,33 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({
   isLoading,
   onRefresh,
 }) => {
+  const timelineScrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const scroller = timelineScrollRef.current;
+    if (!scroller) {
+      return;
+    }
+    // react-chrono renders nested overflow containers with zero scroll
+    // extent. Chrome latches wheel gestures onto the one under the cursor
+    // and never chains them to the real scroll container, so the clipped
+    // timeline cannot be scrolled. Scroll it ourselves; preventDefault
+    // only when the scroll position actually changed, so overscroll still
+    // chains to the page once the container reaches either end.
+    const onWheel = (e: WheelEvent) => {
+      if (scroller.scrollHeight <= scroller.clientHeight) {
+        return;
+      }
+      const before = scroller.scrollTop;
+      scroller.scrollTop += e.deltaY;
+      if (scroller.scrollTop !== before) {
+        e.preventDefault();
+      }
+    };
+    scroller.addEventListener("wheel", onWheel, { passive: false });
+    return () => scroller.removeEventListener("wheel", onWheel);
+  }, []);
+
   // Default audit event if no audit data is available
   const defaultAuditEvent = alert
     ? [
@@ -86,7 +113,8 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({
           title="Refresh"
         />
       </div>
-      <Card className="max-h-[500px] overflow-y-auto p-0">
+      <Card className="p-0">
+        <div ref={timelineScrollRef} className="max-h-[500px] overflow-y-auto">
         {isLoading ? (
           <div className="flex justify-center items-center h-full">
             <p>Loading...</p>
@@ -129,6 +157,7 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({
             </Chrono>
           </div>
         )}
+        </div>
       </Card>
     </div>
   );


### PR DESCRIPTION
Fixes #6759.

## Root cause

react-chrono renders nested overflow containers with zero scroll extent inside the timeline (the reporter documented this with DevTools measurements). Chrome latches wheel gestures onto the zero-extent scroll container under the cursor and never chains them to the real scroll container - the tremor Card with `max-h-[500px] overflow-y-auto`. Net effect: the wheel does nothing over the timeline.

## Fix

One file: `keep-ui/features/alerts/alert-detail-sidebar/ui/alert-timeline.tsx` (+31/-2).

- The scroll container moves off the Card onto a plain inner div (`timelineScrollRef`) carrying the same `max-h-[500px] overflow-y-auto`.
- A non-passive `wheel` listener scrolls that div directly (`scrollTop += e.deltaY`) and calls `preventDefault()` only when the scroll position actually changed, so overscroll at either end still chains to the page.

A CSS-only override of react-chrono's styled-component class names was considered and rejected as too fragile across react-chrono upgrades.

## Verification

Wheel-handler logic exercised in a real Chrome page with a DOM mirroring the reporter's measured structure (658px content in a 500px clipped container):
- wheel over the nested wrapper scrolls the container and prevents default
- at max scroll the event passes through unmodified (page chaining preserved)
- scrolling back up resumes correctly
- a container with no overflow ignores the gesture entirely (no scroll trap)

**Not run:** the full keep-ui build/test suite and a native-input repro - synthetic `WheelEvent` dispatch does not trigger native scrolling, so the no-handler side reflects the reporter's documented measurements rather than fresh native input. No `tsc` pass locally; the diff is confined to one component using the file's existing imports plus `useEffect`/`useRef`.

> Built by breken, your AI support engineer - breken.ai - this one's on us.
