### PR TITLE
fix(sentry): don't crash the backend when Sentry returns an error with an empty body

### DIFF
--- a/keep/providers/sentry_provider/sentry_provider.py
+++ b/keep/providers/sentry_provider/sentry_provider.py
@@ -155,6 +155,30 @@ class SentryProvider(BaseProvider):
     def get_parameters(self):
         return {}
 
+    @staticmethod
+    def _error_detail(response) -> str:
+        """Best-effort error text from a Sentry API response.
+
+        Sentry does not guarantee a JSON body on an error. A 404 from an endpoint that no
+        longer exists comes back with an EMPTY body, so `response.json()` raises
+        JSONDecodeError. Because `validate_scopes()` is called from
+        ProvidersService.provision_providers() at application startup, and that exception
+        is not caught, an unparseable error body takes the whole backend down in a crash
+        loop rather than surfacing as a failed scope.
+
+        Returns the API's `detail` when there is one, and falls back to the status code so
+        the caller still gets an actionable string instead of an exception.
+        """
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+        if isinstance(payload, dict):
+            detail = payload.get("detail")
+            if detail:
+                return str(detail)
+        return f"HTTP {response.status_code} from {response.url}"
+
     def validate_scopes(self) -> dict[str, bool | str]:
         validated_scopes = {}
         project_slug = None
@@ -166,8 +190,7 @@ class SentryProvider(BaseProvider):
                         headers=self.__headers,
                     )
                     if not response.ok:
-                        response_json = response.json()
-                        validated_scopes[scope.name] = response_json.get("detail")
+                        validated_scopes[scope.name] = self._error_detail(response)
                         continue
                 else:
                     projects_response = requests.get(
@@ -175,8 +198,9 @@ class SentryProvider(BaseProvider):
                         headers=self.__headers,
                     )
                     if not projects_response.ok:
-                        response_json = projects_response.json()
-                        validated_scopes[scope.name] = response_json.get("detail")
+                        validated_scopes[scope.name] = self._error_detail(
+                            projects_response
+                        )
                         continue
                     projects = projects_response.json()
                     project_slug = projects[0].get("slug")
@@ -185,8 +209,7 @@ class SentryProvider(BaseProvider):
                         headers=self.__headers,
                     )
                     if not response.ok:
-                        response_json = response.json()
-                        validated_scopes[scope.name] = response_json.get("detail")
+                        validated_scopes[scope.name] = self._error_detail(response)
                         continue
                 validated_scopes[scope.name] = True
             elif scope.name == "project:read":
@@ -195,8 +218,7 @@ class SentryProvider(BaseProvider):
                     headers=self.__headers,
                 )
                 if not response.ok:
-                    response_json = response.json()
-                    validated_scopes[scope.name] = response_json.get("detail")
+                    validated_scopes[scope.name] = self._error_detail(response)
                     continue
                 validated_scopes[scope.name] = True
             elif scope.name == "project:write":
@@ -205,8 +227,7 @@ class SentryProvider(BaseProvider):
                     headers=self.__headers,
                 )
                 if not response.ok:
-                    response_json = response.json()
-                    validated_scopes[scope.name] = response_json.get("detail")
+                    validated_scopes[scope.name] = self._error_detail(response)
                     continue
                 validated_scopes[scope.name] = True
         return validated_scopes

--- a/tests/test_sentry_provider_error_body.py
+++ b/tests/test_sentry_provider_error_body.py
@@ -1,0 +1,59 @@
+"""Regression tests for SentryProvider._error_detail.
+
+validate_scopes() is called by ProvidersService.provision_providers() at APPLICATION
+STARTUP, and the exception is not caught there. So any error path that assumes a JSON
+body turns a failed scope check into a backend crash loop rather than a reported scope.
+
+Sentry does not guarantee a JSON body on errors: a 404 from an endpoint that no longer
+exists returns an EMPTY body. `project:write` is validated by POSTing to the legacy
+per-project endpoint /projects/{org}/{project}/plugins/webhooks/, which modern Sentry
+answers with exactly that.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from keep.providers.sentry_provider.sentry_provider import SentryProvider
+
+
+def _response(status_code, *, json_body=None, raises=False, url="https://sentry.io/x"):
+    r = MagicMock()
+    r.status_code = status_code
+    r.url = url
+    r.ok = 200 <= status_code < 300
+    if raises:
+        # requests raises ValueError (JSONDecodeError subclasses it) on an empty body
+        r.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+    else:
+        r.json.return_value = json_body
+    return r
+
+
+class TestSentryErrorDetail(unittest.TestCase):
+    def test_empty_body_does_not_raise(self):
+        """The regression: a 404 with an empty body must not propagate."""
+        detail = SentryProvider._error_detail(_response(404, raises=True))
+        self.assertIsInstance(detail, str)
+        self.assertIn("404", detail)
+
+    def test_detail_is_used_when_present(self):
+        detail = SentryProvider._error_detail(
+            _response(403, json_body={"detail": "You do not have permission"})
+        )
+        self.assertEqual(detail, "You do not have permission")
+
+    def test_falls_back_when_json_is_not_an_object(self):
+        """Sentry returns a bare list from some endpoints."""
+        detail = SentryProvider._error_detail(_response(400, json_body=["nope"]))
+        self.assertIsInstance(detail, str)
+        self.assertIn("400", detail)
+
+    def test_falls_back_when_detail_is_absent_or_empty(self):
+        for body in ({}, {"detail": ""}, {"error": "other shape"}):
+            with self.subTest(body=body):
+                detail = SentryProvider._error_detail(_response(500, json_body=body))
+                self.assertIsInstance(detail, str)
+                self.assertIn("500", detail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #6808

## The bug

`SentryProvider.validate_scopes()` assumes every non-ok response carries a JSON body, and calls `response.json()` on **five** error paths. Sentry does not guarantee that — a 404 from an endpoint that no longer exists comes back with an **empty body**, so `response.json()` raises `JSONDecodeError`.

## Why it takes the site down rather than failing a scope

`ProvidersService.provision_providers()` calls `validate_scopes()` at **application startup**, and the exception is not caught there. So an unparseable error body crash-loops `keep-backend` instead of reporting a failed scope.

## It is reachable today

The `project:write` check POSTs to the legacy per-project endpoint:

```
POST /projects/{org}/{project}/plugins/webhooks/
```

Modern Sentry SaaS answers **404 with an empty body**. So provisioning a `sentry` provider through `KEEP_PROVIDERS` against a current Sentry org crash-loops the backend:

```
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Observed in production on `0.54.2`; the same POST is still on `main` today.

Worth noting the asymmetry we hit while diagnosing: installing the **same** provider through `POST /providers/install` returns a clean `HTTP 412` and the backend survives. Only the startup provisioning path is fatal — which is what made this surprising to run into.

## The fix

Extract the error text through a helper that tolerates a missing, non-dict, or unparseable body and falls back to the status code, so a failed scope is **reported** rather than raised. Applied to all five error paths, not only the one that triggered it.

## Deliberately minimal

This does **not** change which endpoint `project:write` probes. That check is arguably also wrong — `plugins/webhooks` is gone from modern Sentry, so the scope will now report `"HTTP 404 …"` rather than validating — but `project:write` is `mandatory=False` (`mandatory_for_webhook=True`), so **install succeeds** and only webhook installation is affected.

I kept the two concerns separate so this stays reviewable. Happy to follow up on the endpoint choice if you'd prefer it in the same PR.

## Tests

`tests/test_sentry_provider_error_body.py` covers:

- 404 with an **empty body** — the actual regression
- a present `detail` (unchanged behaviour)
- a non-dict body (Sentry returns bare lists from some endpoints)
- absent / empty `detail`

⚠️ I could not run the full suite locally — `tests/conftest.py` needs `mysql.connector`, and my local pydantic (2.12) conflicts with the pinned version. I verified the helper's behaviour standalone against all four cases above; CI here will be the real check.
