### PR TITLE
fix(auth): normalize AUTH_TYPE to uppercase to prevent silent redirect loop

### DIFF
--- a/keep-ui/auth.config.ts
+++ b/keep-ui/auth.config.ts
@@ -35,7 +35,7 @@ const authSessionTimeout = runtimeEnv("AUTH_SESSION_TIMEOUT")
   ? Number.parseInt(runtimeEnv("AUTH_SESSION_TIMEOUT")!)
   : 30 * 24 * 60 * 60; // Default to 30 days if not set
 // Determine auth type with backward compatibility
-const authTypeEnv = runtimeEnv("AUTH_TYPE");
+const authTypeEnv = runtimeEnv("AUTH_TYPE")?.toUpperCase();
 export const authType =
   authTypeEnv === MULTI_TENANT
     ? AuthType.AUTH0


### PR DESCRIPTION
## Summary

One-line fix: adds `.toUpperCase()` when reading the `AUTH_TYPE` environment variable in the frontend, so that lowercase values like `db` correctly match the uppercase `AuthType` enum (`"DB"`).

## Problem

Setting `AUTH_TYPE=db` (lowercase) works on the **backend** (Python, case-insensitive) but silently breaks the **frontend**. The `AuthType` enum and backward-compat constants are all uppercase:

```typescript
// utils/authenticationType.ts
export enum AuthType {
  DB = "DB",
  NOAUTH = "NOAUTH",
  // ...
}
export const MULTI_TENANT = "MULTI_TENANT";
export const SINGLE_TENANT = "SINGLE_TENANT";
export const NO_AUTH = "NO_AUTH";
```

But `auth.config.ts` compared the raw env value without normalizing:

```typescript
const authTypeEnv = runtimeEnv("AUTH_TYPE"); // "db"
// ... none of the comparisons match "db" ...
: (authTypeEnv as AuthType); // "db" cast — not "DB"
```

This causes `baseProviderConfigs["db"]` to return `undefined`, silently falling back to the `NoAuth` credentials provider. The signin page then auto-calls `signIn("credentials")`, creating a NextAuth session without a valid Keep JWT, which produces an infinite redirect loop with no error message.

## Fix

```diff
-const authTypeEnv = runtimeEnv("AUTH_TYPE");
+const authTypeEnv = runtimeEnv("AUTH_TYPE")?.toUpperCase();
```

All enum values and backward-compat constants are already uppercase, so this is safe.

Fixes #6809