### PR TITLE
fix(sentry): handle empty/non-JSON error responses in validate_scopes

### DIFF
--- a/keep/providers/sentry_provider/sentry_provider.py
+++ b/keep/providers/sentry_provider/sentry_provider.py
@@ -155,6 +155,16 @@ class SentryProvider(BaseProvider):
     def get_parameters(self):
         return {}
 
+    @staticmethod
+    def _extract_error_detail(response: requests.Response) -> str:
+        try:
+            response_json = response.json()
+            if isinstance(response_json, dict):
+                return response_json.get("detail") or str(response_json)
+        except Exception:
+            pass
+        return f"HTTP {response.status_code}"
+
     def validate_scopes(self) -> dict[str, bool | str]:
         validated_scopes = {}
         project_slug = None
@@ -166,8 +176,7 @@ class SentryProvider(BaseProvider):
                         headers=self.__headers,
                     )
                     if not response.ok:
-                        response_json = response.json()
-                        validated_scopes[scope.name] = response_json.get("detail")
+                        validated_scopes[scope.name] = self._extract_error_detail(response)
                         continue
                 else:
                     projects_response = requests.get(
@@ -175,18 +184,22 @@ class SentryProvider(BaseProvider):
                         headers=self.__headers,
                     )
                     if not projects_response.ok:
-                        response_json = projects_response.json()
-                        validated_scopes[scope.name] = response_json.get("detail")
+                        validated_scopes[scope.name] = self._extract_error_detail(projects_response)
                         continue
-                    projects = projects_response.json()
-                    project_slug = projects[0].get("slug")
+                    try:
+                        projects = projects_response.json()
+                        project_slug = projects[0].get("slug") if projects else None
+                    except Exception:
+                        project_slug = None
+                    if not project_slug:
+                        validated_scopes[scope.name] = "No projects found"
+                        continue
                     response = requests.get(
                         f"{self.sentry_api}/projects/{self.sentry_org_slug}/{project_slug}/issues/",
                         headers=self.__headers,
                     )
                     if not response.ok:
-                        response_json = response.json()
-                        validated_scopes[scope.name] = response_json.get("detail")
+                        validated_scopes[scope.name] = self._extract_error_detail(response)
                         continue
                 validated_scopes[scope.name] = True
             elif scope.name == "project:read":
@@ -195,8 +208,7 @@ class SentryProvider(BaseProvider):
                     headers=self.__headers,
                 )
                 if not response.ok:
-                    response_json = response.json()
-                    validated_scopes[scope.name] = response_json.get("detail")
+                    validated_scopes[scope.name] = self._extract_error_detail(response)
                     continue
                 validated_scopes[scope.name] = True
             elif scope.name == "project:write":
@@ -205,8 +217,7 @@ class SentryProvider(BaseProvider):
                     headers=self.__headers,
                 )
                 if not response.ok:
-                    response_json = response.json()
-                    validated_scopes[scope.name] = response_json.get("detail")
+                    validated_scopes[scope.name] = self._extract_error_detail(response)
                     continue
                 validated_scopes[scope.name] = True
         return validated_scopes


### PR DESCRIPTION
## Summary

Safely extracts error details during Sentry `validate_scopes` to prevent unhandled `JSONDecodeError` from crashing the entire validation check when Sentry returns an error response with an empty or non-JSON body.

Fixes #6812

## Problem

In `sentry_provider.py`, `validate_scopes` checks scopes (`event:read`, `project:read`, `project:write`).
For `project:write`, it sends a `POST` request to `{sentry_api}/projects/{org}/{project}/plugins/webhooks/`.

When Sentry returns an error with an empty HTML body (e.g. `HTTP 404` with 0 bytes, as the legacy `/plugins/webhooks/` API has been deprecated by Sentry), calling `response.json()` raises `requests.exceptions.JSONDecodeError`.

Because this exception was unhandled:
1. It crashed the entire `validate_provider_scopes` endpoint with an internal server error.
2. The UI showed "Failed to revalidate scopes" and reported all scopes as "Not checked", even though `event:read` and `project:read` were fully valid and alerts were being ingested fine.

## Fix

Added a helper method `_extract_error_detail(response)` that attempts to parse `response.json().get("detail")` or string representation, and cleanly falls back to `f"HTTP {response.status_code}"` if parsing fails. Applied across all error handling branches in `validate_scopes`.