### PR TITLE
fix(cilium): pre-import protobuf dependencies before observer_pb2

### DIFF
--- a/keep/providers/cilium_provider/cilium_provider.py
+++ b/keep/providers/cilium_provider/cilium_provider.py
@@ -124,6 +124,9 @@ class CiliumProvider(BaseTopologyProvider):
 
     def pull_topology(self) -> list[TopologyServiceInDto]:
         # for some providers that depends on grpc like cilium provider, this might fail on imports not from Keep (such as the docs script)
+        from google.protobuf import any_pb2, field_mask_pb2, timestamp_pb2, wrappers_pb2  # noqa
+        import keep.providers.cilium_provider.grpc.flow.flow_pb2  # noqa
+        import keep.providers.cilium_provider.grpc.relay.relay_pb2  # noqa
         from keep.providers.cilium_provider.grpc.observer_pb2 import (  # noqa
             FlowFilter,
             GetFlowsRequest,


### PR DESCRIPTION
## Summary

Pre-imports well-known Google protobuf types (`any_pb2`, `field_mask_pb2`, `timestamp_pb2`, `wrappers_pb2`) and Hubble flow/relay pb2 modules in `CiliumProvider.pull_topology()` before loading `observer_pb2`.

## Problem

On Python 3.13 with `protobuf>=5.x`, loading `observer_pb2` dynamically registers `observer.proto` via `descriptor_pool.Default().AddSerializedFile(...)`. 

Because its dependencies (`google/protobuf/any.proto`, `google/protobuf/field_mask.proto`, etc.) are not loaded prior to importing `observer_pb2`, protobuf raises an unhandled `KeyError` in `descriptor_database.py`:

```text
KeyError: 'google/protobuf/any.proto'
  File "google/protobuf/descriptor_pool.py", line 1313, in _GetDeps
    dep_desc = self.FindFileByName(dependency)
```

This crashes the Keep topology collector whenever Cilium provider attempts to pull network flows.

## Fix

Pre-import the required protobuf types so they are registered in the default descriptor pool before `observer_pb2` is loaded.

Fixes #6820
