### PR TITLE
fix(providers): handle empty choices array defensively (#6715)

### DIFF
--- a/keep/providers/deepseek_provider/deepseek_provider.py
+++ b/keep/providers/deepseek_provider/deepseek_provider.py
@@ -80,7 +80,10 @@ class DeepseekProvider(BaseProvider):
             max_tokens=max_tokens,
             response_format=structured_output_format,
         )
-        response = response.choices[0].message.content
+        if response and response.choices and len(response.choices) > 0:
+            response = response.choices[0].message.content or ""
+        else:
+            response = ""
         try:
             response = json.loads(response)
         except Exception:

--- a/keep/providers/openai_provider/openai_provider.py
+++ b/keep/providers/openai_provider/openai_provider.py
@@ -66,7 +66,10 @@ class OpenaiProvider(BaseProvider):
             max_tokens=max_tokens,
             response_format=structured_output_format,
         )
-        response = response.choices[0].message.content
+        if response and response.choices and len(response.choices) > 0:
+            response = response.choices[0].message.content or ""
+        else:
+            response = ""
         try:
             response = json.loads(response)
         except Exception:


### PR DESCRIPTION
## Description
Resolves #6715.

Defensively handles scenarios where the OpenAI or DeepSeek API returns an empty `choices` list (e.g. content filtering, moderation blocks, or blank completions) instead of throwing an unhandled `IndexError: list index out of range`.

## Changes Made
- Added defensive check: `if response and response.choices and len(response.choices) > 0:`
- Gracefully falls back to empty string `""` matching existing provider patterns.
- Applied to both `openai_provider.py` and `deepseek_provider.py`.

## Checklist
- [x] Tested and verified
- [x] Fixes #6715

