### PR TITLE
fix(iohandler): preserve empty containers and literal False in template args (#6728)

### DIFF
--- a/keep/iohandler/iohandler.py
+++ b/keep/iohandler/iohandler.py
@@ -331,15 +331,9 @@ class IOHandler:
                                 pass
                     else:
                         _arg = arg.id
-                    # if the value is empty '', we still need to pass it to the function
-                    # also, if the value is 0 or 0.0, we need to pass it to the function
-                    # 0 == False, so we need to check if the value is not False explicitly
-                    if (
-                        _arg
-                        or _arg == ""
-                        or (_arg == 0 or _arg == 0.0)
-                        and _arg is not False
-                    ):
+                    # _arg is None only when parsing produced no value (e.g. nested keep.* call returned nothing).
+                    # Keep all valid arguments: "", 0, 0.0, False, [], {}, (), etc.
+                    if _arg is not None:
                         _args.append(_arg)
 
                 # Parse keyword args

--- a/tests/test_iohandler.py
+++ b/tests/test_iohandler.py
@@ -1154,3 +1154,25 @@ def test_safe_tuple_literal_still_works(context_manager):
     ):
         result = iohandler.render(template)
     assert result == "True"
+
+def test_iohandler_does_not_drop_falsy_arguments(context_manager):
+    """Verify that IOHandler does not drop empty list, empty dict, empty tuple, or literal False arguments (#6728)."""
+    iohandler = IOHandler(context_manager)
+    context_manager.steps_context = {
+        "empty_list": [],
+        "empty_dict": {},
+        "empty_tuple": (),
+        "false_val": False,
+        "zero_val": 0,
+        "empty_str": "",
+    }
+    # Test keep.len on empty list
+    assert iohandler.render("keep.len({{ steps.empty_list }})") == "0"
+    assert iohandler.render("keep.len([])") == "0"
+
+    # Test keep.eq with False and empty collections
+    assert iohandler.render("keep.eq({{ steps.false_val }}, False)") == "True"
+    assert iohandler.render("keep.eq(False, False)") == "True"
+    assert iohandler.render("keep.eq({{ steps.empty_dict }}, {})") == "True"
+    assert iohandler.render("keep.eq({{ steps.empty_list }}, [])") == "True"
+    assert iohandler.render("keep.eq({{ steps.empty_tuple }}, ())") == "True"


### PR DESCRIPTION
Closes #6728

## 📑 Description
`IOHandler`'s template-function parser previously dropped empty containers (`[]`, `{}`, `()`) and boolean `False` positional arguments due to an overly restrictive truthiness guard. This caused subsequent arguments to shift left, leading to parameter mismatch or unexpected `TypeError` exceptions during workflow evaluation.

### Changes Made
1. **`keep/iohandler/iohandler.py`**: Replaced flawed check with `if _arg is not None:`. Ensures all valid evaluated arguments (`""`, `0`, `0.0`, `False`, `[]`, `{}`, `()`) are preserved positionally.
2. **`tests/test_iohandler.py`**: Added unit test `test_iohandler_does_not_drop_falsy_arguments` verifying `keep.len` and `keep.eq` on empty lists, dicts, tuples, and boolean `False`.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
Fixes parameter shifting and unexpected TypeErrors when workflows pass falsy collections or boolean `False` into `keep.*` functions.
