### PR TITLE
fix(step): safely unwrap single foreach item when resolving to falsy scalar (#6721)

### DIFF
--- a/keep/step/step.py
+++ b/keep/step/step.py
@@ -127,7 +127,7 @@ class Step:
             foreach_items.append(items)
         if not foreach_items:
             return []
-        return len(foreach_items) == 1 and foreach_items[0] or zip(*foreach_items)
+        return foreach_items[0] if len(foreach_items) == 1 else zip(*foreach_items)
 
     def _run_foreach(self):
         """Evaluate the action for each item, when using the `foreach` attribute (see foreach.md)"""

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -176,3 +176,34 @@ def test_continue_on_error_explicit_false():
         {},
     )
     assert step.continue_on_error is False
+
+def test_get_foreach_items_falsy_scalar():
+    """Verify that single foreach resolving to 0 or False returns the value without TypeError (#6721)."""
+    context_manager = Mock()
+    context_manager.get_full_context.return_value = {
+        "steps": {
+            "count_step": {"results": {"count": 0}},
+            "flag_step": {"results": {"flag": False}},
+        }
+    }
+    # Test count == 0
+    step_zero = Step(
+        context_manager,
+        "step_zero",
+        {"foreach": "{{ steps.count_step.results.count }}"},
+        StepType.STEP,
+        Mock(),
+        {},
+    )
+    assert step_zero._get_foreach_items() == 0
+
+    # Test flag == False
+    step_false = Step(
+        context_manager,
+        "step_false",
+        {"foreach": "{{ steps.flag_step.results.flag }}"},
+        StepType.STEP,
+        Mock(),
+        {},
+    )
+    assert step_false._get_foreach_items() is False


### PR DESCRIPTION
Closes #6721

## 📑 Description
`Step._get_foreach_items` previously used the Python ternary anti-pattern `return len(foreach_items) == 1 and foreach_items[0] or zip(*foreach_items)`. When a single `foreach` reference legitimately evaluates to `0` or `False`, the expression falls through to `zip(*foreach_items)` which raises `TypeError: Value after * must be an iterable, not int / bool`.

### Changes Made
1. **`keep/step/step.py`**: Replaced anti-pattern with standard conditional expression: `return foreach_items[0] if len(foreach_items) == 1 else zip(*foreach_items)`.
2. **`tests/test_steps.py`**: Added unit test `test_get_foreach_items_falsy_scalar` validating single `foreach` evaluation when resolved context yields `0` or `False`.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

